### PR TITLE
Simple spatiotemporal reconstruction for path tracing

### DIFF
--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
@@ -32,6 +32,9 @@ struct PathTracingUniform
 {
 	float randFloats0[RANDOM_SEQUENCE_LENGTH];
 	float randFloats1[RANDOM_SEQUENCE_LENGTH];
+	Float4x4 prevViewInv;
+	Float4x4 prevProjInv;
+	Float4x4 prevViewProj;
 	uint32 renderTargetWidth;
 	uint32 renderTargetHeight;
 	uint32 bInvalidateHistory;
@@ -213,6 +216,9 @@ void PathTracingPass::renderPathTracing(
 			uboData->randFloats0[i] = Cymath::randFloat();
 			uboData->randFloats1[i] = Cymath::randFloat();
 		}
+		uboData->prevViewInv = passInput.prevViewInvMatrix;
+		uboData->prevProjInv = passInput.prevProjInvMatrix;
+		uboData->prevViewProj = passInput.prevViewProjMatrix;
 		uboData->renderTargetWidth = sceneWidth;
 		uboData->renderTargetHeight = sceneHeight;
 		uboData->bInvalidateHistory = bCameraHasMoved;
@@ -270,9 +276,9 @@ void PathTracingPass::renderPathTracing(
 		SPT.byteAddressBuffer("gVertexBuffer", gVertexBufferPool->getByteAddressBufferView());
 		SPT.structuredBuffer("gpuSceneBuffer", gpuScene->getGPUSceneBufferSRV());
 		SPT.texture("skybox", skyboxSRV);
-		SPT.texture("sceneDepth", passInput.sceneDepthSRV);
+		SPT.texture("sceneDepthTexture", passInput.sceneDepthSRV);
 		SPT.rwTexture("renderTarget", sceneColorUAV);
-		SPT.rwTexture("prevSceneDepth", prevSceneDepthUAV.get());
+		SPT.rwTexture("prevSceneDepthTexture", prevSceneDepthUAV.get());
 		SPT.rwTexture("currentMoment", currentMomentUAV);
 		SPT.rwTexture("prevMoment", prevMomentUAV);
 		SPT.constantBuffer("sceneUniform", sceneUniformBuffer);

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
@@ -38,7 +38,7 @@ struct PathTracingUniform
 	uint32 renderTargetWidth;
 	uint32 renderTargetHeight;
 	uint32 bInvalidateHistory;
-	uint32 _pad0;
+	uint32 bLimitHistory;
 };
 
 struct BlurUniform
@@ -252,6 +252,7 @@ void PathTracingPass::renderPathTracing(RenderCommandList* commandList, uint32 s
 		uboData->renderTargetWidth = sceneWidth;
 		uboData->renderTargetHeight = sceneHeight;
 		uboData->bInvalidateHistory = bCameraHasMoved && passInput.mode == EPathTracingMode::Offline;
+		uboData->bLimitHistory = passInput.mode == EPathTracingMode::Realtime;
 
 		auto uniformCBV = rayPassDescriptor.getUniformCBV(swapchainIndex);
 		uniformCBV->writeToGPU(commandList, uboData, sizeof(PathTracingUniform));
@@ -273,11 +274,11 @@ void PathTracingPass::renderPathTracing(RenderCommandList* commandList, uint32 s
 		requiredVolatiles += 1; // gVertexBuffer
 		requiredVolatiles += 1; // gpuSceneBuffer
 		requiredVolatiles += 1; // skybox
-		requiredVolatiles += 1; // sceneDepth
+		requiredVolatiles += 1; // sceneDepthTexture
+		requiredVolatiles += 1; // sceneNormalTexture
 		requiredVolatiles += 1; // currentColorTexture
 		requiredVolatiles += 1; // prevColorTexture
-		requiredVolatiles += 1; // prevSceneDepth
-		requiredVolatiles += 1; // worldNormal
+		requiredVolatiles += 1; // prevSceneDepthTexture
 		requiredVolatiles += 1; // currentMoment
 		requiredVolatiles += 1; // prevMoment
 		requiredVolatiles += 1; // sceneUniform
@@ -311,6 +312,7 @@ void PathTracingPass::renderPathTracing(RenderCommandList* commandList, uint32 s
 		SPT.structuredBuffer("gpuSceneBuffer", gpuScene->getGPUSceneBufferSRV());
 		SPT.texture("skybox", skyboxSRV);
 		SPT.texture("sceneDepthTexture", passInput.sceneDepthSRV);
+		SPT.rwTexture("sceneNormalTexture", passInput.worldNormalUAV);
 		SPT.rwTexture("currentColorTexture", currentColorUAV);
 		SPT.rwTexture("prevColorTexture", prevColorUAV);
 		SPT.rwTexture("prevSceneDepthTexture", prevSceneDepthUAV.get());

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
@@ -251,7 +251,7 @@ void PathTracingPass::renderPathTracing(RenderCommandList* commandList, uint32 s
 		uboData->prevViewProj = passInput.prevViewProjMatrix;
 		uboData->renderTargetWidth = sceneWidth;
 		uboData->renderTargetHeight = sceneHeight;
-		uboData->bInvalidateHistory = bCameraHasMoved;
+		uboData->bInvalidateHistory = bCameraHasMoved && passInput.mode == EPathTracingMode::Offline;
 
 		auto uniformCBV = rayPassDescriptor.getUniformCBV(swapchainIndex);
 		uniformCBV->writeToGPU(commandList, uboData, sizeof(PathTracingUniform));

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.cpp
@@ -181,15 +181,17 @@ void PathTracingPass::renderPathTracing(
 	uint32 swapchainIndex,
 	const SceneProxy* scene,
 	const Camera* camera,
-	bool bCameraHasMoved,
-	ConstantBufferView* sceneUniformBuffer,
-	AccelerationStructure* raytracingScene,
-	GPUScene* gpuScene,
-	UnorderedAccessView* sceneColorUAV,
-	ShaderResourceView* skyboxSRV,
-	uint32 sceneWidth,
-	uint32 sceneHeight)
+	const PathTracingInput& passInput)
 {
+	auto bCameraHasMoved    = passInput.bCameraHasMoved;
+	auto sceneWidth         = passInput.sceneWidth;
+	auto sceneHeight        = passInput.sceneHeight;
+	auto gpuScene           = passInput.gpuScene;
+	auto raytracingScene    = passInput.raytracingScene;
+	auto sceneUniformBuffer = passInput.sceneUniformBuffer;
+	auto sceneColorUAV      = passInput.sceneColorUAV;
+	auto skyboxSRV          = passInput.skyboxSRV;
+
 	if (isAvailable() == false)
 	{
 		return;

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -31,6 +31,7 @@ public:
 		uint32 sceneHeight);
 
 private:
+	void resizeTextures(RenderCommandList* commandList, uint32 newWidth, uint32 newHeight);
 	void resizeVolatileHeap(uint32 swapchainIndex, uint32 maxDescriptors);
 	void resizeHitGroupShaderTable(uint32 swapchainIndex, const SceneProxy* scene);
 
@@ -46,6 +47,10 @@ private:
 	UniquePtr<Buffer> uniformMemory;
 	UniquePtr<DescriptorHeap> uniformDescriptorHeap;
 	BufferedUniquePtr<ConstantBufferView> uniformCBVs;
+
+	uint32 historyWidth = 0;
+	uint32 historyHeight = 0;
+	UniquePtr<Texture> momentHistory[2];
 
 	std::vector<uint32> totalVolatileDescriptor;
 	BufferedUniquePtr<DescriptorHeap> volatileViewHeap;

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -4,6 +4,7 @@
 #include "core/smart_pointer.h"
 #include "rhi/rhi_forward.h"
 #include "rhi/gpu_resource_view.h"
+#include "rhi/texture.h"
 
 class SceneProxy;
 class Camera;
@@ -11,14 +12,16 @@ class GPUScene;
 
 struct PathTracingInput
 {
-	bool                      bCameraHasMoved;
-	uint32                    sceneWidth;
-	uint32                    sceneHeight;
-	GPUScene*                 gpuScene;
-	AccelerationStructure*    raytracingScene;
-	ConstantBufferView*       sceneUniformBuffer;
-	UnorderedAccessView*      sceneColorUAV;
-	ShaderResourceView*       skyboxSRV;
+	bool                       bCameraHasMoved;
+	uint32                     sceneWidth;
+	uint32                     sceneHeight;
+	GPUScene*                  gpuScene;
+	AccelerationStructure*     raytracingScene;
+	ConstantBufferView*        sceneUniformBuffer;
+	UnorderedAccessView*       sceneColorUAV;
+	const TextureCreateParams* sceneDepthDesc;
+	ShaderResourceView*        sceneDepthSRV;
+	ShaderResourceView*        skyboxSRV;
 };
 
 class PathTracingPass final
@@ -36,7 +39,7 @@ public:
 		const PathTracingInput& passInput);
 
 private:
-	void resizeTextures(RenderCommandList* commandList, uint32 newWidth, uint32 newHeight);
+	void resizeTextures(RenderCommandList* commandList, uint32 newWidth, uint32 newHeight, const TextureCreateParams* sceneDepthDesc);
 	void resizeVolatileHeap(uint32 swapchainIndex, uint32 maxDescriptors);
 	void resizeHitGroupShaderTable(uint32 swapchainIndex, const SceneProxy* scene);
 
@@ -56,6 +59,9 @@ private:
 	uint32 historyWidth = 0;
 	uint32 historyHeight = 0;
 	UniquePtr<Texture> momentHistory[2];
+
+	UniquePtr<Texture> prevSceneDepth;
+	UniquePtr<UnorderedAccessView> prevSceneDepthUAV;
 
 	std::vector<uint32> totalVolatileDescriptor;
 	BufferedUniquePtr<DescriptorHeap> volatileViewHeap;

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -77,6 +77,9 @@ private:
 	UniquePtr<Texture> momentHistory[2];
 	UniquePtr<UnorderedAccessView> momentHistoryUAV[2];
 
+	UniquePtr<Texture> colorHistory[2];
+	UniquePtr<UnorderedAccessView> colorHistoryUAV[2];
+
 	UniquePtr<Texture> colorScratch;
 	UniquePtr<UnorderedAccessView> colorScratchUAV;
 

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -12,6 +12,9 @@ class GPUScene;
 
 struct PathTracingInput
 {
+	Float4x4                   prevViewInvMatrix;
+	Float4x4                   prevProjInvMatrix;
+	Float4x4                   prevViewProjMatrix;
 	bool                       bCameraHasMoved;
 	uint32                     sceneWidth;
 	uint32                     sceneHeight;

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -15,6 +15,7 @@ struct PathTracingInput
 	bool                       bCameraHasMoved;
 	uint32                     sceneWidth;
 	uint32                     sceneHeight;
+
 	GPUScene*                  gpuScene;
 	AccelerationStructure*     raytracingScene;
 	ConstantBufferView*        sceneUniformBuffer;
@@ -59,6 +60,7 @@ private:
 	uint32 historyWidth = 0;
 	uint32 historyHeight = 0;
 	UniquePtr<Texture> momentHistory[2];
+	UniquePtr<UnorderedAccessView> momentHistoryUAV[2];
 
 	UniquePtr<Texture> prevSceneDepth;
 	UniquePtr<UnorderedAccessView> prevSceneDepthUAV;

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -9,6 +9,18 @@ class SceneProxy;
 class Camera;
 class GPUScene;
 
+struct PathTracingInput
+{
+	bool                      bCameraHasMoved;
+	uint32                    sceneWidth;
+	uint32                    sceneHeight;
+	GPUScene*                 gpuScene;
+	AccelerationStructure*    raytracingScene;
+	ConstantBufferView*       sceneUniformBuffer;
+	UnorderedAccessView*      sceneColorUAV;
+	ShaderResourceView*       skyboxSRV;
+};
+
 class PathTracingPass final
 {
 public:
@@ -21,14 +33,7 @@ public:
 		uint32 swapchainIndex,
 		const SceneProxy* scene,
 		const Camera* camera,
-		bool bCameraHasMoved,
-		ConstantBufferView* sceneUniformBuffer,
-		AccelerationStructure* raytracingScene,
-		GPUScene* gpuScene,
-		UnorderedAccessView* sceneColorUAV,
-		ShaderResourceView* skyboxSRV,
-		uint32 sceneWidth,
-		uint32 sceneHeight);
+		const PathTracingInput& passInput);
 
 private:
 	void resizeTextures(RenderCommandList* commandList, uint32 newWidth, uint32 newHeight);

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -28,6 +28,7 @@ struct PathTracingInput
 	UnorderedAccessView*       sceneColorUAV;
 	const TextureCreateParams* sceneDepthDesc;
 	ShaderResourceView*        sceneDepthSRV;
+	UnorderedAccessView*       worldNormalUAV;
 	ShaderResourceView*        skyboxSRV;
 };
 
@@ -37,13 +38,18 @@ private:
 	class VolatileDescriptorHelper
 	{
 	public:
-		void initialize(const wchar_t* inPassName, uint32 swapchainCount);
+		void initialize(const wchar_t* inPassName, uint32 swapchainCount, uint32 uniformTotalSize);
 		void resizeDescriptorHeap(uint32 swapchainIndex, uint32 maxDescriptors);
 		inline DescriptorHeap* getDescriptorHeap(uint32 swapchainIndex) const { return descriptorHeap.at(swapchainIndex); }
+		inline ConstantBufferView* getUniformCBV(uint32 swapchainIndex) const { return uniformCBVs.at(swapchainIndex); }
 	private:
 		std::wstring passName;
 		std::vector<uint32> totalDescriptor; // size = swapchain count
 		BufferedUniquePtr<DescriptorHeap> descriptorHeap; // size = swapchain count
+		// #todo-renderer: Temp dedicated memory for uniforms
+		UniquePtr<Buffer> uniformMemory;
+		UniquePtr<DescriptorHeap> uniformDescriptorHeap;
+		BufferedUniquePtr<ConstantBufferView> uniformCBVs;
 	};
 
 public:
@@ -65,11 +71,6 @@ private:
 	std::vector<uint32> totalHitGroupShaderRecord;
 
 	UniquePtr<ComputePipelineState> blurPipelineState;
-
-	// #todo-renderer: Temp dedicated memory for pathTracingUniform
-	UniquePtr<Buffer> uniformMemory;
-	UniquePtr<DescriptorHeap> uniformDescriptorHeap;
-	BufferedUniquePtr<ConstantBufferView> uniformCBVs;
 
 	uint32 historyWidth = 0;
 	uint32 historyHeight = 0;

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -5,6 +5,7 @@
 #include "rhi/rhi_forward.h"
 #include "rhi/gpu_resource_view.h"
 #include "rhi/texture.h"
+#include "render/renderer.h"
 
 class SceneProxy;
 class Camera;
@@ -14,6 +15,7 @@ struct PathTracingInput
 {
 	const SceneProxy*          scene;
 	const Camera*              camera;
+	EPathTracingMode           mode;
 
 	Float4x4                   prevViewInvMatrix;
 	Float4x4                   prevProjInvMatrix;

--- a/projects/Cyseal/src/render/renderer.h
+++ b/projects/Cyseal/src/render/renderer.h
@@ -19,6 +19,15 @@ enum class EBufferVisualizationMode : uint32
 	Count,
 };
 
+enum class EPathTracingMode : uint32
+{
+	Disabled         = 0,
+	Offline          = 1,
+	Realtime         = 2,
+
+	Count
+};
+
 inline const char** getBufferVisualizationModeNames()
 {
 	static const char* strings[] =
@@ -30,6 +39,17 @@ inline const char** getBufferVisualizationModeNames()
 	return strings;
 };
 
+inline const char** getPathTracingModeNames()
+{
+	static const char* strings[] =
+	{
+		"Disabled",
+		"Offline",
+		"Realtime",
+	};
+	return strings;
+};
+
 struct RendererOptions
 {
 	bool bEnableRayTracedReflections = true;
@@ -37,11 +57,12 @@ struct RendererOptions
 	bool bEnableGPUCulling = true;
 	EBufferVisualizationMode bufferVisualization = EBufferVisualizationMode::None;
 
-	bool bEnablePathTracing = false;
+	EPathTracingMode pathTracing = EPathTracingMode::Disabled;
 	bool bCameraHasMoved = false;
 
 	bool anyRayTracingEnabled() const
 	{
+		bool bEnablePathTracing = pathTracing != EPathTracingMode::Disabled;
 		return bEnableRayTracedReflections || bEnablePathTracing;
 	}
 };

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -148,7 +148,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	const uint32 sceneHeight = swapChain->getBackbufferHeight();
 
 	const bool bSupportsRaytracing = (device->getRaytracingTier() != ERaytracingTier::NotSupported);
-	const bool bRenderPathTracing = bSupportsRaytracing && renderOptions.bEnablePathTracing;
+	const bool bRenderPathTracing = bSupportsRaytracing && (renderOptions.pathTracing != EPathTracingMode::Disabled);
 	
 	bool bRenderRTR = bSupportsRaytracing && renderOptions.bEnableRayTracedReflections;
 	// Let RT_indirectSpecular cleared as black so that tone mapping pass
@@ -291,6 +291,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			PathTracingInput passInput{
 				.scene              = scene,
 				.camera             = camera,
+				.mode               = renderOptions.pathTracing,
 
 				.prevViewInvMatrix  = prevSceneUniformData.viewInvMatrix,
 				.prevProjInvMatrix  = prevSceneUniformData.projInvMatrix,

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -304,6 +304,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.sceneColorUAV      = pathTracingUAV.get(),
 				.sceneDepthDesc     = &sceneDepthDesc,
 				.sceneDepthSRV      = sceneDepthSRV.get(),
+				.worldNormalUAV     = thinGBufferAUAV.get(),
 				.skyboxSRV          = skyboxSRV.get(),
 			};
 			pathTracingPass->renderPathTracing(commandList, swapchainIndex, passInput);

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -482,7 +482,7 @@ void SceneRenderer::recreateSceneTextures(uint32 sceneWidth, uint32 sceneHeight)
 	auto cleanup = [&cleanupList](GPUResource* resource) {
 		if (resource != nullptr)
 		{
-			cleanupList.push_back({ resource, 0 });
+			cleanupList.push_back({ resource });
 		}
 	};
 

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -289,6 +289,9 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		if (bRenderPathTracing)
 		{
 			PathTracingInput passInput{
+				.scene              = scene,
+				.camera             = camera,
+
 				.prevViewInvMatrix  = prevSceneUniformData.viewInvMatrix,
 				.prevProjInvMatrix  = prevSceneUniformData.projInvMatrix,
 				.prevViewProjMatrix = prevSceneUniformData.viewProjMatrix,
@@ -303,7 +306,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.sceneDepthSRV      = sceneDepthSRV.get(),
 				.skyboxSRV          = skyboxSRV.get(),
 			};
-			pathTracingPass->renderPathTracing(commandList, swapchainIndex, scene, camera, passInput);
+			pathTracingPass->renderPathTracing(commandList, swapchainIndex, passInput);
 		}
 	}
 

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -306,15 +306,17 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		if (bRenderPathTracing)
 		{
-			pathTracingPass->renderPathTracing(
-				commandList, swapchainIndex, scene, camera,
-				renderOptions.bCameraHasMoved,
-				sceneUniformCBVs[swapchainIndex].get(),
-				accelStructure.get(),
-				gpuScene,
-				pathTracingUAV.get(),
-				skyboxSRV.get(),
-				sceneWidth, sceneHeight);
+			PathTracingInput passInput{
+				.bCameraHasMoved    = renderOptions.bCameraHasMoved,
+				.sceneWidth         = sceneWidth,
+				.sceneHeight        = sceneHeight,
+				.gpuScene           = gpuScene,
+				.raytracingScene    = accelStructure.get(),
+				.sceneUniformBuffer = sceneUniformCBVs[swapchainIndex].get(),
+				.sceneColorUAV      = pathTracingUAV.get(),
+				.skyboxSRV          = skyboxSRV.get(),
+			};
+			pathTracingPass->renderPathTracing(commandList, swapchainIndex, scene, camera, passInput);
 		}
 	}
 

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -53,8 +53,10 @@ private:
 	UniquePtr<ShaderResourceView> sceneColorSRV;
 	UniquePtr<RenderTargetView> sceneColorRTV;
 
+	TextureCreateParams sceneDepthDesc;
 	UniquePtr<Texture> RT_sceneDepth;
 	UniquePtr<DepthStencilView> sceneDepthDSV;
+	UniquePtr<ShaderResourceView> sceneDepthSRV;
 
 	// Gonna stick to forward shading, but render thin GBuffers like DOOM reboot series.
 	UniquePtr<Texture> RT_thinGBufferA; // #todo-renderer: Maybe switch to R10G10B10A2?

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -18,6 +18,24 @@ class ToneMapping;
 class BufferVisualization;
 class PathTracingPass;
 
+// Should match with common.hlsl
+struct SceneUniform
+{
+	Float4x4 viewMatrix;
+	Float4x4 projMatrix;
+	Float4x4 viewProjMatrix;
+
+	Float4x4 viewInvMatrix;
+	Float4x4 projInvMatrix;
+	Float4x4 viewProjInvMatrix;
+
+	CameraFrustum cameraFrustum;
+
+	vec3 cameraPosition; float _pad0;
+	vec3 sunDirection;   float _pad1;
+	vec3 sunIlluminance; float _pad2;
+};
+
 // Render a 3D scene with hybrid rendering. (rasterization + raytracing)
 class SceneRenderer final : public Renderer
 {
@@ -31,11 +49,7 @@ public:
 	virtual void recreateSceneTextures(uint32 sceneWidth, uint32 sceneHeight) override;
 	
 private:
-	void updateSceneUniform(
-		RenderCommandList* commandList,
-		uint32 swapchainIndex,
-		const SceneProxy* scene,
-		const Camera* camera);
+	void updateSceneUniform(RenderCommandList* commandList, uint32 swapchainIndex, const SceneProxy* scene, const Camera* camera);
 
 	void rebuildFrameResources(RenderCommandList* commandList, const SceneProxy* scene);
 
@@ -46,6 +60,9 @@ private:
 
 	struct DeferredCleanup { GPUResource* resource; /*uint32 count;*/ }; // Don't remember why I put 'count' there...?
 	std::vector<DeferredCleanup> deferredCleanupList;
+
+	SceneUniform sceneUniformData;
+	SceneUniform prevSceneUniformData;
 
 	// ------------------------------------------------------------------------
 	// #todo-renderer: Temporarily manage render targets in the renderer.

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -44,7 +44,7 @@ private:
 private:
 	RenderDevice* device = nullptr;
 
-	struct DeferredCleanup { GPUResource* resource; uint32 count; };
+	struct DeferredCleanup { GPUResource* resource; /*uint32 count;*/ }; // Don't remember why I put 'count' there...?
 	std::vector<DeferredCleanup> deferredCleanupList;
 
 	// ------------------------------------------------------------------------

--- a/projects/Cyseal/src/rhi/descriptor_heap.h
+++ b/projects/Cyseal/src/rhi/descriptor_heap.h
@@ -34,6 +34,11 @@ struct DescriptorHeapDesc
 	uint32 nodeMask            = 0; // MGPU thing
 };
 
+struct DescriptorIndexTracker
+{
+	int32 lastIndex = 0;
+};
+
 // ID3D12DescriptorHeap
 // VkDescriptorPool
 class DescriptorHeap

--- a/projects/Cyseal/src/rhi/dx12/d3d_device.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_device.cpp
@@ -655,9 +655,5 @@ void D3DDevice::copyDescriptors(
 	D3D12_CPU_DESCRIPTOR_HANDLE srcHandle = rawSrcHeap->GetCPUDescriptorHandleForHeapStart();
 	srcHandle.ptr += descSize * srcHeapDescriptorStartOffset;
 
-	device->CopyDescriptorsSimple(
-		numDescriptors,
-		destHandle,
-		srcHandle,
-		into_d3d::descriptorHeapType(dstType));
+	device->CopyDescriptorsSimple(numDescriptors, destHandle, srcHandle, into_d3d::descriptorHeapType(dstType));
 }

--- a/projects/Cyseal/src/rhi/dx12/d3d_into.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_into.h
@@ -241,17 +241,20 @@ namespace into_d3d
 	{
 		switch (inFormat)
 		{
-			case EPixelFormat::UNKNOWN            : return DXGI_FORMAT_UNKNOWN;
-			case EPixelFormat::R32_TYPELESS       : return DXGI_FORMAT_R32_TYPELESS;
-			case EPixelFormat::R8G8B8A8_UNORM     : return DXGI_FORMAT_R8G8B8A8_UNORM;
-			case EPixelFormat::B8G8R8A8_UNORM     : return DXGI_FORMAT_B8G8R8A8_UNORM;
-			case EPixelFormat::R32G32_FLOAT       : return DXGI_FORMAT_R32G32_FLOAT;
-			case EPixelFormat::R32G32B32_FLOAT    : return DXGI_FORMAT_R32G32B32_FLOAT;
-			case EPixelFormat::R32G32B32A32_FLOAT : return DXGI_FORMAT_R32G32B32A32_FLOAT;
-			case EPixelFormat::R16G16B16A16_FLOAT : return DXGI_FORMAT_R16G16B16A16_FLOAT;
-			case EPixelFormat::R32_UINT           : return DXGI_FORMAT_R32_UINT;
-			case EPixelFormat::R16_UINT           : return DXGI_FORMAT_R16_UINT;
-			case EPixelFormat::D24_UNORM_S8_UINT  : return DXGI_FORMAT_D24_UNORM_S8_UINT;
+			case EPixelFormat::UNKNOWN               : return DXGI_FORMAT_UNKNOWN;
+			case EPixelFormat::R32_TYPELESS          : return DXGI_FORMAT_R32_TYPELESS;
+			case EPixelFormat::R24G8_TYPELESS        : return DXGI_FORMAT_R24G8_TYPELESS;
+			case EPixelFormat::R24_UNORM_X8_TYPELESS : return DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
+			case EPixelFormat::R8G8B8A8_UNORM        : return DXGI_FORMAT_R8G8B8A8_UNORM;
+			case EPixelFormat::B8G8R8A8_UNORM        : return DXGI_FORMAT_B8G8R8A8_UNORM;
+			case EPixelFormat::R32_FLOAT             : return DXGI_FORMAT_R32_FLOAT;
+			case EPixelFormat::R32G32_FLOAT          : return DXGI_FORMAT_R32G32_FLOAT;
+			case EPixelFormat::R32G32B32_FLOAT       : return DXGI_FORMAT_R32G32B32_FLOAT;
+			case EPixelFormat::R32G32B32A32_FLOAT    : return DXGI_FORMAT_R32G32B32A32_FLOAT;
+			case EPixelFormat::R16G16B16A16_FLOAT    : return DXGI_FORMAT_R16G16B16A16_FLOAT;
+			case EPixelFormat::R32_UINT              : return DXGI_FORMAT_R32_UINT;
+			case EPixelFormat::R16_UINT              : return DXGI_FORMAT_R16_UINT;
+			case EPixelFormat::D24_UNORM_S8_UINT     : return DXGI_FORMAT_D24_UNORM_S8_UINT;
 		}
 		CHECK_NO_ENTRY(); // #todo-dx12: Unknown pixel format
 		return DXGI_FORMAT_UNKNOWN;

--- a/projects/Cyseal/src/rhi/dx12/d3d_render_command.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_render_command.cpp
@@ -331,7 +331,8 @@ void D3DRenderCommandList::updateGraphicsRootConstants(PipelineState* pipelineSt
 void D3DRenderCommandList::bindComputeShaderParameters(
 	PipelineState* pipelineState,
 	const ShaderParameterTable* inParameters,
-	DescriptorHeap* descriptorHeap)
+	DescriptorHeap* descriptorHeap,
+	DescriptorIndexTracker* tracker)
 {
 	D3DComputePipelineState* d3dPipelineState = static_cast<D3DComputePipelineState*>(pipelineState);
 	ID3D12RootSignature* d3dRootSig = d3dPipelineState->getRootSignature();
@@ -362,7 +363,7 @@ void D3DRenderCommandList::bindComputeShaderParameters(
 
 	// #todo-dx12: Root Descriptor vs Descriptor Table
 	// For now, always use descriptor table.
-	uint32 descriptorIx = 0;
+	uint32 descriptorIx = (tracker == nullptr) ? 0 : tracker->lastIndex;
 
 	for (const auto& inParam : inParameters->pushConstants)
 	{
@@ -377,6 +378,8 @@ void D3DRenderCommandList::bindComputeShaderParameters(
 	setRootDescriptorTables(commandList.Get(), inParameters->textures, &descriptorIx);
 	setRootDescriptorTables(commandList.Get(), inParameters->rwTextures, &descriptorIx);
 	CHECK(inParameters->accelerationStructures.size() == 0); // Not allowed in compute pipeline.
+
+	if (tracker != nullptr) tracker->lastIndex = descriptorIx;
 }
 
 void D3DRenderCommandList::drawIndexedInstanced(

--- a/projects/Cyseal/src/rhi/dx12/d3d_render_command.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_render_command.h
@@ -112,7 +112,7 @@ public:
 	// ------------------------------------------------------------------------
 	// Compute pipeline
 
-	virtual void bindComputeShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap) override;
+	virtual void bindComputeShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker) override;
 
 	virtual void dispatchCompute(uint32 threadGroupX, uint32 threadGroupY, uint32 threadGroupZ) override;
 

--- a/projects/Cyseal/src/rhi/dx12/d3d_texture.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_texture.cpp
@@ -25,7 +25,8 @@ void D3DTexture::initialize(const TextureCreateParams& params)
 			CHECK(textureDesc.Format == DXGI_FORMAT_D16_UNORM
 				|| textureDesc.Format == DXGI_FORMAT_D24_UNORM_S8_UINT
 				|| textureDesc.Format == DXGI_FORMAT_D32_FLOAT
-				|| textureDesc.Format == DXGI_FORMAT_D32_FLOAT_S8X24_UINT);
+				|| textureDesc.Format == DXGI_FORMAT_D32_FLOAT_S8X24_UINT
+				|| textureDesc.Format == DXGI_FORMAT_R24G8_TYPELESS);
 		}
 	}
 
@@ -33,6 +34,10 @@ void D3DTexture::initialize(const TextureCreateParams& params)
 	bool bNeedsClearValue = false;
 	D3D12_CLEAR_VALUE optClearValue;
 	optClearValue.Format = textureDesc.Format;
+	if (optClearValue.Format == DXGI_FORMAT_R24G8_TYPELESS)
+	{
+		optClearValue.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	}
 	if (isColorTarget && ENUM_HAS_FLAG(params.accessFlags, ETextureAccessFlags::RTV))
 	{
 		bNeedsClearValue = true;

--- a/projects/Cyseal/src/rhi/pixel_format.h
+++ b/projects/Cyseal/src/rhi/pixel_format.h
@@ -13,12 +13,15 @@ enum class EPixelFormat : uint8
 
 	// TYPELESS
 	R32_TYPELESS,
+	R24G8_TYPELESS,
+	R24_UNORM_X8_TYPELESS,
 
 	// UNORM
 	R8G8B8A8_UNORM,
 	B8G8R8A8_UNORM,
 	
 	// FLOAT
+	R32_FLOAT,
 	R32G32_FLOAT,
 	R32G32B32_FLOAT,
 	R32G32B32A32_FLOAT,
@@ -36,15 +39,18 @@ inline uint32 getPixelFormatBytes(EPixelFormat format)
 {
 	switch (format)
 	{
-		case EPixelFormat::R32_TYPELESS       : return 4;
-		case EPixelFormat::R8G8B8A8_UNORM     : return 4;
-		case EPixelFormat::B8G8R8A8_UNORM     : return 4;
-		case EPixelFormat::R32G32_FLOAT       : return 8;
-		case EPixelFormat::R32G32B32_FLOAT    : return 12;
-		case EPixelFormat::R32G32B32A32_FLOAT : return 16;
-		case EPixelFormat::R16G16B16A16_FLOAT : return 8;
-		case EPixelFormat::R32_UINT           : return 4;
-		case EPixelFormat::R16_UINT           : return 2;
+		case EPixelFormat::R32_TYPELESS          : return 4;
+		case EPixelFormat::R24G8_TYPELESS        : return 4;
+		case EPixelFormat::R24_UNORM_X8_TYPELESS : return 4;
+		case EPixelFormat::R8G8B8A8_UNORM        : return 4;
+		case EPixelFormat::B8G8R8A8_UNORM        : return 4;
+		case EPixelFormat::R32_FLOAT             : return 4;
+		case EPixelFormat::R32G32_FLOAT          : return 8;
+		case EPixelFormat::R32G32B32_FLOAT       : return 12;
+		case EPixelFormat::R32G32B32A32_FLOAT    : return 16;
+		case EPixelFormat::R16G16B16A16_FLOAT    : return 8;
+		case EPixelFormat::R32_UINT              : return 4;
+		case EPixelFormat::R16_UINT              : return 2;
 		default: CHECK_NO_ENTRY();
 	}
 	return 0;

--- a/projects/Cyseal/src/rhi/render_command.h
+++ b/projects/Cyseal/src/rhi/render_command.h
@@ -161,8 +161,14 @@ public:
 	void executeCustomCommands();
 
 	template<typename T>
-	void enqueueDeferredDealloc(T* addrToDelete)
+	void enqueueDeferredDealloc(T* addrToDelete, bool ignoreNullPtr = false)
 	{
+		if (addrToDelete == nullptr)
+		{
+			if (ignoreNullPtr) return;
+			CHECK_NO_ENTRY();
+		}
+
 		auto deallocFn = [addrToDelete]() {
 			delete (T*)addrToDelete;
 		};

--- a/projects/Cyseal/src/rhi/render_command.h
+++ b/projects/Cyseal/src/rhi/render_command.h
@@ -138,7 +138,7 @@ public:
 	// ------------------------------------------------------------------------
 	// Compute pipeline
 
-	virtual void bindComputeShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap) = 0;
+	virtual void bindComputeShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker = nullptr) = 0;
 
 	virtual void dispatchCompute(uint32 threadGroupX, uint32 threadGroupY, uint32 threadGroupZ) = 0;
 

--- a/projects/Cyseal/src/rhi/vulkan/vk_into.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_into.h
@@ -206,18 +206,21 @@ namespace into_vk
 	{
 		switch (inFormat)
 		{
-			case EPixelFormat::UNKNOWN            : return VkFormat::VK_FORMAT_UNDEFINED;
-			// #todo-vulkan: R32_TYPLESS in Vulkan?
-			case EPixelFormat::R32_TYPELESS       : return VkFormat::VK_FORMAT_R32_SFLOAT;
-			case EPixelFormat::R8G8B8A8_UNORM     : return VkFormat::VK_FORMAT_R8G8B8A8_UNORM;
-			case EPixelFormat::B8G8R8A8_UNORM     : return VkFormat::VK_FORMAT_B8G8R8A8_UNORM;
-			case EPixelFormat::R32G32_FLOAT       : return VkFormat::VK_FORMAT_R32G32_SFLOAT;
-			case EPixelFormat::R32G32B32_FLOAT    : return VkFormat::VK_FORMAT_R32G32B32_SFLOAT;
-			case EPixelFormat::R32G32B32A32_FLOAT : return VkFormat::VK_FORMAT_R32G32B32A32_SFLOAT;
-			case EPixelFormat::R16G16B16A16_FLOAT : return VkFormat::VK_FORMAT_R16G16B16A16_SFLOAT;
-			case EPixelFormat::R32_UINT           : return VkFormat::VK_FORMAT_R32_UINT;
-			case EPixelFormat::R16_UINT           : return VkFormat::VK_FORMAT_R16_UINT;
-			case EPixelFormat::D24_UNORM_S8_UINT  : return VkFormat::VK_FORMAT_D24_UNORM_S8_UINT;
+			case EPixelFormat::UNKNOWN               : return VkFormat::VK_FORMAT_UNDEFINED;
+			// #todo-vulkan: TYPLESS formats in Vulkan?
+			case EPixelFormat::R32_TYPELESS          : CHECK_NO_ENTRY(); return VkFormat::VK_FORMAT_R32_SFLOAT;
+			case EPixelFormat::R24G8_TYPELESS        : CHECK_NO_ENTRY(); return VkFormat::VK_FORMAT_R32_SFLOAT;
+			case EPixelFormat::R24_UNORM_X8_TYPELESS : CHECK_NO_ENTRY(); return VkFormat::VK_FORMAT_R32_SFLOAT;
+			case EPixelFormat::R8G8B8A8_UNORM        : return VkFormat::VK_FORMAT_R8G8B8A8_UNORM;
+			case EPixelFormat::B8G8R8A8_UNORM        : return VkFormat::VK_FORMAT_B8G8R8A8_UNORM;
+			case EPixelFormat::R32_FLOAT             : return VkFormat::VK_FORMAT_R32_SFLOAT;
+			case EPixelFormat::R32G32_FLOAT          : return VkFormat::VK_FORMAT_R32G32_SFLOAT;
+			case EPixelFormat::R32G32B32_FLOAT       : return VkFormat::VK_FORMAT_R32G32B32_SFLOAT;
+			case EPixelFormat::R32G32B32A32_FLOAT    : return VkFormat::VK_FORMAT_R32G32B32A32_SFLOAT;
+			case EPixelFormat::R16G16B16A16_FLOAT    : return VkFormat::VK_FORMAT_R16G16B16A16_SFLOAT;
+			case EPixelFormat::R32_UINT              : return VkFormat::VK_FORMAT_R32_UINT;
+			case EPixelFormat::R16_UINT              : return VkFormat::VK_FORMAT_R16_UINT;
+			case EPixelFormat::D24_UNORM_S8_UINT     : return VkFormat::VK_FORMAT_D24_UNORM_S8_UINT;
 		}
 		CHECK_NO_ENTRY();
 		return VkFormat::VK_FORMAT_UNDEFINED;

--- a/projects/Cyseal/src/rhi/vulkan/vk_render_command.cpp
+++ b/projects/Cyseal/src/rhi/vulkan/vk_render_command.cpp
@@ -323,7 +323,8 @@ void VulkanRenderCommandList::executeIndirect(
 void VulkanRenderCommandList::bindComputeShaderParameters(
 	PipelineState* pipelineState,
 	const ShaderParameterTable* parameters,
-	DescriptorHeap* descriptorHeap)
+	DescriptorHeap* descriptorHeap,
+	DescriptorIndexTracker* tracker)
 {
 	// #todo-vulkan
 	CHECK_NO_ENTRY();

--- a/projects/Cyseal/src/rhi/vulkan/vk_render_command.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_render_command.h
@@ -106,7 +106,7 @@ public:
 	// ------------------------------------------------------------------------
 	// Compute pipeline
 
-	virtual void bindComputeShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap) override;
+	virtual void bindComputeShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker) override;
 
 	virtual void dispatchCompute(uint32 threadGroupX, uint32 threadGroupY, uint32 threadGroupZ) override;
 

--- a/projects/Shaders/Shaders.vcxproj
+++ b/projects/Shaders/Shaders.vcxproj
@@ -81,6 +81,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <FxCompile Include="..\..\shaders\base_pass.hlsl" />
+    <FxCompile Include="..\..\shaders\bilateral_blur.hlsl" />
     <FxCompile Include="..\..\shaders\bsdf.hlsl" />
     <FxCompile Include="..\..\shaders\buffer_visualization.hlsl" />
     <FxCompile Include="..\..\shaders\common.hlsl" />

--- a/projects/Shaders/Shaders.vcxproj.filters
+++ b/projects/Shaders/Shaders.vcxproj.filters
@@ -10,5 +10,6 @@
     <FxCompile Include="..\..\shaders\buffer_visualization.hlsl" />
     <FxCompile Include="..\..\shaders\path_tracing.hlsl" />
     <FxCompile Include="..\..\shaders\bsdf.hlsl" />
+    <FxCompile Include="..\..\shaders\bilateral_blur.hlsl" />
   </ItemGroup>
 </Project>

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -103,13 +103,16 @@ void TestApplication::onTick(float deltaSeconds)
 		}
 		appState.rendererOptions.bCameraHasMoved = bCameraHasMoved;
 
-		if (bCameraHasMoved)
+		if (appState.rendererOptions.pathTracing != EPathTracingMode::Disabled)
 		{
-			appState.pathTracingNumFrames = 0;
-		}
-		else if (appState.rendererOptions.bEnablePathTracing)
-		{
-			appState.pathTracingNumFrames += 1;
+			if (bCameraHasMoved && appState.rendererOptions.pathTracing == EPathTracingMode::Offline)
+			{
+				appState.pathTracingNumFrames = 0;
+			}
+			else
+			{
+				appState.pathTracingNumFrames += 1;
+			}
 		}
 
 		world->onTick(deltaSeconds);
@@ -148,7 +151,8 @@ void TestApplication::onTick(float deltaSeconds)
 			appState.rendererOptions.bufferVisualization = (EBufferVisualizationMode)appState.selectedBufferVisualizationMode;
 
 			ImGui::SeparatorText("Path Tracing");
-			ImGui::Checkbox("Enable", &appState.rendererOptions.bEnablePathTracing);
+			ImGui::Combo("Path Tracing Mode", &appState.selectedPathTracingMode, getPathTracingModeNames(), (int32)EPathTracingMode::Count);
+			appState.rendererOptions.pathTracing = (EPathTracingMode)appState.selectedPathTracingMode;
 			ImGui::Text("Frames: %u", appState.pathTracingNumFrames);
 
 			ImGui::SeparatorText("Control");

--- a/projects/TestApplication/src/app.h
+++ b/projects/TestApplication/src/app.h
@@ -9,6 +9,7 @@ struct AppState
 {
 	RendererOptions rendererOptions;
 	int32 selectedBufferVisualizationMode = 0;
+	int32 selectedPathTracingMode = 0;
 	uint32 pathTracingNumFrames = 0;
 };
 

--- a/projects/TestApplication/src/world1.cpp
+++ b/projects/TestApplication/src/world1.cpp
@@ -59,7 +59,7 @@ void World1::onInitialize()
 void World1::onTick(float deltaSeconds)
 {
 	// Animate meshes.
-	if (!appState->rendererOptions.bEnablePathTracing)
+	if (appState->rendererOptions.pathTracing == EPathTracingMode::Disabled)
 	{
 		static float elapsed = 0.0f;
 		elapsed += deltaSeconds;

--- a/shaders/bilateral_blur.hlsl
+++ b/shaders/bilateral_blur.hlsl
@@ -1,5 +1,7 @@
 #include "common.hlsl"
 
+// [Holger Dammertz] Edge Avoiding A-Trous Wavelet Transform for fast Global Illumination Filtering
+
 // ------------------------------------------------------------------------
 // Resource bindings
 

--- a/shaders/bilateral_blur.hlsl
+++ b/shaders/bilateral_blur.hlsl
@@ -3,30 +3,100 @@
 // ------------------------------------------------------------------------
 // Resource bindings
 
-struct PushConstants0
+struct BlurUniform
 {
-    uint width;
-};
-struct PushConstants1
-{
-    uint height;
+    float4 kernelAndOffset[25]; // (kernel, offsetX, offsetY, _unused)
+    float cPhi;
+    float nPhi;
+    float pPhi;
+    float _pad0;
+    uint textureWidth;
+    uint textureHeight;
+    uint stepWidth;
+    uint _pad1;
 };
 
-ConstantBuffer<PushConstants0> pushConstants0;
-ConstantBuffer<PushConstants1> pushConstants1;
-RWTexture2D<float4>            inputTexture;
+ConstantBuffer<SceneUniform>   sceneUniform;
+ConstantBuffer<BlurUniform>    blurUniform;
+RWTexture2D<float4>            inColorTexture;
+RWTexture2D<float4>            inNormalTexture;
+Texture2D<float>               inDepthTexture;
 RWTexture2D<float4>            outputTexture;
 
 // ------------------------------------------------------------------------
 // Compute shader
 
+float2 getResolution()
+{
+    return float2(blurUniform.textureWidth, blurUniform.textureHeight);
+}
+
+float3 getWorldPosition(uint2 tid)
+{
+    float sceneDepth = inDepthTexture.Load(int3(tid.xy, 0)).r;
+    float2 uv = (float2(tid.xy) + float2(0.5, 0.5)) / getResolution();
+#if REVERSE_Z
+    float z = sceneDepth; // clipZ is [0,1] in Reverse-Z
+#else
+    float z = sceneDepth * 2.0 - 1.0; // Use this if not Reverse-Z
+#endif
+    float4 positionCS = float4(uv * 2.0 - 1.0, z, 1.0);
+    float4 positionVS = mul(positionCS, sceneUniform.projInvMatrix);
+    positionVS /= positionVS.w; // Perspective division
+    float4 positionWS = mul(positionVS, sceneUniform.viewInvMatrix);
+    return positionWS.xyz;
+}
+
 [numthreads(8, 8, 1)]
 void mainCS(uint3 tid : SV_DispatchThreadID)
 {
-    if (tid.x >= pushConstants0.width || tid.y >= pushConstants1.height)
+    if (tid.x >= blurUniform.textureWidth || tid.y >= blurUniform.textureHeight)
     {
         return;
     }
 
-    outputTexture[tid.xy] = inputTexture[tid.xy];
+    float2 resolution = getResolution();
+    float stepWidth = float(blurUniform.stepWidth);
+
+    float2 uv0 = (float2(tid.xy) + float2(0.5, 0.5)) / resolution;
+    float3 color0 = inColorTexture[tid.xy].xyz;
+    float3 normal0 = inNormalTexture[tid.xy].xyz;
+    float3 pos0 = getWorldPosition(tid.xy);
+
+    float2 step = 1.0 / resolution;
+    float3 sum = float3(0.0, 0.0, 0.0);
+    float weightSum = 0.0;
+    for (int i = 0; i < 25; ++i)
+    {
+        float4 params = blurUniform.kernelAndOffset[i];
+        float kernel = params.x;
+        float2 offset = params.yz;
+
+        float3 diff; float distSq;
+
+        float2 uv1 = uv0 + offset * step * stepWidth;
+        uint2 neighborTexel = uint2(uv1 * resolution);
+        float3 color1 = inColorTexture[neighborTexel].xyz;
+        float3 normal1 = inNormalTexture[neighborTexel].xyz;
+        float3 pos1 = getWorldPosition(neighborTexel);
+
+        diff = color0 - color1;
+        distSq = dot(diff, diff);
+        float colorWeight = min(1.0, exp(-distSq / blurUniform.cPhi));
+
+        diff = normal0 - normal1;
+        distSq = max(0.0, dot(diff, diff) / (stepWidth * stepWidth));
+        float normalWeight = min(1.0, exp(-distSq / blurUniform.nPhi));
+
+        diff = pos0 - pos1;
+        distSq = dot(diff, diff);
+        float posWeight = min(1.0, exp(-distSq / blurUniform.pPhi));
+
+        float weight = colorWeight * normalWeight * posWeight;
+        sum += color1 * weight * kernel;
+        weightSum += weight * kernel;
+    }
+    float3 finalColor = sum / weightSum;
+
+    outputTexture[tid.xy] = float4(finalColor, 1.0);
 }

--- a/shaders/bilateral_blur.hlsl
+++ b/shaders/bilateral_blur.hlsl
@@ -1,0 +1,32 @@
+#include "common.hlsl"
+
+// ------------------------------------------------------------------------
+// Resource bindings
+
+struct PushConstants0
+{
+    uint width;
+};
+struct PushConstants1
+{
+    uint height;
+};
+
+ConstantBuffer<PushConstants0> pushConstants0;
+ConstantBuffer<PushConstants1> pushConstants1;
+RWTexture2D<float4>            inputTexture;
+RWTexture2D<float4>            outputTexture;
+
+// ------------------------------------------------------------------------
+// Compute shader
+
+[numthreads(8, 8, 1)]
+void mainCS(uint3 tid : SV_DispatchThreadID)
+{
+    if (tid.x >= pushConstants0.width || tid.y >= pushConstants1.height)
+    {
+        return;
+    }
+
+    outputTexture[tid.xy] = inputTexture[tid.xy];
+}

--- a/shaders/bilateral_blur.hlsl
+++ b/shaders/bilateral_blur.hlsl
@@ -1,6 +1,8 @@
 #include "common.hlsl"
 
-// [Holger Dammertz] Edge Avoiding A-Trous Wavelet Transform for fast Global Illumination Filtering
+// References
+// - [Holger Dammertz] Edge Avoiding A-Trous Wavelet Transform for fast Global Illumination Filtering
+// - [AMD FidelityFX-Denoiser] Temporal reprojection logic: https://github.com/GPUOpen-Effects/FidelityFX-Denoiser/blob/master/ffx-shadows-dnsr/ffx_denoiser_shadows_tileclassification.h
 
 // ------------------------------------------------------------------------
 // Resource bindings
@@ -86,8 +88,6 @@ void mainCS(uint3 tid : SV_DispatchThreadID)
 
         float3 diff; float distSq;
 
-        //float2 uv1 = uv0 + offset * step * stepWidth;
-        //uint2 neighborTexel = uint2(uv1 * resolution);
         int2 neighborTexel = clampTexel(int2(float2(tid.xy) + offset * stepWidth));
 
         float3 color1 = inColorTexture[neighborTexel].xyz;
@@ -105,10 +105,6 @@ void mainCS(uint3 tid : SV_DispatchThreadID)
         diff = pos0 - pos1;
         distSq = dot(diff, diff);
         float posWeight = min(1.0, exp(-distSq / blurUniform.pPhi));
-
-        //if (abs(colorWeight - 1.0) > 0.001) colorWeight = 1;
-        //if (abs(normalWeight - 1.0) > 0.001) normalWeight = 1;
-        //if (abs(posWeight - 1.0) > 0.001) posWeight = 1;
 
         float weight = colorWeight * normalWeight * posWeight;
         sum += color1 * weight * kernel;

--- a/shaders/common.hlsl
+++ b/shaders/common.hlsl
@@ -6,6 +6,9 @@
 #define HALF_PI    1.57079632679489661923
 #define FLT_MAX    (3.402823466e+38F)
 
+// #todo: Toggle Reverse-Z
+#define REVERSE_Z  0
+
 struct GPUSceneItem
 {
     float4x4 modelMatrix; // local to world

--- a/shaders/common.hlsl
+++ b/shaders/common.hlsl
@@ -4,6 +4,7 @@
 #define PI         3.14159265
 #define TWO_PI     6.28318530718
 #define HALF_PI    1.57079632679489661923
+#define FLT_MAX    (3.402823466e+38F)
 
 struct GPUSceneItem
 {

--- a/shaders/gpu_culling.hlsl
+++ b/shaders/gpu_culling.hlsl
@@ -81,8 +81,6 @@ RWBuffer<uint> drawCounterBuffer;
 // ------------------------------------------------------------------------
 // Compute shader
 
-#define FLT_MAX (3.402823466e+38F)
-
 AABB calculateWorldBounds(float3 localMin, float3 localMax, float4x4 localToWorld)
 {
     float3 vs[8];

--- a/shaders/path_tracing.hlsl
+++ b/shaders/path_tracing.hlsl
@@ -59,7 +59,9 @@ ByteAddressBuffer                  gIndexBuffer       : register(t1, space0);
 ByteAddressBuffer                  gVertexBuffer      : register(t2, space0);
 StructuredBuffer<GPUSceneItem>     gpuSceneBuffer     : register(t3, space0);
 TextureCube                        skybox             : register(t4, space0);
+Texture2D                          sceneDepth         : register(t5, space0);
 RWTexture2D<float4>                renderTarget       : register(u0, space0);
+RWTexture2D<float>                 prevSceneDepth     : register(u1, space0);
 ConstantBuffer<SceneUniform>       sceneUniform       : register(b0, space0);
 ConstantBuffer<PathTracingUniform> pathTracingUniform : register(b1, space0);
 // Material binding
@@ -381,6 +383,8 @@ void MainRaygen()
 
 	renderTarget[targetTexel] = float4(Li, historyCount);
 #endif
+
+	prevSceneDepth[targetTexel] = sceneDepth.Load(int3(targetTexel, 0)).r;
 }
 
 [shader("closesthit")]

--- a/shaders/path_tracing.hlsl
+++ b/shaders/path_tracing.hlsl
@@ -32,6 +32,9 @@
 #define RANDOM_SEQUENCE_HEIGHT    64
 #define RANDOM_SEQUENCE_LENGTH    (RANDOM_SEQUENCE_WIDTH * RANDOM_SEQUENCE_HEIGHT)
 
+// Limit history count for realtime mode.
+#define MAX_REALTIME_HISTORY      64
+
 struct PathTracingUniform
 {
 	float4 randFloats0[RANDOM_SEQUENCE_LENGTH / 4];
@@ -42,7 +45,7 @@ struct PathTracingUniform
 	uint renderTargetWidth;
 	uint renderTargetHeight;
 	uint bInvalidateHistory; // If nonzero, force invalidate the whole history.
-	uint _pad0;
+	uint bLimitHistory;
 };
 
 struct VertexAttributes
@@ -63,11 +66,12 @@ ByteAddressBuffer                  gVertexBuffer         : register(t2, space0);
 StructuredBuffer<GPUSceneItem>     gpuSceneBuffer        : register(t3, space0);
 TextureCube                        skybox                : register(t4, space0);
 Texture2D                          sceneDepthTexture     : register(t5, space0);
-RWTexture2D<float4>                currentColorTexture   : register(u0, space0);
-RWTexture2D<float4>                prevColorTexture      : register(u1, space0);
-RWTexture2D<float>                 prevSceneDepthTexture : register(u2, space0);
-RWTexture2D<float4>                currentMoment         : register(u3, space0);
-RWTexture2D<float4>                prevMoment            : register(u4, space0);
+RWTexture2D<float4>                sceneNormalTexture    : register(u0, space0);
+RWTexture2D<float4>                currentColorTexture   : register(u1, space0);
+RWTexture2D<float4>                prevColorTexture      : register(u2, space0);
+RWTexture2D<float>                 prevSceneDepthTexture : register(u3, space0);
+RWTexture2D<float4>                currentMoment         : register(u4, space0);
+RWTexture2D<float4>                prevMoment            : register(u5, space0);
 ConstantBuffer<SceneUniform>       sceneUniform          : register(b0, space0);
 ConstantBuffer<PathTracingUniform> pathTracingUniform    : register(b1, space0);
 // Material binding
@@ -125,35 +129,50 @@ float2 getScreenResolution()
 	return float2(pathTracingUniform.renderTargetWidth, pathTracingUniform.renderTargetHeight);
 }
 
-float3 getWorldPositionFromSceneDepth(float2 screenUV, float sceneDepth)
+float getNdcZ(float sceneDepth)
 {
-	float z = sceneDepth * 2.0 - 1.0; // Use this if not Reverse-Z
-	//float z = sceneDepth; // clipZ is [0,1] in Reverse-Z
-	float4 positionCS = float4(screenUV * 2.0 - 1.0, z, 1.0);
-	float4 positionVS = mul(positionCS, sceneUniform.projInvMatrix);
-	positionVS /= positionVS.w; // Perspective division
-	float4 positionWS = mul(positionVS, sceneUniform.viewInvMatrix);
-	return positionWS.xyz;
+#if REVERSE_Z
+	return sceneDepth; // clipZ is [0,1] in Reverse-Z
+#else
+	return sceneDepth * 2.0 - 1.0;
+#endif
 }
 
-float3 getPrevWorldPosition(float3 currPositionWS)
+float getLinearDepth(float2 screenUV, float sceneDepth)
+{
+	float4 positionCS = float4(2.0 * screenUV - 1.0, sceneDepth, 1.0);
+	float4 projected = mul(positionCS, sceneUniform.projInvMatrix);
+	return abs(projected.z / projected.w);
+}
+
+float3 getWorldPositionFromSceneDepth(float2 screenUV, float sceneDepth)
+{
+	float z = getNdcZ(sceneDepth);
+	float4 positionCS = float4(screenUV * 2.0 - 1.0, z, 1.0);
+	float4 positionWS = mul(positionCS, sceneUniform.viewProjInvMatrix);
+	return positionWS.xyz / positionWS.w;
+}
+
+bool getPrevWorldPosition(float3 currPositionWS, out float3 prevPositionWS, out float prevLinearDepth)
 {
 	float4 positionCS = mul(float4(currPositionWS, 1.0), pathTracingUniform.prevViewProjMatrix);
 	float2 screenUV = 0.5 * (positionCS.xy / positionCS.w) + float2(0.5, 0.5);
 	if (any(screenUV < float2(0, 0)) || any(screenUV >= float2(1, 1)))
 	{
-		return float3(FLT_MAX, FLT_MAX, FLT_MAX);
+		return false;
 	}
 	float2 resolution = getScreenResolution();
 	float sceneDepth = prevSceneDepthTexture[int2(screenUV * resolution)].r;
 
-	float z = sceneDepth * 2.0 - 1.0; // Use this if not Reverse-Z
-	//float z = sceneDepth; // clipZ is [0,1] in Reverse-Z
+	float z = getNdcZ(sceneDepth);
 	positionCS = float4(screenUV * 2.0 - 1.0, z, 1.0); // [-1,1]
 	float4 positionVS = mul(positionCS, pathTracingUniform.prevProjInvMatrix);
 	positionVS /= positionVS.w; // Perspective division
 	float4 positionWS = mul(positionVS, pathTracingUniform.prevViewInvMatrix);
-	return positionWS.xyz;
+	
+	prevPositionWS = positionWS.xyz;
+	prevLinearDepth = getLinearDepth(screenUV, sceneDepth);
+	return true;
 }
 
 float getLuminance(float3 color)
@@ -393,10 +412,23 @@ void MainRaygen()
 	generateCameraRay(targetTexel, cameraRayOrigin, cameraRayDir);
 
 	float sceneDepth = sceneDepthTexture.Load(int3(targetTexel, 0)).r;
+	float3 sceneNormal = sceneNormalTexture[targetTexel].xyz;
 	float3 positionWS = getWorldPositionFromSceneDepth(screenUV, sceneDepth);
-	float3 prevPositionWS = getPrevWorldPosition(positionWS);
+	float linearDepth = getLinearDepth(screenUV, sceneDepth);
 
-	bool bTemporalReprojection = (pathTracingUniform.bInvalidateHistory == 0) && length(positionWS - prevPositionWS) <= 0.01; // 1.0 = 1 meter
+	float3 prevPositionWS;
+	float prevLinearDepth;
+	bool bPrevValid = getPrevWorldPosition(positionWS, prevPositionWS, prevLinearDepth);
+
+	float3 viewDir = normalize(sceneUniform.cameraPosition.xyz - positionWS);
+	float zAlignment = 1.0 - dot(viewDir, sceneNormal);
+	zAlignment = pow(zAlignment, 8);
+
+	float depthDiff = abs(prevLinearDepth - linearDepth) / linearDepth;
+	float depthTolerance = lerp(1e-2f, 1e-1f, zAlignment);
+
+	bool bClose = bPrevValid && depthDiff < depthTolerance; // length(positionWS - prevPositionWS) <= 0.01; // 1.0 = 1 meter
+	bool bTemporalReprojection = (pathTracingUniform.bInvalidateHistory == 0) && bClose;
 
 #if TRACE_MODE == TRACE_AMBIENT_OCCLUSION
 	float ambientOcclusion = traceAmbientOcclusion(targetTexel, cameraRayOrigin, cameraRayDir);
@@ -456,6 +488,11 @@ void MainRaygen()
 
 	// Update prevColorTexture also to simplify blur pass setup.
 	prevColorTexture[targetTexel] = currentColorTexture[targetTexel];
+
+	if (pathTracingUniform.bLimitHistory != 0)
+	{
+		historyCount = min(historyCount, MAX_REALTIME_HISTORY);
+	}
 
 	prevSceneDepthTexture[targetTexel] = sceneDepth;
 	currentMoment[targetTexel] = float4(moments.x, moments.y, variance, historyCount);

--- a/shaders/path_tracing.hlsl
+++ b/shaders/path_tracing.hlsl
@@ -41,7 +41,7 @@ struct PathTracingUniform
 	float4x4 prevViewProjMatrix;
 	uint renderTargetWidth;
 	uint renderTargetHeight;
-	uint bInvalidateHistory;
+	uint bInvalidateHistory; // If nonzero, force invalidate the whole history.
 	uint _pad0;
 };
 
@@ -396,8 +396,7 @@ void MainRaygen()
 	float3 positionWS = getWorldPositionFromSceneDepth(screenUV, sceneDepth);
 	float3 prevPositionWS = getPrevWorldPosition(positionWS);
 
-	//bool bTemporalReprojection = (pathTracingUniform.bInvalidateHistory == 0);
-	bool bTemporalReprojection = length(positionWS - prevPositionWS) <= 0.01; // 1.0 = 1 meter
+	bool bTemporalReprojection = (pathTracingUniform.bInvalidateHistory == 0) && length(positionWS - prevPositionWS) <= 0.01; // 1.0 = 1 meter
 
 #if TRACE_MODE == TRACE_AMBIENT_OCCLUSION
 	float ambientOcclusion = traceAmbientOcclusion(targetTexel, cameraRayOrigin, cameraRayDir);


### PR DESCRIPTION
Not so good implementation
Just a stepping stone for SVGF

![path_tracing_mode](https://github.com/user-attachments/assets/dfa9cff6-422a-4db9-b2b2-81e2277ab88c)

Offline is same as before; reset history on camera move
Realtime uses temporal reprojection + edge-avoiding atrous filter

![realtime_pt](https://github.com/user-attachments/assets/2a3c3d04-d147-4fe2-bb2b-cd65e456282b)

History count = 64 for realtime mode
Atrous is only good for denoising indirect diffuse, so the image is super noisy due to specular highlights

Implement SVGF someday