### PR TITLE
GPU frustum culling

### DIFF
--- a/projects/Cyseal/Cyseal.vcxproj
+++ b/projects/Cyseal/Cyseal.vcxproj
@@ -102,6 +102,7 @@
     <ClInclude Include="src\memory\free_number_list.h" />
     <ClInclude Include="src\memory\mem_alloc.h" />
     <ClInclude Include="src\render\base_pass.h" />
+    <ClInclude Include="src\render\gpu_culling.h" />
     <ClInclude Include="src\rhi\global_descriptor_heaps.h" />
     <ClInclude Include="src\render\gpu_scene.h" />
     <ClInclude Include="src\render\null_renderer.h" />
@@ -170,6 +171,7 @@
     <ClCompile Include="src\loader\image_loader.cpp" />
     <ClCompile Include="src\memory\mem_alloc.cpp" />
     <ClCompile Include="src\render\base_pass.cpp" />
+    <ClCompile Include="src\render\gpu_culling.cpp" />
     <ClCompile Include="src\rhi\dx12\d3d_pipeline_state.cpp" />
     <ClCompile Include="src\rhi\global_descriptor_heaps.cpp" />
     <ClCompile Include="src\render\gpu_scene.cpp" />

--- a/projects/Cyseal/Cyseal.vcxproj
+++ b/projects/Cyseal/Cyseal.vcxproj
@@ -87,6 +87,7 @@
     <ClInclude Include="src\core\engine.h" />
     <ClInclude Include="src\core\int_types.h" />
     <ClInclude Include="src\core\matrix.h" />
+    <ClInclude Include="src\core\plane.h" />
     <ClInclude Include="src\core\platform.h" />
     <ClInclude Include="src\core\quaternion.h" />
     <ClInclude Include="src\core\types.h" />

--- a/projects/Cyseal/Cyseal.vcxproj.filters
+++ b/projects/Cyseal/Cyseal.vcxproj.filters
@@ -249,6 +249,9 @@
     <ClInclude Include="src\core\aabb.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="src\core\plane.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\memory\mem_alloc.cpp">

--- a/projects/Cyseal/Cyseal.vcxproj.filters
+++ b/projects/Cyseal/Cyseal.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClInclude Include="src\core\plane.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="src\render\gpu_culling.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\memory\mem_alloc.cpp">
@@ -399,6 +402,9 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="src\rhi\dx12\d3d_pipeline_state.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="src\render\gpu_culling.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>

--- a/projects/Cyseal/src/core/plane.h
+++ b/projects/Cyseal/src/core/plane.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "vec3.h"
+
+struct Plane3D
+{
+	vec3 normal;
+	float distance;
+
+	static Plane3D fromNormalAndDistance(const vec3& n, float d)
+	{
+		return Plane3D{ n, d };
+	}
+	static Plane3D fromPointAndNormal(const vec3& p, const vec3& n)
+	{
+		return Plane3D{ n, dot(p, n) };
+	}
+	static Plane3D fromThreePoints(const vec3& a, const vec3& b, const vec3& c)
+	{
+		return fromPointAndNormal(a, normalize(cross(b - a, c - a)));
+	}
+};

--- a/projects/Cyseal/src/core/types.h
+++ b/projects/Cyseal/src/core/types.h
@@ -4,3 +4,4 @@
 #include "vec3.h"
 #include "vec2.h"
 #include "matrix.h"
+#include "aabb.h"

--- a/projects/Cyseal/src/core/vec3.h
+++ b/projects/Cyseal/src/core/vec3.h
@@ -13,6 +13,7 @@ public:
 
 public:
 	vec3() : vec3(0.0f, 0.0f, 0.0f) {}
+	vec3(float e0) { x = y = z = e0; }
 	vec3(float e0, float e1, float e2)
 	{
 		x = e0;

--- a/projects/Cyseal/src/render/base_pass.cpp
+++ b/projects/Cyseal/src/render/base_pass.cpp
@@ -297,7 +297,7 @@ void BasePass::renderBasePass(
 	// #todo-lod: LOD selection
 	const uint32 LOD = 0;
 
-	bindRootParameters(commandList, sceneUniformBuffer, gpuScene);
+	bindRootParameters(commandList, swapchainIndex, sceneUniformBuffer, gpuScene);
 	
 	if (bUseIndirectDraw)
 	{
@@ -364,16 +364,15 @@ void BasePass::renderBasePass(
 
 void BasePass::bindRootParameters(
 	RenderCommandList* cmdList,
+	uint32 swapchainIndex,
 	ConstantBufferView* sceneUniform,
 	GPUScene* gpuScene)
 {
-	uint32 frameIndex = gRenderDevice->getSwapChain()->getCurrentBackbufferIndex();
-
 	// slot0: Updated per drawcall, not here
 	//cmdList->setGraphicsRootConstant32(0, payloadID, 0);
 
 	// #todo-sampler: volatile sampler heap in the second element
-	DescriptorHeap* volatileHeap = volatileViewHeaps[frameIndex].get();
+	DescriptorHeap* volatileHeap = volatileViewHeaps[swapchainIndex].get();
 	DescriptorHeap* heaps[] = { volatileHeap, };
 	cmdList->setDescriptorHeaps(1, heaps);
 
@@ -392,6 +391,7 @@ void BasePass::bindRootParameters(
 	uint32 materialSRVBaseIndex, materialSRVCount;
 	uint32 freeDescriptorIndexAfterMaterials;
 	gpuScene->copyMaterialDescriptors(
+		swapchainIndex,
 		volatileHeap, 1,
 		materialCBVBaseIndex, materialCBVCount,
 		materialSRVBaseIndex, materialSRVCount,

--- a/projects/Cyseal/src/render/base_pass.h
+++ b/projects/Cyseal/src/render/base_pass.h
@@ -11,6 +11,7 @@ class Material;
 class SceneProxy;
 class Camera;
 class GPUScene;
+class GPUCulling;
 class Texture;
 
 class BasePass final
@@ -25,6 +26,7 @@ public:
 		const Camera* camera,
 		ConstantBufferView* sceneUniformBuffer,
 		GPUScene* gpuScene,
+		GPUCulling* gpuCulling,
 		Texture* RT_sceneColor,
 		Texture* RT_thinGBufferA);
 
@@ -44,6 +46,11 @@ private:
 	std::unique_ptr<CommandSignature> commandSignature;
 	std::unique_ptr<IndirectCommandGenerator> argumentBufferGenerator;
 	std::vector<std::unique_ptr<Buffer>> argumentBuffers;
+	std::vector<std::unique_ptr<ShaderResourceView>> argumentBufferSRVs;
+	std::vector<std::unique_ptr<Buffer>> culledArgumentBuffers;
+	std::vector<std::unique_ptr<UnorderedAccessView>> culledArgumentBufferUAVs;
+	std::vector<std::unique_ptr<Buffer>> drawCounterBuffers;
+	std::vector<std::unique_ptr<UnorderedAccessView>> drawCounterBufferUAVs;
 
 	uint32 totalVolatileDescriptors = 0;
 	std::vector<std::unique_ptr<DescriptorHeap>> volatileViewHeaps;

--- a/projects/Cyseal/src/render/base_pass.h
+++ b/projects/Cyseal/src/render/base_pass.h
@@ -34,6 +34,7 @@ private:
 	// Bind root parameters for the current root signature
 	void bindRootParameters(
 		RenderCommandList* cmdList,
+		uint32 swapchainIndex,
 		ConstantBufferView* sceneUniform,
 		GPUScene* gpuScene);
 

--- a/projects/Cyseal/src/render/base_pass.h
+++ b/projects/Cyseal/src/render/base_pass.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "renderer.h"
 #include "rhi/pipeline_state.h"
 #include "rhi/gpu_resource_binding.h"
 #include "rhi/gpu_resource.h"
@@ -24,6 +25,7 @@ public:
 		uint32 swapchainIndex,
 		const SceneProxy* scene,
 		const Camera* camera,
+		const RendererOptions& rendererOptions,
 		ConstantBufferView* sceneUniformBuffer,
 		GPUScene* gpuScene,
 		GPUCulling* gpuCulling,

--- a/projects/Cyseal/src/render/gpu_culling.cpp
+++ b/projects/Cyseal/src/render/gpu_culling.cpp
@@ -78,6 +78,8 @@ void GPUCulling::cullDrawCommands(
 	Buffer* drawCounterBuffer,
 	UnorderedAccessView* drawCounterBufferUAV)
 {
+	SCOPED_DRAW_EVENT(commandList, GPUCulling);
+
 	// Resize volatile heaps if needed.
 	{
 		uint32 requiredVolatiles = 0;
@@ -96,12 +98,6 @@ void GPUCulling::cullDrawCommands(
 	drawCounterBuffer->singleWriteToGPU(commandList, &zeroValue, sizeof(zeroValue), 0);
 
 	ResourceBarrier barriersBefore[] = {
-		{
-			EResourceBarrierType::Transition,
-			gpuScene->gpuSceneBuffer.get(),
-			EGPUResourceState::COMMON,
-			EGPUResourceState::PIXEL_SHADER_RESOURCE
-		},
 		{
 			EResourceBarrierType::Transition,
 			indirectDrawBuffer,
@@ -149,10 +145,22 @@ void GPUCulling::cullDrawCommands(
 	ResourceBarrier barriersAfter[] = {
 		{
 			EResourceBarrierType::Transition,
+			indirectDrawBuffer,
+			EGPUResourceState::PIXEL_SHADER_RESOURCE,
+			EGPUResourceState::INDIRECT_ARGUMENT
+		},
+		{
+			EResourceBarrierType::Transition,
 			culledIndirectDrawBuffer,
 			EGPUResourceState::UNORDERED_ACCESS,
-			EGPUResourceState::PIXEL_SHADER_RESOURCE
-		}
+			EGPUResourceState::INDIRECT_ARGUMENT
+		},
+		{
+			EResourceBarrierType::Transition,
+			drawCounterBuffer,
+			EGPUResourceState::UNORDERED_ACCESS,
+			EGPUResourceState::INDIRECT_ARGUMENT
+		},
 	};
 	commandList->resourceBarriers(_countof(barriersAfter), barriersAfter);
 }

--- a/projects/Cyseal/src/render/gpu_culling.cpp
+++ b/projects/Cyseal/src/render/gpu_culling.cpp
@@ -1,0 +1,184 @@
+#include "gpu_culling.h"
+#include "gpu_scene.h"
+#include "rhi/render_device.h"
+#include "rhi/render_command.h"
+#include "rhi/swap_chain.h"
+#include "rhi/gpu_resource_binding.h"
+#include "util/logging.h"
+
+#include <memory>
+
+DEFINE_LOG_CATEGORY_STATIC(LogGPUCulling);
+
+namespace RootParameters
+{
+	enum Value
+	{
+		PushConstantsSlot = 0,
+		SceneUniformSlot,
+		GPUSceneSlot,
+		DrawBufferSlot,
+		CulledDrawBufferSlot,
+		CounterBufferSlot,
+		Count
+	};
+}
+
+void GPUCulling::initialize()
+{
+	// Root signature
+	{
+		DescriptorRange descriptorRanges[2];
+		descriptorRanges[0].init(EDescriptorRangeType::CBV, 1, 1, 0); // register(b1, space0)
+		descriptorRanges[1].init(EDescriptorRangeType::UAV, 1, 1, 0); // register(u1, space0)
+
+		RootParameter rootParameters[RootParameters::Count];
+		rootParameters[RootParameters::PushConstantsSlot].initAsConstants(0, 0, 1);
+		rootParameters[RootParameters::SceneUniformSlot].initAsDescriptorTable(1, &descriptorRanges[0]);
+		rootParameters[RootParameters::GPUSceneSlot].initAsSRV(0, 0);           // register(t0, space0)
+		rootParameters[RootParameters::DrawBufferSlot].initAsSRV(1, 0);         // register(t1, space0)
+		rootParameters[RootParameters::CulledDrawBufferSlot].initAsUAV(0, 0);   // register(u0, space0)
+		rootParameters[RootParameters::CounterBufferSlot].initAsDescriptorTable(1, &descriptorRanges[1]);
+
+		RootSignatureDesc rootSigDesc(
+			RootParameters::Count,
+			rootParameters,
+			0, nullptr,
+			ERootSignatureFlags::None);
+		rootSignature = std::unique_ptr<RootSignature>(gRenderDevice->createRootSignature(rootSigDesc));
+	}
+
+	// Shader
+	ShaderStage* shaderCS = gRenderDevice->createShader(EShaderStage::COMPUTE_SHADER, "GPUCullingCS");
+	shaderCS->loadFromFile(L"gpu_culling.hlsl", "mainCS");
+
+	// PSO
+	pipelineState = std::unique_ptr<PipelineState>(gRenderDevice->createComputePipelineState(
+		ComputePipelineDesc{
+			.rootSignature = rootSignature.get(),
+			.cs            = shaderCS,
+			.nodeMask      = 0
+		}
+	));
+
+	delete shaderCS;
+}
+
+void GPUCulling::cullDrawCommands(
+	RenderCommandList* commandList,
+	uint32 swapchainIndex,
+	ConstantBufferView* sceneUniform,
+	const Camera* camera,
+	GPUScene* gpuScene,
+	uint32 maxDrawCommands,
+	Buffer* indirectDrawBuffer,
+	ShaderResourceView* indirectDrawBufferSRV,
+	Buffer* culledIndirectDrawBuffer,
+	UnorderedAccessView* culledIndirectDrawBufferUAV,
+	Buffer* drawCounterBuffer,
+	UnorderedAccessView* drawCounterBufferUAV)
+{
+	// Resize volatile heaps if needed.
+	{
+		uint32 requiredVolatiles = 0;
+		requiredVolatiles += 1; // scene uniform
+		//requiredVolatiles += 1; // gpu scene
+		//requiredVolatiles += 1; // draw command buffer
+		//requiredVolatiles += 1; // culled draw command buffer
+		requiredVolatiles += 1; // draw counter buffer
+		if (requiredVolatiles > totalVolatileDescriptors)
+		{
+			resizeVolatileHeaps(requiredVolatiles);
+		}
+	}
+
+	uint32 zeroValue = 0;
+	drawCounterBuffer->singleWriteToGPU(commandList, &zeroValue, sizeof(zeroValue), 0);
+
+	ResourceBarrier barriersBefore[] = {
+		{
+			EResourceBarrierType::Transition,
+			gpuScene->gpuSceneBuffer.get(),
+			EGPUResourceState::COMMON,
+			EGPUResourceState::PIXEL_SHADER_RESOURCE
+		},
+		{
+			EResourceBarrierType::Transition,
+			indirectDrawBuffer,
+			EGPUResourceState::COMMON,
+			EGPUResourceState::PIXEL_SHADER_RESOURCE
+		},
+		{
+			EResourceBarrierType::Transition,
+			culledIndirectDrawBuffer,
+			EGPUResourceState::COMMON,
+			EGPUResourceState::UNORDERED_ACCESS
+		},
+		{
+			EResourceBarrierType::Transition,
+			drawCounterBuffer,
+			EGPUResourceState::COMMON,
+			EGPUResourceState::UNORDERED_ACCESS
+		},
+	};
+	commandList->resourceBarriers(_countof(barriersBefore), barriersBefore);
+
+	commandList->setPipelineState(pipelineState.get());
+	commandList->setComputeRootSignature(rootSignature.get());
+
+	DescriptorHeap* volatileHeap = volatileViewHeaps[swapchainIndex].get();
+	DescriptorHeap* heaps[] = { volatileHeap };
+	commandList->setDescriptorHeaps(1, heaps);
+
+	constexpr uint32 VOLATILE_IX_SceneUniform = 0;
+	constexpr uint32 VOLATILE_IX_DrawCounterBuffer = 1;
+	gRenderDevice->copyDescriptors(1, volatileHeap, VOLATILE_IX_SceneUniform,
+		sceneUniform->getSourceHeap(), sceneUniform->getDescriptorIndexInHeap());
+	gRenderDevice->copyDescriptors(1, volatileHeap, VOLATILE_IX_DrawCounterBuffer,
+		drawCounterBufferUAV->getSourceHeap(), drawCounterBufferUAV->getDescriptorIndexInHeap());
+
+	commandList->setComputeRootConstant32(RootParameters::PushConstantsSlot, maxDrawCommands, 0);
+	commandList->setComputeRootDescriptorTable(RootParameters::SceneUniformSlot, volatileHeap, VOLATILE_IX_SceneUniform);
+	commandList->setComputeRootDescriptorSRV(RootParameters::GPUSceneSlot, gpuScene->gpuSceneBufferSRV.get());
+	commandList->setComputeRootDescriptorSRV(RootParameters::DrawBufferSlot, indirectDrawBufferSRV);
+	commandList->setComputeRootDescriptorUAV(RootParameters::CulledDrawBufferSlot, culledIndirectDrawBufferUAV);
+	commandList->setComputeRootDescriptorTable(RootParameters::CounterBufferSlot, volatileHeap, VOLATILE_IX_DrawCounterBuffer);
+
+	commandList->dispatchCompute(maxDrawCommands, 1, 1);
+
+	ResourceBarrier barriersAfter[] = {
+		{
+			EResourceBarrierType::Transition,
+			culledIndirectDrawBuffer,
+			EGPUResourceState::UNORDERED_ACCESS,
+			EGPUResourceState::PIXEL_SHADER_RESOURCE
+		}
+	};
+	commandList->resourceBarriers(_countof(barriersAfter), barriersAfter);
+}
+
+void GPUCulling::resizeVolatileHeaps(uint32 maxDescriptors)
+{
+	totalVolatileDescriptors = maxDescriptors;
+
+	const uint32 swapchainCount = gRenderDevice->getSwapChain()->getBufferCount();
+
+	volatileViewHeaps.resize(swapchainCount);
+	for (uint32 i = 0; i < swapchainCount; ++i)
+	{
+		volatileViewHeaps[i] = std::unique_ptr<DescriptorHeap>(gRenderDevice->createDescriptorHeap(
+			DescriptorHeapDesc{
+				.type           = EDescriptorHeapType::CBV_SRV_UAV,
+				.numDescriptors = maxDescriptors,
+				.flags          = EDescriptorHeapFlags::ShaderVisible,
+				.nodeMask       = 0,
+			}
+		));
+
+		wchar_t debugName[256];
+		swprintf_s(debugName, L"GPUCulling_VolatileViewHeap_%u", i);
+		volatileViewHeaps[i]->setDebugName(debugName);
+	}
+
+	CYLOG(LogGPUCulling, Log, L"Resize volatile heap: %u descriptors", maxDescriptors);
+}

--- a/projects/Cyseal/src/render/gpu_culling.h
+++ b/projects/Cyseal/src/render/gpu_culling.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "core/vec3.h"
+#include "rhi/gpu_resource_view.h"
+
+#include <vector>
+#include <memory>
+
+class GPUScene;
+
+class RenderCommandList;
+class PipelineState;
+class RootSignature;
+class DescriptorHeap;
+class Buffer;
+class ConstantBufferView;
+class ShaderResourceView;
+class UnorderedAccessView;
+class SceneProxy;
+class Camera;
+
+// Cull indirect draw commands using GPU scene.
+class GPUCulling final
+{
+public:
+	void initialize();
+
+	void cullDrawCommands(
+		RenderCommandList* commandList,
+		uint32 swapchainIndex,
+		ConstantBufferView* sceneUniform,
+		const Camera* camera,
+		GPUScene* gpuScene,
+		uint32 maxDrawCommands,
+		Buffer* indirectDrawBuffer,
+		ShaderResourceView* indirectDrawBufferSRV,
+		Buffer* culledIndirectDrawBuffer,
+		UnorderedAccessView* culledIndirectDrawBufferUAV,
+		Buffer* drawCounterBuffer,
+		UnorderedAccessView* drawCounterBufferUAV);
+
+private:
+	void resizeVolatileHeaps(uint32 maxDescriptors);
+
+private:
+	std::unique_ptr<PipelineState> pipelineState;
+	std::unique_ptr<RootSignature> rootSignature;
+
+	uint32 totalVolatileDescriptors = 0;
+	std::vector<std::unique_ptr<DescriptorHeap>> volatileViewHeaps;
+};

--- a/projects/Cyseal/src/render/gpu_scene.cpp
+++ b/projects/Cyseal/src/render/gpu_scene.cpp
@@ -314,6 +314,7 @@ void GPUScene::resizeGPUSceneBuffers(uint32 maxElements)
 			.accessFlags = EBufferAccessFlags::CPU_WRITE | EBufferAccessFlags::UAV,
 		}
 	));
+	gpuSceneBuffer->setDebugName(L"Buffer_GPUScene");
 	
 	{
 		ShaderResourceViewDesc srvDesc{};

--- a/projects/Cyseal/src/render/gpu_scene.cpp
+++ b/projects/Cyseal/src/render/gpu_scene.cpp
@@ -82,12 +82,12 @@ void GPUScene::initialize()
 
 void GPUScene::renderGPUScene(
 	RenderCommandList* commandList,
+	uint32 swapchainIndex,
 	const SceneProxy* scene,
 	const Camera* camera,
 	ConstantBufferView* sceneUniform)
 {
 	const uint32 LOD = 0; // #todo-lod: LOD
-	const uint32 swapchainIndex = gRenderDevice->getSwapChain()->getCurrentBackbufferIndex();
 
 	auto& materialCBVs = materialCBVsPerFrame[swapchainIndex];
 
@@ -239,13 +239,12 @@ void GPUScene::queryMaterialDescriptorsCount(uint32& outCBVCount, uint32& outSRV
 }
 
 void GPUScene::copyMaterialDescriptors(
+	uint32 swapchainIndex,
 	DescriptorHeap* destHeap, uint32 destBaseIndex,
 	uint32& outCBVBaseIndex, uint32& outCBVCount,
 	uint32& outSRVBaseIndex, uint32& outSRVCount,
 	uint32& outNextAvailableIndex)
 {
-	const uint32 swapchainIndex = gRenderDevice->getSwapChain()->getCurrentBackbufferIndex();
-
 	outCBVBaseIndex = destBaseIndex;
 	outCBVCount = currentMaterialCBVCount;
 

--- a/projects/Cyseal/src/render/gpu_scene.h
+++ b/projects/Cyseal/src/render/gpu_scene.h
@@ -11,6 +11,7 @@ class PipelineState;
 class RootSignature;
 class DescriptorHeap;
 class Buffer;
+class ConstantBufferView;
 class ShaderResourceView;
 class UnorderedAccessView;
 class SceneProxy;
@@ -29,7 +30,12 @@ class GPUScene final
 {
 public:
 	void initialize();
-	void renderGPUScene(RenderCommandList* commandList, const SceneProxy* scene, const Camera* camera);
+
+	void renderGPUScene(
+		RenderCommandList* commandList,
+		const SceneProxy* scene,
+		const Camera* camera,
+		ConstantBufferView* sceneUniform);
 
 	ShaderResourceView* getGPUSceneBufferSRV() const;
 	ShaderResourceView* getCulledGPUSceneBufferSRV() const;
@@ -50,12 +56,16 @@ public:
 	inline uint32 getGPUSceneItemMaxCount() const { return gpuSceneMaxElements; }
 
 private:
+	void resizeVolatileHeaps(uint32 maxDescriptors);
 	void resizeGPUSceneBuffers(uint32 maxElements);
 	void resizeMaterialBuffers(uint32 maxCBVCount, uint32 maxSRVCount);
 
 private:
 	std::unique_ptr<PipelineState> pipelineState;
 	std::unique_ptr<RootSignature> rootSignature;
+
+	uint32 totalVolatileDescriptors = 0;
+	std::vector<std::unique_ptr<DescriptorHeap>> volatileViewHeaps;
 
 	// GPU scene buffers
 	uint32 gpuSceneMaxElements = 0;

--- a/projects/Cyseal/src/render/gpu_scene.h
+++ b/projects/Cyseal/src/render/gpu_scene.h
@@ -36,6 +36,7 @@ public:
 	// Update GPU scene buffer.
 	void renderGPUScene(
 		RenderCommandList* commandList,
+		uint32 swapchainIndex,
 		const SceneProxy* scene,
 		const Camera* camera,
 		ConstantBufferView* sceneUniform);
@@ -50,6 +51,7 @@ public:
 	// This method will copy a variable number of descriptors, so other descriptors
 	// unrelated to material descriptors can be bound starting from 'outNextAvailableIndex'.
 	void copyMaterialDescriptors(
+		uint32 swapchainIndex,
 		DescriptorHeap* destHeap, uint32 destBaseIndex,
 		uint32& outCBVBaseIndex, uint32& outCBVCount,
 		uint32& outSRVBaseIndex, uint32& outSRVCount,

--- a/projects/Cyseal/src/render/gpu_scene.h
+++ b/projects/Cyseal/src/render/gpu_scene.h
@@ -28,9 +28,12 @@ struct MaterialConstants
 
 class GPUScene final
 {
+	friend class GPUCulling;
+
 public:
 	void initialize();
 
+	// Update GPU scene buffer.
 	void renderGPUScene(
 		RenderCommandList* commandList,
 		const SceneProxy* scene,
@@ -38,7 +41,6 @@ public:
 		ConstantBufferView* sceneUniform);
 
 	ShaderResourceView* getGPUSceneBufferSRV() const;
-	ShaderResourceView* getCulledGPUSceneBufferSRV() const;
 
 	// Query how many descriptors are needed.
 	// Use this before copyMaterialDescriptors() if you're unsure the dest heap is big enough.
@@ -67,16 +69,11 @@ private:
 	uint32 totalVolatileDescriptors = 0;
 	std::vector<std::unique_ptr<DescriptorHeap>> volatileViewHeaps;
 
-	// GPU scene buffers
+	// GPU scene buffer
 	uint32 gpuSceneMaxElements = 0;
 	std::unique_ptr<Buffer> gpuSceneBuffer;
-	std::unique_ptr<Buffer> culledGpuSceneBuffer;
-
-	// GPU scene buffer views
 	std::unique_ptr<ShaderResourceView> gpuSceneBufferSRV;
-	std::unique_ptr<ShaderResourceView> culledGpuSceneBufferSRV;
 	std::unique_ptr<UnorderedAccessView> gpuSceneBufferUAV;
-	std::unique_ptr<UnorderedAccessView> culledGpuSceneBufferUAV;
 
 	// Bindless materials
 	std::unique_ptr<Buffer> materialCBVMemory;

--- a/projects/Cyseal/src/render/ray_traced_reflections.cpp
+++ b/projects/Cyseal/src/render/ray_traced_reflections.cpp
@@ -219,6 +219,7 @@ bool RayTracedReflections::isAvailable() const
 
 void RayTracedReflections::renderRayTracedReflections(
 	RenderCommandList* commandList,
+	uint32 swapchainIndex,
 	const SceneProxy* scene,
 	const Camera* camera,
 	ConstantBufferView* sceneUniformBuffer,
@@ -290,7 +291,6 @@ void RayTracedReflections::renderRayTracedReflections(
 		));
 	}
 
-	const uint32 swapchainIndex = gRenderDevice->getSwapChain()->getCurrentBackbufferIndex();
 	DescriptorHeap* descriptorHeaps[] = { volatileViewHeaps[swapchainIndex].get() };
 
 	//////////////////////////////////////////////////////////////////////////
@@ -324,6 +324,7 @@ void RayTracedReflections::renderRayTracedReflections(
 		volatileHeap, VOLATILE_DESC_IX_SKYBOX,
 		skyboxSRVWithFallback->getSourceHeap(), skyboxSRVWithFallback->getDescriptorIndexInHeap());
 	gpuScene->copyMaterialDescriptors(
+		swapchainIndex,
 		volatileHeap, VOLATILE_DESC_IX_MATERIAL_BEGIN,
 		VOLATILE_DESC_IX_MATERIAL_CBV, unusedMaterialCBVCount,
 		VOLATILE_DESC_IX_MATERIAL_SRV, unusedMaterialSRVCount,

--- a/projects/Cyseal/src/render/ray_traced_reflections.h
+++ b/projects/Cyseal/src/render/ray_traced_reflections.h
@@ -28,6 +28,7 @@ public:
 
 	void renderRayTracedReflections(
 		RenderCommandList* commandList,
+		uint32 swapchainIndex,
 		const SceneProxy* scene,
 		const Camera* camera,
 		ConstantBufferView* sceneUniformBuffer,

--- a/projects/Cyseal/src/render/renderer.h
+++ b/projects/Cyseal/src/render/renderer.h
@@ -13,6 +13,8 @@ enum class ERendererType
 struct RendererOptions
 {
 	bool bEnableRayTracedReflections = true;
+	bool bEnableIndirectDraw = true;
+	bool bEnableGPUCulling = true;
 };
 
 class Renderer

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -264,7 +264,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		basePass->renderBasePass(
 			commandList, swapchainIndex,
-			scene, camera,
+			scene, camera, renderOptions,
 			sceneUniformCBVs[swapchainIndex].get(),
 			gpuScene,
 			gpuCulling,

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -9,6 +9,7 @@
 #include "rhi/global_descriptor_heaps.h"
 #include "render/static_mesh.h"
 #include "render/gpu_scene.h"
+#include "render/gpu_culling.h"
 #include "render/base_pass.h"
 #include "render/ray_traced_reflections.h"
 #include "render/tone_mapping.h"
@@ -91,6 +92,9 @@ void SceneRenderer::initialize(RenderDevice* renderDevice)
 		gpuScene = new GPUScene;
 		gpuScene->initialize();
 
+		gpuCulling = new GPUCulling;
+		gpuCulling->initialize();
+
 		basePass = new BasePass;
 		basePass->initialize();
 
@@ -109,6 +113,7 @@ void SceneRenderer::destroy()
 	delete RT_indirectSpecular;
 
 	delete gpuScene;
+	delete gpuCulling;
 	delete basePass;
 	delete rtReflections;
 	delete toneMapping;
@@ -260,6 +265,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			scene, camera,
 			sceneUniformCBVs[swapchainIndex].get(),
 			gpuScene,
+			gpuCulling,
 			RT_sceneColor, RT_thinGBufferA);
 	}
 

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -185,7 +185,9 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		SCOPED_DRAW_EVENT(commandList, GPUScene);
 
-		gpuScene->renderGPUScene(commandList, scene, camera, sceneUniformCBVs[swapchainIndex].get());
+		gpuScene->renderGPUScene(
+			commandList, swapchainIndex,
+			scene, camera, sceneUniformCBVs[swapchainIndex].get());
 	}
 
 	if (bSupportsRaytracing && scene->bRebuildRaytracingScene)
@@ -314,7 +316,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		commandList->resourceBarriers(_countof(barriers), barriers);
 
 		rtReflections->renderRayTracedReflections(
-			commandList, scene, camera,
+			commandList, swapchainIndex, scene, camera,
 			sceneUniformCBVs[swapchainIndex].get(),
 			accelStructure,
 			gpuScene,
@@ -360,6 +362,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		toneMapping->renderToneMapping(
 			commandList,
+			swapchainIndex,
 			RT_sceneColor,
 			RT_indirectSpecular);
 	}

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -1,6 +1,7 @@
 #include "scene_renderer.h"
 #include "core/assertion.h"
 #include "core/platform.h"
+#include "core/plane.h"
 #include "rhi/render_command.h"
 #include "rhi/gpu_resource.h"
 #include "rhi/swap_chain.h"
@@ -25,6 +26,8 @@ struct SceneUniform
 	Float4x4 viewInvMatrix;
 	Float4x4 projInvMatrix;
 	Float4x4 viewProjInvMatrix;
+
+	Plane3D cameraFrustum[6];
 
 	vec3 cameraPosition; float _pad0;
 	vec3 sunDirection;   float _pad1;
@@ -177,7 +180,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		SCOPED_DRAW_EVENT(commandList, GPUScene);
 
-		gpuScene->renderGPUScene(commandList, scene, camera);
+		gpuScene->renderGPUScene(commandList, scene, camera, sceneUniformCBVs[swapchainIndex].get());
 	}
 
 	if (bSupportsRaytracing && scene->bRebuildRaytracingScene)
@@ -444,6 +447,8 @@ void SceneRenderer::updateSceneUniform(
 	uboData.viewInvMatrix     = camera->getViewInvMatrix();
 	uboData.projInvMatrix     = camera->getProjInvMatrix();
 	uboData.viewProjInvMatrix = camera->getViewProjInvMatrix();
+
+	camera->getFrustum(uboData.cameraFrustum);
 
 	uboData.cameraPosition    = camera->getPosition();
 	uboData.sunDirection      = scene->sun.direction;

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -370,9 +370,13 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	//////////////////////////////////////////////////////////////////////////
 	// Dear Imgui: Record commands
 
-	DescriptorHeap* imguiHeaps[] = { device->getDearImguiSRVHeap() };
-	commandList->setDescriptorHeaps(1, imguiHeaps);
-	device->renderDearImgui(commandList);
+	{
+		SCOPED_DRAW_EVENT(commandList, DearImgui);
+
+		DescriptorHeap* imguiHeaps[] = { device->getDearImguiSRVHeap() };
+		commandList->setDescriptorHeaps(1, imguiHeaps);
+		device->renderDearImgui(commandList);
+	}
 
 	//////////////////////////////////////////////////////////////////////////
 	// Finalize

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -10,6 +10,7 @@ class Texture;
 class DescriptorHeap;
 class ConstantBufferView;
 class GPUScene;
+class GPUCulling;
 class BasePass;
 class RayTracedReflections;
 class ToneMapping;
@@ -56,6 +57,7 @@ private:
 	// ------------------------------------------------------------------------
 	// Render passes
 	GPUScene* gpuScene = nullptr;
+	GPUCulling* gpuCulling = nullptr;
 	BasePass* basePass = nullptr;
 	RayTracedReflections* rtReflections = nullptr;
 	ToneMapping* toneMapping = nullptr;

--- a/projects/Cyseal/src/render/static_mesh.cpp
+++ b/projects/Cyseal/src/render/static_mesh.cpp
@@ -6,7 +6,8 @@ void StaticMesh::addSection(
 	std::shared_ptr<VertexBufferAsset> positionBuffer,
 	std::shared_ptr<VertexBufferAsset> nonPositionBuffer,
 	std::shared_ptr<IndexBufferAsset> indexBuffer,
-	std::shared_ptr<Material> material)
+	std::shared_ptr<Material> material,
+	const AABB& localBounds)
 {
 	if (LODs.size() <= lod)
 	{
@@ -14,10 +15,11 @@ void StaticMesh::addSection(
 	}
 	LODs[lod].sections.emplace_back(
 		StaticMeshSection{
-			.positionBuffer = positionBuffer,
+			.positionBuffer    = positionBuffer,
 			.nonPositionBuffer = nonPositionBuffer,
-			.indexBuffer = indexBuffer,
-			.material = material,
+			.indexBuffer       = indexBuffer,
+			.material          = material,
+			.localBounds       = localBounds,
 		}
 	);
 }

--- a/projects/Cyseal/src/render/static_mesh.h
+++ b/projects/Cyseal/src/render/static_mesh.h
@@ -11,7 +11,8 @@ struct StaticMeshSection
 	std::shared_ptr<VertexBufferAsset> positionBuffer;
 	std::shared_ptr<VertexBufferAsset> nonPositionBuffer;
 	std::shared_ptr<IndexBufferAsset>  indexBuffer;
-	std::shared_ptr<Material> material;
+	std::shared_ptr<Material>          material;
+	AABB                               localBounds;
 };
 
 struct StaticMeshLOD
@@ -27,7 +28,8 @@ public:
 		std::shared_ptr<VertexBufferAsset> positionBuffer,
 		std::shared_ptr<VertexBufferAsset> nonPositionBuffer,
 		std::shared_ptr<IndexBufferAsset> indexBuffer,
-		std::shared_ptr<Material> material);
+		std::shared_ptr<Material> material,
+		const AABB& localBounds);
 
 	inline const std::vector<StaticMeshSection>& getSections(uint32 lod) const
 	{

--- a/projects/Cyseal/src/render/tone_mapping.cpp
+++ b/projects/Cyseal/src/render/tone_mapping.cpp
@@ -108,11 +108,10 @@ ToneMapping::ToneMapping()
 
 void ToneMapping::renderToneMapping(
 	RenderCommandList* commandList,
+	uint32 swapchainIndex,
 	Texture* sceneColor,
 	Texture* indirectSpecular)
 {
-	const uint32 frameIndex = gRenderDevice->getSwapChain()->getCurrentBackbufferIndex();
-
 	commandList->setPipelineState(pipelineState.get());
 	commandList->setGraphicsRootSignature(rootSignature.get());
 
@@ -120,7 +119,7 @@ void ToneMapping::renderToneMapping(
 
 	// Resource binding
 	{
-		DescriptorHeap* heaps[] = { volatileViewHeaps[frameIndex].get() };
+		DescriptorHeap* heaps[] = { volatileViewHeaps[swapchainIndex].get() };
 		commandList->setDescriptorHeaps(1, heaps);
 
 		gRenderDevice->copyDescriptors(

--- a/projects/Cyseal/src/render/tone_mapping.h
+++ b/projects/Cyseal/src/render/tone_mapping.h
@@ -15,6 +15,7 @@ public:
 
 	void renderToneMapping(
 		RenderCommandList* commandList,
+		uint32 swapchainIndex,
 		Texture* sceneColor,
 		Texture* indirectSpecular);
 

--- a/projects/Cyseal/src/rhi/dx12/d3d_buffer.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_buffer.cpp
@@ -323,3 +323,8 @@ void D3DBuffer::writeToGPU(RenderCommandList* commandList, uint32 numUploads, Bu
 		defaultBuffer.Get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COMMON);
 	cmdList->ResourceBarrier(1, &barrierAfter);
 }
+
+void D3DBuffer::setDebugName(const wchar_t* inDebugName)
+{
+	defaultBuffer->SetName(inDebugName);
+}

--- a/projects/Cyseal/src/rhi/dx12/d3d_buffer.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_buffer.cpp
@@ -251,7 +251,7 @@ void D3DBuffer::writeToGPU(RenderCommandList* commandList, uint32 numUploads, Bu
 	for (uint32 i = 0; i < numUploads; ++i)
 	{
 		CHECK((createParams.alignment == 0) || (uploadDescs[i].destOffsetInBytes % createParams.alignment == 0));
-		CHECK(uploadDescs[i].destOffsetInBytes + uploadDescs[i].sizeInBytes < createParams.sizeInBytes);
+		CHECK(uploadDescs[i].destOffsetInBytes + uploadDescs[i].sizeInBytes <= createParams.sizeInBytes);
 	}
 
 	ID3D12GraphicsCommandList* cmdList = static_cast<D3DRenderCommandList*>(commandList)->getRaw();

--- a/projects/Cyseal/src/rhi/dx12/d3d_buffer.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_buffer.h
@@ -18,6 +18,7 @@ public:
 	virtual void writeToGPU(RenderCommandList* commandList, uint32 numUploads, Buffer::UploadDesc* uploadDescs) override;
 
 	virtual void* getRawResource() const { return defaultBuffer.Get(); }
+	virtual void setDebugName(const wchar_t* inDebugName) override;
 
 private:
 	WRL::ComPtr<ID3D12Resource> defaultBuffer;

--- a/projects/Cyseal/src/rhi/gpu_resource.h
+++ b/projects/Cyseal/src/rhi/gpu_resource.h
@@ -165,6 +165,8 @@ public:
 	// Vulkan: VkBuffer or VkImage
 	virtual void* getRawResource() const { CHECK_NO_ENTRY(); return nullptr; }
 	virtual void setRawResource(void* inRawResource) { CHECK_NO_ENTRY(); }
+
+	virtual void setDebugName(const wchar_t* inDebugName) {}
 };
 
 // #todo-barrier: There are 3 types of barriers (transition, aliasing, and UAV)
@@ -314,8 +316,6 @@ public:
 		uint64 rowPitch,
 		uint64 slicePitch,
 		uint32 subresourceIndex = 0) = 0;
-	
-	virtual void setDebugName(const wchar_t* debugName) = 0;
 
 	// #todo-wip: A Texture should not internally hold its views.
 	virtual RenderTargetView*    getRTV() const = 0;

--- a/projects/Cyseal/src/world/camera.h
+++ b/projects/Cyseal/src/world/camera.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/matrix.h"
+#include "core/plane.h"
 
 class Camera
 {
@@ -10,6 +11,8 @@ public:
 	void perspective(float fovY_degrees, float aspectWH, float zNear, float zFar);
 
 	void lookAt(const vec3& origin, const vec3& target, const vec3& up);
+
+	void getFrustum(Plane3D outPlanes[6]) const;
 
 	inline vec3 getPosition() const { return position; }
 
@@ -31,6 +34,11 @@ public:
 
 private:
 	void updateViewProjection() const;
+
+	float fovY_radians;
+	float aspectRatioWH;
+	float zNear;
+	float zFar;
 
 	vec3 position;
 

--- a/projects/Shaders/Shaders.vcxproj
+++ b/projects/Shaders/Shaders.vcxproj
@@ -82,6 +82,7 @@
   <ItemGroup>
     <FxCompile Include="..\..\shaders\base_pass.hlsl" />
     <FxCompile Include="..\..\shaders\common.hlsl" />
+    <FxCompile Include="..\..\shaders\gpu_culling.hlsl" />
     <FxCompile Include="..\..\shaders\gpu_scene.hlsl" />
     <FxCompile Include="..\..\shaders\rt_reflection.hlsl" />
     <FxCompile Include="..\..\shaders\tone_mapping.hlsl" />

--- a/projects/Shaders/Shaders.vcxproj.filters
+++ b/projects/Shaders/Shaders.vcxproj.filters
@@ -6,5 +6,6 @@
     <FxCompile Include="..\..\shaders\common.hlsl" />
     <FxCompile Include="..\..\shaders\gpu_scene.hlsl" />
     <FxCompile Include="..\..\shaders\rt_reflection.hlsl" />
+    <FxCompile Include="..\..\shaders\gpu_culling.hlsl" />
   </ItemGroup>
 </Project>

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -98,8 +98,18 @@ void TestApplication::onTick(float deltaSeconds)
 		{
 			static float elapsed = 0.0f;
 			elapsed += 0.5f * deltaSeconds;
-			vec3 posDelta = vec3(5.0f * sinf(elapsed), 0.0f, 3.0f * cosf(elapsed));
-			camera.lookAt(CAMERA_POSITION + posDelta, CAMERA_LOOKAT + posDelta, CAMERA_UP);
+
+			if (appState.bRotateCamera)
+			{
+				float theta = 3.0f * elapsed;
+				vec3 posDelta = vec3(cosf(theta), 0.0f, sin(theta));
+				camera.lookAt(CAMERA_POSITION, CAMERA_POSITION + posDelta, CAMERA_UP);
+			}
+			else
+			{
+				vec3 posDelta = vec3(5.0f * sinf(elapsed), 0.0f, 3.0f * cosf(elapsed));
+				camera.lookAt(CAMERA_POSITION + posDelta, CAMERA_LOOKAT + posDelta, CAMERA_UP);
+			}
 			//ground->getTransform().setScale(1.0f + 0.2f * cosf(elapsed));
 			ground->setRotation(vec3(0.0f, 1.0f, 0.0f), elapsed * 30.0f);
 		}
@@ -121,18 +131,22 @@ void TestApplication::onTick(float deltaSeconds)
 
 		cysealEngine.beginImguiNewFrame();
 		{
+			//ImGui::ShowDemoWindow(0);
+
 			ImGui::Begin("Rendering options");
-			ImGui::Checkbox("Base Pass - Indirect Draw", &rendererOptions.bEnableIndirectDraw);
-			if (!rendererOptions.bEnableIndirectDraw)
+			ImGui::Checkbox("Base Pass - Indirect Draw", &appState.rendererOptions.bEnableIndirectDraw);
+			if (!appState.rendererOptions.bEnableIndirectDraw)
 			{
 				ImGui::BeginDisabled();
 			}
-			ImGui::Checkbox("Base Pass - GPU Culling", &rendererOptions.bEnableGPUCulling);
-			if (!rendererOptions.bEnableIndirectDraw)
+			ImGui::Checkbox("Base Pass - GPU Culling", &appState.rendererOptions.bEnableGPUCulling);
+			if (!appState.rendererOptions.bEnableIndirectDraw)
 			{
 				ImGui::EndDisabled();
 			}
-			ImGui::Checkbox("Ray Traced Reflections", &rendererOptions.bEnableRayTracedReflections);
+			ImGui::Checkbox("Ray Traced Reflections", &appState.rendererOptions.bEnableRayTracedReflections);
+
+			ImGui::Checkbox("Rotate Camera", &appState.bRotateCamera);
 			//ImGui::SliderFloat("float", &sliderValue, 0.0f, 1.0f);
 			ImGui::End();
 		}
@@ -140,7 +154,7 @@ void TestApplication::onTick(float deltaSeconds)
 
 		SceneProxy* sceneProxy = scene.createProxy();
 
-		cysealEngine.getRenderer()->render(sceneProxy, &camera, rendererOptions);
+		cysealEngine.getRenderer()->render(sceneProxy, &camera, appState.rendererOptions);
 
 		delete sceneProxy;
 	}

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -45,7 +45,7 @@
 #define CAMERA_LOOKAT        vec3(0.0f, 0.0f, 0.0f)
 #define CAMERA_UP            vec3(0.0f, 1.0f, 0.0f)
 #define CAMERA_FOV_Y         70.0f
-#define CAMERA_Z_NEAR        1.0f
+#define CAMERA_Z_NEAR        0.01f
 #define CAMERA_Z_FAR         10000.0f
 
 #define CRUMPLED_WORLD       0

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -121,9 +121,17 @@ void TestApplication::onTick(float deltaSeconds)
 
 		cysealEngine.beginImguiNewFrame();
 		{
-			//ImGui::ShowDemoWindow(0);
-
 			ImGui::Begin("Rendering options");
+			ImGui::Checkbox("Base Pass - Indirect Draw", &rendererOptions.bEnableIndirectDraw);
+			if (!rendererOptions.bEnableIndirectDraw)
+			{
+				ImGui::BeginDisabled();
+			}
+			ImGui::Checkbox("Base Pass - GPU Culling", &rendererOptions.bEnableGPUCulling);
+			if (!rendererOptions.bEnableIndirectDraw)
+			{
+				ImGui::EndDisabled();
+			}
 			ImGui::Checkbox("Ray Traced Reflections", &rendererOptions.bEnableRayTracedReflections);
 			//ImGui::SliderFloat("float", &sliderValue, 0.0f, 1.0f);
 			ImGui::End();

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -228,6 +228,7 @@ void TestApplication::createResources()
 			100.0f, 100.0f, 2, 2,
 			ProceduralGeometry::EPlaneNormal::Y);
 #endif
+		AABB localBounds = planeGeometry->localBounds;
 
 		std::shared_ptr<VertexBufferAsset> positionBufferAsset = std::make_shared<VertexBufferAsset>();
 		std::shared_ptr<VertexBufferAsset> nonPositionBufferAsset = std::make_shared<VertexBufferAsset>();
@@ -259,7 +260,7 @@ void TestApplication::createResources()
 		material->roughness = 0.0f;
 
 		ground = new StaticMesh;
-		ground->addSection(0, positionBufferAsset, nonPositionBufferAsset, indexBufferAsset, material);
+		ground->addSection(0, positionBufferAsset, nonPositionBufferAsset, indexBufferAsset, material, localBounds);
 		ground->setPosition(vec3(0.0f, -10.0f, 0.0f));
 
 		scene.addStaticMesh(ground);
@@ -278,6 +279,7 @@ void TestApplication::createResources()
 			50.0f, 50.0f, 2, 2,
 			ProceduralGeometry::EPlaneNormal::X);
 #endif
+		AABB localBounds = planeGeometry->localBounds;
 
 		std::shared_ptr<VertexBufferAsset> positionBufferAsset = std::make_shared<VertexBufferAsset>();
 		std::shared_ptr<VertexBufferAsset> nonPositionBufferAsset = std::make_shared<VertexBufferAsset>();
@@ -309,7 +311,7 @@ void TestApplication::createResources()
 		material->roughness = 0.0f;
 
 		wallA = new StaticMesh;
-		wallA->addSection(0, positionBufferAsset, nonPositionBufferAsset, indexBufferAsset, material);
+		wallA->addSection(0, positionBufferAsset, nonPositionBufferAsset, indexBufferAsset, material, localBounds);
 		wallA->setPosition(vec3(-25.0f, 0.0f, 0.0f));
 		wallA->setRotation(vec3(0.0f, 0.0f, 1.0f), -10.0f);
 

--- a/projects/TestApplication/src/app.h
+++ b/projects/TestApplication/src/app.h
@@ -12,6 +12,12 @@
 
 class StaticMesh;
 
+struct AppState
+{
+	RendererOptions rendererOptions;
+	bool bRotateCamera;
+};
+
 class TestApplication : public WindowsApplication
 {
 
@@ -29,7 +35,7 @@ private:
 private:
 	Scene scene;
 	Camera camera;
-	RendererOptions rendererOptions;
+	AppState appState;
 
 	MeshSplatting meshSplatting;
 

--- a/projects/TestApplication/src/mesh_splatting.cpp
+++ b/projects/TestApplication/src/mesh_splatting.cpp
@@ -42,6 +42,7 @@ void MeshSplatting::createResources(const CreateParams& createParams)
 			{
 				ProceduralGeometry::cube(*geom, 1.0f, 1.0f, 1.0f);
 			}
+			AABB localBounds = geom->localBounds;
 
 			auto positionBufferAsset = std::make_shared<VertexBufferAsset>();
 			auto nonPositionBufferAsset = std::make_shared<VertexBufferAsset>();
@@ -70,7 +71,7 @@ void MeshSplatting::createResources(const CreateParams& createParams)
 			);
 
 			auto material = baseMaterials[meshIx % baseMaterials.size()];
-			staticMesh->addSection(lod, positionBufferAsset, nonPositionBufferAsset, indexBufferAsset, material);
+			staticMesh->addSection(lod, positionBufferAsset, nonPositionBufferAsset, indexBufferAsset, material, localBounds);
 		}
 
 		float theta = (float)createParams.numLoop * (2.0f * Cymath::PI) * (meshIx / (float)createParams.numMeshes);

--- a/shaders/common.hlsl
+++ b/shaders/common.hlsl
@@ -1,10 +1,12 @@
 struct MeshData
 {
-    float4x4 modelMatrix;
+    float4x4 modelMatrix; // local to world
+    float3   localMinBounds;
     uint     positionBufferOffset;
+    float3   localMaxBounds;
     uint     nonPositionBufferOffset;
     uint     indexBufferOffset;
-    uint     _pad0;
+    float3   _pad0;
 };
 
 struct Material
@@ -12,6 +14,24 @@ struct Material
     float3 albedoMultiplier;
     float  roughness;
     uint   albedoTextureIndex; float3 _pad0;
+};
+
+struct AABB
+{
+    float3 minBounds;
+    float3 maxBounds;
+};
+
+struct Plane3D
+{
+    float3 normal; // Surface normal
+    float distance; // Length of perp vector from O to the plane
+};
+
+struct Frustum3D
+{
+    // 0: top, 1: bottom, 2: left, 3: right, 4: near, 5: far
+    Plane3D planes[6];
 };
 
 struct SceneUniform
@@ -23,6 +43,8 @@ struct SceneUniform
     float4x4 viewInvMatrix;
     float4x4 projInvMatrix;
     float4x4 viewProjInvMatrix;
+
+    Frustum3D cameraFrustum;
 
     float4 cameraPosition; // (x, y, z, ?)
     float4 sunDirection;   // (x, y, z, ?)

--- a/shaders/gpu_culling.hlsl
+++ b/shaders/gpu_culling.hlsl
@@ -96,7 +96,7 @@ AABB calculateWorldBounds(float3 localMin, float3 localMax, float4x4 localToWorl
     float3 worldMax = -FLT_MAX;
     for (uint i = 0; i < 8; ++i)
     {
-        vs[i] = mul(localToWorld, float4(vs[i], 1.0)).xyz;
+        vs[i] = mul(float4(vs[i], 1.0), localToWorld).xyz;
         worldMin = min(worldMin, vs[i]);
         worldMax = max(worldMax, vs[i]);
     }
@@ -106,6 +106,7 @@ AABB calculateWorldBounds(float3 localMin, float3 localMax, float4x4 localToWorl
     return ret;
 }
 
+// true if AABB is on positive side of the plane.
 bool hitTest_AABB_plane(AABB box, Plane3D plane)
 {
     float3 boxCenter = 0.5 * (box.maxBounds + box.minBounds);
@@ -114,6 +115,7 @@ bool hitTest_AABB_plane(AABB box, Plane3D plane)
     float s = dot(boxCenter, plane.normal) - plane.distance;
     return -r <= s;
 }
+// true if AABB is inside of the frustum.
 bool hitTest_AABB_frustum(AABB box, Frustum3D frustum)
 {
     for (int i = 0; i < 6; ++i)
@@ -125,6 +127,7 @@ bool hitTest_AABB_frustum(AABB box, Frustum3D frustum)
     }
     return true;
 }
+// Same as hitTest_AABB_frustum(), but ignore the far plane.
 bool hitTest_AABB_frustumNoFarPlane(AABB box, Frustum3D frustum)
 {
     for (int i = 0; i < 5; ++i)

--- a/shaders/gpu_culling.hlsl
+++ b/shaders/gpu_culling.hlsl
@@ -1,0 +1,165 @@
+#include "common.hlsl"
+
+// ------------------------------------------------------------------------
+// Indirect draw definitions
+// https://learn.microsoft.com/en-us/windows/win32/direct3d12/indirect-drawing
+
+#define D3D12_GPU_VIRTUAL_ADDRESS uint2
+#define DXGI_FORMAT               uint
+#define UINT                      uint
+#define INT                       int
+
+struct D3D12_DRAW_ARGUMENTS
+{
+	UINT VertexCountPerInstance;
+	UINT InstanceCount;
+	UINT StartVertexLocation;
+	UINT StartInstanceLocation;
+};
+
+struct D3D12_DRAW_INDEXED_ARGUMENTS
+{
+	UINT IndexCountPerInstance;
+	UINT InstanceCount;
+	UINT StartIndexLocation;
+	INT  BaseVertexLocation;
+	UINT StartInstanceLocation;
+};
+
+struct D3D12_DISPATCH_ARGUMENTS
+{
+	UINT ThreadGroupCountX;
+	UINT ThreadGroupCountY;
+	UINT ThreadGroupCountZ;
+};
+
+struct D3D12_VERTEX_BUFFER_VIEW
+{
+	D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+	UINT                      SizeInBytes;
+	UINT                      StrideInBytes;
+};
+
+struct D3D12_INDEX_BUFFER_VIEW
+{
+	D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+	UINT                      SizeInBytes;
+	DXGI_FORMAT               Format;
+};
+
+struct D3D12_CONSTANT_BUFFER_VIEW_DESC
+{
+	D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+	UINT                      SizeInBytes;
+};
+
+// ------------------------------------------------------------------------
+// Resource bindings
+
+struct PushConstants
+{
+    uint numDrawCommands;
+};
+
+// #todo-wip-cull: Specific to base pass
+struct IDrawCommand
+{
+	uint                         sceneItemIndex; // index in gpu scene buffer
+	D3D12_VERTEX_BUFFER_VIEW     positionBufferView;
+	D3D12_VERTEX_BUFFER_VIEW     nonPositionBufferView;
+	D3D12_INDEX_BUFFER_VIEW      indexBufferView;
+	D3D12_DRAW_INDEXED_ARGUMENTS drawIndexedArguments;
+};
+
+ConstantBuffer<PushConstants> pushConstants              : register(b0);
+ConstantBuffer<SceneUniform> sceneUniform                : register(b1);
+StructuredBuffer<MeshData> gpuSceneBuffer                : register(t0);
+StructuredBuffer<IDrawCommand> drawCommandBuffer         : register(t1);
+RWStructuredBuffer<IDrawCommand> culledDrawCommandBuffer : register(u0);
+RWBuffer<uint> drawCounterBuffer                         : register(u1);
+
+// ------------------------------------------------------------------------
+// Compute shader
+
+#define FLT_MAX (3.402823466e+38F)
+
+AABB calculateWorldBounds(float3 localMin, float3 localMax, float4x4 localToWorld)
+{
+    float3 vs[8];
+    for (uint i = 0; i < 8; ++i)
+    {
+        vs[i].x = (i & 1) ? localMin.x : localMax.x;
+        vs[i].y = ((i >> 1) & 1) ? localMin.y : localMax.y;
+        vs[i].z = ((i >> 2) & 1) ? localMin.z : localMax.z;
+    }
+    float3 worldMin = FLT_MAX;
+    float3 worldMax = -FLT_MAX;
+    for (uint i = 0; i < 8; ++i)
+    {
+        vs[i] = mul(localToWorld, float4(vs[i], 1.0)).xyz;
+        worldMin = min(worldMin, vs[i]);
+        worldMax = max(worldMax, vs[i]);
+    }
+    AABB ret;
+    ret.minBounds = worldMin;
+    ret.maxBounds = worldMax;
+    return ret;
+}
+
+bool hitTest_AABB_plane(AABB box, Plane3D plane)
+{
+    float3 boxCenter = 0.5 * (box.maxBounds + box.minBounds);
+    float3 boxHalfSize = 0.5 * (box.maxBounds - box.minBounds);
+    float r = dot(boxHalfSize, abs(plane.normal));
+    float s = dot(boxCenter, plane.normal) - plane.distance;
+    return -r <= s;
+}
+bool hitTest_AABB_frustum(AABB box, Frustum3D frustum)
+{
+    for (int i = 0; i < 6; ++i)
+    {
+        if (!hitTest_AABB_plane(box, frustum.planes[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+bool hitTest_AABB_frustumNoFarPlane(AABB box, Frustum3D frustum)
+{
+    for (int i = 0; i < 5; ++i)
+    {
+        if (!hitTest_AABB_plane(box, frustum.planes[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+[numthreads(1, 1, 1)]
+void mainCS(uint3 tid : SV_DispatchThreadID)
+{
+    uint objectID = tid.x;
+    if (objectID >= pushConstants.numDrawCommands)
+    {
+        return;
+    }
+
+    MeshData sceneItem = gpuSceneBuffer[objectID];
+
+    AABB worldBounds = calculateWorldBounds(
+        sceneItem.localMinBounds,
+        sceneItem.localMaxBounds,
+        sceneItem.modelMatrix);
+
+    bool bInFrustum = hitTest_AABB_frustum(worldBounds, sceneUniform.cameraFrustum);
+
+    if (bInFrustum)
+    {
+        uint nextItemIndex;
+        InterlockedAdd(drawCounterBuffer[0], 1, nextItemIndex);
+
+        culledDrawCommandBuffer[nextItemIndex] = drawCommandBuffer[objectID];
+    }
+}

--- a/shaders/gpu_scene.hlsl
+++ b/shaders/gpu_scene.hlsl
@@ -1,5 +1,7 @@
 #include "common.hlsl"
 
+#define FLT_MAX (3.402823466e+38F)
+
 // ------------------------------------------------------------------------
 // Resource bindings
 
@@ -9,12 +11,68 @@ struct PushConstants
 };
 
 ConstantBuffer<PushConstants> pushConstants       : register(b0);
-//ConstantBuffer<SceneUniform> sceneUniform       : register(b1);
+ConstantBuffer<SceneUniform> sceneUniform         : register(b1);
 RWStructuredBuffer<MeshData> gpuSceneBuffer       : register(u0);
 RWStructuredBuffer<MeshData> culledGpuSceneBuffer : register(u1);
+// #todo-wip-cull: Cull something
+//RWBuffer<uint> numVisibleItems                    : register(u2);
 
 // ------------------------------------------------------------------------
 // Compute shader
+
+AABB calculateWorldBounds(float3 localMin, float3 localMax, float4x4 localToWorld)
+{
+    float3 vs[8];
+    for (uint i = 0; i < 8; ++i)
+    {
+        vs[i].x = (i & 1) ? localMin.x : localMax.x;
+        vs[i].y = ((i >> 1) & 1) ? localMin.y : localMax.y;
+        vs[i].z = ((i >> 2) & 1) ? localMin.z : localMax.z;
+    }
+    float3 worldMin = FLT_MAX;
+    float3 worldMax = -FLT_MAX;
+    for (uint i = 0; i < 8; ++i)
+    {
+        vs[i] = mul(localToWorld, float4(vs[i], 1.0)).xyz;
+        worldMin = min(worldMin, vs[i]);
+        worldMax = max(worldMax, vs[i]);
+    }
+    AABB ret;
+    ret.minBounds = worldMin;
+    ret.maxBounds = worldMax;
+    return ret;
+}
+
+bool hitTest_AABB_plane(AABB box, Plane3D plane)
+{
+    float3 boxCenter = 0.5 * (box.maxBounds + box.minBounds);
+    float3 boxHalfSize = 0.5 * (box.maxBounds - box.minBounds);
+    float r = dot(boxHalfSize, abs(plane.normal));
+    float s = dot(boxCenter, plane.normal) - plane.distance;
+    return -r <= s;
+}
+bool hitTest_AABB_frustum(AABB box, Frustum3D frustum)
+{
+    for (int i = 0; i < 6; ++i)
+    {
+        if (!hitTest_AABB_plane(box, frustum.planes[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+bool hitTest_AABB_frustumNoFarPlane(AABB box, Frustum3D frustum)
+{
+    for (int i = 0; i < 5; ++i)
+    {
+        if (!hitTest_AABB_plane(box, frustum.planes[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
 
 [numthreads(1, 1, 1)]
 void mainCS(uint3 tid: SV_DispatchThreadID)
@@ -25,6 +83,22 @@ void mainCS(uint3 tid: SV_DispatchThreadID)
         return;
     }
 
-    // #todo-wip: Cull something
-    culledGpuSceneBuffer[objectID] = gpuSceneBuffer[objectID];
+    MeshData sceneItem = gpuSceneBuffer[objectID];
+
+    AABB worldBounds = calculateWorldBounds(
+        sceneItem.localMinBounds,
+        sceneItem.localMaxBounds,
+        sceneItem.modelMatrix);
+
+    bool bInFrustum = hitTest_AABB_frustum(worldBounds, sceneUniform.cameraFrustum);
+
+    // #todo-wip-cull: Cull something
+    //if (bInFrustum)
+    //{
+    //    uint nextItemIndex;
+    //    InterlockedAdd(numVisibleItems[0], 1, nextItemIndex);
+    //    culledGpuSceneBuffer[nextItemIndex] = sceneItem;
+    //}
+
+    culledGpuSceneBuffer[objectID] = sceneItem;
 }

--- a/shaders/gpu_scene.hlsl
+++ b/shaders/gpu_scene.hlsl
@@ -1,7 +1,5 @@
 #include "common.hlsl"
 
-#define FLT_MAX (3.402823466e+38F)
-
 // ------------------------------------------------------------------------
 // Resource bindings
 
@@ -13,66 +11,9 @@ struct PushConstants
 ConstantBuffer<PushConstants> pushConstants       : register(b0);
 ConstantBuffer<SceneUniform> sceneUniform         : register(b1);
 RWStructuredBuffer<MeshData> gpuSceneBuffer       : register(u0);
-RWStructuredBuffer<MeshData> culledGpuSceneBuffer : register(u1);
-// #todo-wip-cull: Cull something
-//RWBuffer<uint> numVisibleItems                    : register(u2);
 
 // ------------------------------------------------------------------------
 // Compute shader
-
-AABB calculateWorldBounds(float3 localMin, float3 localMax, float4x4 localToWorld)
-{
-    float3 vs[8];
-    for (uint i = 0; i < 8; ++i)
-    {
-        vs[i].x = (i & 1) ? localMin.x : localMax.x;
-        vs[i].y = ((i >> 1) & 1) ? localMin.y : localMax.y;
-        vs[i].z = ((i >> 2) & 1) ? localMin.z : localMax.z;
-    }
-    float3 worldMin = FLT_MAX;
-    float3 worldMax = -FLT_MAX;
-    for (uint i = 0; i < 8; ++i)
-    {
-        vs[i] = mul(localToWorld, float4(vs[i], 1.0)).xyz;
-        worldMin = min(worldMin, vs[i]);
-        worldMax = max(worldMax, vs[i]);
-    }
-    AABB ret;
-    ret.minBounds = worldMin;
-    ret.maxBounds = worldMax;
-    return ret;
-}
-
-bool hitTest_AABB_plane(AABB box, Plane3D plane)
-{
-    float3 boxCenter = 0.5 * (box.maxBounds + box.minBounds);
-    float3 boxHalfSize = 0.5 * (box.maxBounds - box.minBounds);
-    float r = dot(boxHalfSize, abs(plane.normal));
-    float s = dot(boxCenter, plane.normal) - plane.distance;
-    return -r <= s;
-}
-bool hitTest_AABB_frustum(AABB box, Frustum3D frustum)
-{
-    for (int i = 0; i < 6; ++i)
-    {
-        if (!hitTest_AABB_plane(box, frustum.planes[i]))
-        {
-            return false;
-        }
-    }
-    return true;
-}
-bool hitTest_AABB_frustumNoFarPlane(AABB box, Frustum3D frustum)
-{
-    for (int i = 0; i < 5; ++i)
-    {
-        if (!hitTest_AABB_plane(box, frustum.planes[i]))
-        {
-            return false;
-        }
-    }
-    return true;
-}
 
 [numthreads(1, 1, 1)]
 void mainCS(uint3 tid: SV_DispatchThreadID)
@@ -85,20 +26,5 @@ void mainCS(uint3 tid: SV_DispatchThreadID)
 
     MeshData sceneItem = gpuSceneBuffer[objectID];
 
-    AABB worldBounds = calculateWorldBounds(
-        sceneItem.localMinBounds,
-        sceneItem.localMaxBounds,
-        sceneItem.modelMatrix);
-
-    bool bInFrustum = hitTest_AABB_frustum(worldBounds, sceneUniform.cameraFrustum);
-
-    // #todo-wip-cull: Cull something
-    //if (bInFrustum)
-    //{
-    //    uint nextItemIndex;
-    //    InterlockedAdd(numVisibleItems[0], 1, nextItemIndex);
-    //    culledGpuSceneBuffer[nextItemIndex] = sceneItem;
-    //}
-
-    culledGpuSceneBuffer[objectID] = sceneItem;
+    // Do nothing because I'm uploading the entire scene every frame.
 }


### PR DESCRIPTION
Argument buffer layout is hard-coded for base pass.

1. Fill indirect draw buffer (currently from CPU).
2. Cull the buffer from GPU.
3. Execute indirect draw with the culled buffer.

GPU culling can be toggled at runtime via imgui.

![gpu_cull](https://user-images.githubusercontent.com/11644393/226112682-707461ae-73d2-4d88-b31f-7d81f7c8e6d7.jpg)

If enabled, GPUCulling pass is executed during BasePass.

![gpu_cull_2](https://user-images.githubusercontent.com/11644393/226112699-091586aa-ee56-4900-a87b-fc32cb6ad04e.jpg)

Result of GPUCulling pass. If GPU culling is disabled, this pass is skipped and indirect draw will just use `IndirectDrawBuffer`. If enabled, indirect draw uses `CulledIndirectDrawBuffer` and `IndirectDrawCounterBuffer`.
