### PR TITLE
Separate temporal pass from ray pass in path tracing

### DIFF
--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -49,23 +49,30 @@ public:
 	void renderPathTracing(RenderCommandList* commandList, uint32 swapchainIndex, const PathTracingInput& passInput);
 
 private:
+	void initializeRaytracingPipeline();
+	void initializeTemporalPipeline();
+
 	void resizeTextures(RenderCommandList* commandList, uint32 newWidth, uint32 newHeight);
 	void resizeHitGroupShaderTable(uint32 swapchainIndex, const SceneProxy* scene);
 
 private:
+	// Ray pass
 	UniquePtr<RaytracingPipelineStateObject> RTPSO;
-	UniquePtr<RaytracingShaderTable> raygenShaderTable;
-	UniquePtr<RaytracingShaderTable> missShaderTable;
+	UniquePtr<RaytracingShaderTable>         raygenShaderTable;
+	UniquePtr<RaytracingShaderTable>         missShaderTable;
 	BufferedUniquePtr<RaytracingShaderTable> hitGroupShaderTable;
-	std::vector<uint32> totalHitGroupShaderRecord;
+	std::vector<uint32>                      totalHitGroupShaderRecord;
+	VolatileDescriptorHelper                 rayPassDescriptor;
 
-	uint32 historyWidth = 0;
-	uint32 historyHeight = 0;
-	UniquePtr<Texture> momentHistory[2];
-	UniquePtr<UnorderedAccessView> momentHistoryUAV[2];
-	UniquePtr<Texture> colorHistory[2];
-	UniquePtr<UnorderedAccessView> colorHistoryUAV[2];
-	UniquePtr<ShaderResourceView> colorHistorySRV[2];
+	// Temporal pass
+	UniquePtr<ComputePipelineState>          temporalPipeline;
+	VolatileDescriptorHelper                 temporalPassDescriptor;
 
-	VolatileDescriptorHelper rayPassDescriptor;
+	uint32                                   historyWidth = 0;
+	uint32                                   historyHeight = 0;
+	UniquePtr<Texture>                       momentHistory[2];
+	UniquePtr<UnorderedAccessView>           momentHistoryUAV[2];
+	UniquePtr<Texture>                       colorHistory[2];
+	UniquePtr<UnorderedAccessView>           colorHistoryUAV[2];
+	UniquePtr<ShaderResourceView>            colorHistorySRV[2];
 };

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -34,6 +34,7 @@ struct PathTracingInput
 	UnorderedAccessView*       sceneColorUAV;
 	ShaderResourceView*        sceneDepthSRV;
 	ShaderResourceView*        prevSceneDepthSRV;
+	ShaderResourceView*        velocityMapSRV;
 	ShaderResourceView*        gbuffer0SRV;
 	ShaderResourceView*        gbuffer1SRV;
 	ShaderResourceView*        skyboxSRV;
@@ -70,6 +71,9 @@ private:
 
 	uint32                                   historyWidth = 0;
 	uint32                                   historyHeight = 0;
+	UniquePtr<Texture>                       raytracingTexture;
+	UniquePtr<ShaderResourceView>            raytracingSRV;
+	UniquePtr<UnorderedAccessView>           raytracingUAV;
 	UniquePtr<Texture>                       momentHistory[2];
 	UniquePtr<UnorderedAccessView>           momentHistoryUAV[2];
 	UniquePtr<Texture>                       colorHistory[2];

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -75,8 +75,6 @@ private:
 	UniquePtr<Texture>                       raytracingTexture;
 	UniquePtr<ShaderResourceView>            raytracingSRV;
 	UniquePtr<UnorderedAccessView>           raytracingUAV;
+	TextureSequence                          colorHistory;
 	TextureSequence                          momentHistory;
-	UniquePtr<Texture>                       colorHistory[2];
-	UniquePtr<UnorderedAccessView>           colorHistoryUAV[2];
-	UniquePtr<ShaderResourceView>            colorHistorySRV[2];
 };

--- a/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
+++ b/projects/Cyseal/src/render/pathtracing/path_tracing_pass.h
@@ -8,6 +8,7 @@
 #include "render/scene_render_pass.h"
 #include "render/renderer_options.h"
 #include "render/util/volatile_descriptor.h"
+#include "render/util/texture_sequence.h"
 
 class SceneProxy;
 class Camera;
@@ -74,8 +75,7 @@ private:
 	UniquePtr<Texture>                       raytracingTexture;
 	UniquePtr<ShaderResourceView>            raytracingSRV;
 	UniquePtr<UnorderedAccessView>           raytracingUAV;
-	UniquePtr<Texture>                       momentHistory[2];
-	UniquePtr<UnorderedAccessView>           momentHistoryUAV[2];
+	TextureSequence                          momentHistory;
 	UniquePtr<Texture>                       colorHistory[2];
 	UniquePtr<UnorderedAccessView>           colorHistoryUAV[2];
 	UniquePtr<ShaderResourceView>            colorHistorySRV[2];

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -427,6 +427,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.sceneColorUAV         = pathTracingUAV.get(),
 				.sceneDepthSRV         = sceneDepthSRV.get(),
 				.prevSceneDepthSRV     = prevSceneDepthSRV.get(),
+				.velocityMapSRV        = velocityMapSRV.get(),
 				.gbuffer0SRV           = gbufferSRVs[0].get(),
 				.gbuffer1SRV           = gbufferSRVs[1].get(),
 				.skyboxSRV             = skyboxSRV.get(),

--- a/projects/Shaders/Shaders.vcxproj
+++ b/projects/Shaders/Shaders.vcxproj
@@ -93,6 +93,7 @@
     <FxCompile Include="..\..\shaders\material.hlsl" />
     <FxCompile Include="..\..\shaders\path_tracing.hlsl" />
     <FxCompile Include="..\..\shaders\indirect_specular_reflection.hlsl" />
+    <FxCompile Include="..\..\shaders\path_tracing_temporal.hlsl" />
     <FxCompile Include="..\..\shaders\raytracing_common.hlsl" />
     <FxCompile Include="..\..\shaders\ray_traced_shadows.hlsl" />
     <FxCompile Include="..\..\shaders\sky_pass.hlsl" />

--- a/projects/Shaders/Shaders.vcxproj.filters
+++ b/projects/Shaders/Shaders.vcxproj.filters
@@ -18,5 +18,6 @@
     <FxCompile Include="..\..\shaders\raytracing_common.hlsl" />
     <FxCompile Include="..\..\shaders\indirect_diffuse_raytracing.hlsl" />
     <FxCompile Include="..\..\shaders\indirect_diffuse_temporal.hlsl" />
+    <FxCompile Include="..\..\shaders\path_tracing_temporal.hlsl" />
   </ItemGroup>
 </Project>

--- a/shaders/path_tracing_temporal.hlsl
+++ b/shaders/path_tracing_temporal.hlsl
@@ -21,10 +21,12 @@ ConstantBuffer<SceneUniform> sceneUniform;
 ConstantBuffer<PassUniform>  passUniform;
 Texture2D                    sceneDepthTexture;
 Texture2D                    raytracingTexture;
+Texture2D                    velocityMapTexture;
 Texture2D                    prevSceneDepthTexture;
 Texture2D                    prevColorTexture;
-Texture2D                    velocityMapTexture;
+Texture2D                    prevMomentTexture;
 RWTexture2D<float4>          currentColorTexture;
+RWTexture2D<float4>          currentMomentTexture;
 
 SamplerState linearSampler : register(s0, space0);
 SamplerState pointSampler  : register(s1, space0);
@@ -39,6 +41,7 @@ struct PrevFrameInfo
 	float  linearDepth;
 	float3 color;
 	float  historyCount;
+	float2 moments;
 };
 
 float2 getScreenUV(uint2 texel)
@@ -53,7 +56,7 @@ float getLuminance(float3 color)
 
 PrevFrameInfo getReprojectedInfo(float2 currentScreenUV)
 {
-	float2 velocity = velocityMapTexture.SampleLevel(pointSampler, currentScreenUV, 0).rg;
+	float2 velocity = velocityMapTexture.SampleLevel(pointSampler, currentScreenUV, 0).xy;
 	float2 screenUV = currentScreenUV - velocity;
 	float4 positionCS = textureUVToClipSpace(screenUV);
 	
@@ -64,14 +67,17 @@ PrevFrameInfo getReprojectedInfo(float2 currentScreenUV)
 		return info;
 	}
 
-	float sceneDepth = prevSceneDepthTexture.SampleLevel(pointSampler, screenUV, 0).r;
-	float4 colorAndHistory = prevColorTexture.SampleLevel(linearSampler, screenUV, 0);
+	float sceneDepth = prevSceneDepthTexture.SampleLevel(pointSampler, screenUV, 0).x;
+	float3 color = prevColorTexture.SampleLevel(linearSampler, screenUV, 0).xyz;
+	float4 moments = prevMomentTexture.SampleLevel(pointSampler, screenUV, 0);
 
 	info.bValid = true;
 	info.positionWS = clipSpaceToWorldSpace(positionCS, sceneUniform.prevViewProjInvMatrix);
 	info.linearDepth = getLinearDepth(screenUV, sceneDepth, sceneUniform.projInvMatrix); // Assume projInv is invariant
-	info.color = colorAndHistory.rgb;
-	info.historyCount = colorAndHistory.a; // #todo-pathtracing: history is bilinear sampled...
+	info.color = color;
+	info.historyCount = moments.z;
+	info.moments = moments.xy;
+	
 	return info;
 }
 
@@ -92,9 +98,12 @@ void mainCS(uint3 tid : SV_DispatchThreadID)
 
 	float3 Wo = 0;
 	float historyCount = 0;
+	float2 moments = 0;
 	if (sceneDepth != DEVICE_Z_FAR)
 	{
 		Wo = raytracingTexture.Load(int3(texel, 0)).xyz;
+		moments.x = getLuminance(Wo);
+		moments.y = moments.x * moments.x;
 		
 		// Temporal reprojection
 		PrevFrameInfo prevFrame = getReprojectedInfo(screenUV);
@@ -106,29 +115,26 @@ void mainCS(uint3 tid : SV_DispatchThreadID)
 		}
 		
 		float3 prevWo = 0;
+		float2 prevMoments = 0;
 		if (bTemporalReprojection)
 		{
 			historyCount = prevFrame.historyCount;
 			prevWo = prevFrame.color;
+			prevMoments = prevFrame.moments;
 		}
 		
 		Wo = lerp(prevWo, Wo, 1.0 / (1.0 + historyCount));
+		moments = lerp(prevMoments, moments, 1.0 / (1.0 + historyCount));
+		
 		historyCount += 1;
 		if (passUniform.bLimitHistory != 0)
 		{
 			historyCount = min(historyCount, MAX_HISTORY);
 		}
 	}
-	
-	// #todo-pathtracing: Should store history in moment texture
-	currentColorTexture[texel] = float4(Wo, historyCount);
-	
-	/*
-	float2 moments;
-	moments.x = getLuminance(Li);
-	moments.y = moments.x * moments.x;
-	moments = lerp(prevMoments, moments, 1.0 / (1.0 + historyCount));
 
-	variance = max(0.0, moments.y - moments.x * moments.x);
-	*/
+	//variance = max(0.0, moments.y - moments.x * moments.x);
+	
+	currentColorTexture[texel] = float4(Wo, 1);
+	currentMomentTexture[texel] = float4(moments, historyCount, 1);
 }

--- a/shaders/path_tracing_temporal.hlsl
+++ b/shaders/path_tracing_temporal.hlsl
@@ -1,0 +1,111 @@
+#include "common.hlsl"
+
+// ---------------------------------------------------------
+
+#define MAX_HISTORY 64
+
+struct PassUniform
+{
+	uint2  screenSize;
+	float2 invScreenSize;
+};
+
+// ---------------------------------------------------------
+// Shader parameters
+
+ConstantBuffer<SceneUniform> sceneUniform;
+ConstantBuffer<PassUniform>  passUniform;
+Texture2D                    sceneDepthTexture;
+Texture2D                    raytracingTexture;
+Texture2D                    prevSceneDepthTexture;
+Texture2D                    prevColorTexture;
+Texture2D                    velocityMapTexture;
+RWTexture2D<float4>          currentColorTexture;
+
+SamplerState linearSampler : register(s0, space0);
+SamplerState pointSampler  : register(s1, space0);
+
+// ---------------------------------------------------------
+// Shader
+
+struct PrevFrameInfo
+{
+	bool   bValid;
+	float3 positionWS;
+	float  linearDepth;
+	float3 color;
+	float  historyCount;
+};
+
+float2 getScreenUV(uint2 texel)
+{
+	return (float2(texel) + float2(0.5, 0.5)) * passUniform.invScreenSize;
+}
+
+PrevFrameInfo getReprojectedInfo(float2 currentScreenUV)
+{
+	float2 velocity = velocityMapTexture.SampleLevel(pointSampler, currentScreenUV, 0).rg;
+	float2 screenUV = currentScreenUV - velocity;
+	float4 positionCS = textureUVToClipSpace(screenUV);
+	
+	PrevFrameInfo info;
+	if (uvOutOfBounds(screenUV))
+	{
+		info.bValid = false;
+		return info;
+	}
+
+	float sceneDepth = prevSceneDepthTexture.SampleLevel(pointSampler, screenUV, 0).r;
+	float4 colorAndHistory = prevColorTexture.SampleLevel(linearSampler, screenUV, 0);
+
+	info.bValid = true;
+	info.positionWS = clipSpaceToWorldSpace(positionCS, sceneUniform.prevViewProjInvMatrix);
+	info.linearDepth = getLinearDepth(screenUV, sceneDepth, sceneUniform.projInvMatrix); // Assume projInv is invariant
+	info.color = colorAndHistory.rgb;
+	info.historyCount = colorAndHistory.a; // #todo-pathtracing: history is bilinear sampled...
+	return info;
+}
+
+[numthreads(8, 8, 1)]
+void mainCS(uint3 tid : SV_DispatchThreadID)
+{
+	if (any(tid.xy >= passUniform.screenSize))
+	{
+		return;
+	}
+	
+	uint2 texel = tid.xy;
+	float2 screenUV = getScreenUV(texel);
+
+	float sceneDepth = sceneDepthTexture.Load(int3(texel, 0)).r;
+	float3 positionWS = getWorldPositionFromSceneDepth(screenUV, sceneDepth, sceneUniform.viewProjInvMatrix);
+	float linearDepth = getLinearDepth(screenUV, sceneDepth, sceneUniform.projInvMatrix);
+
+	float3 Wo = 0;
+	float historyCount = 0;
+	if (sceneDepth != DEVICE_Z_FAR)
+	{
+		Wo = raytracingTexture.Load(int3(texel, 0)).xyz;
+		
+		// Temporal reprojection
+		PrevFrameInfo prevFrame = getReprojectedInfo(screenUV);
+		bool bTemporalReprojection = false;
+		{
+			float depthDiff = abs(prevFrame.linearDepth - linearDepth) / linearDepth;
+			bTemporalReprojection = prevFrame.bValid && depthDiff <= 0.03;
+		}
+		
+		float3 prevWo = 0;
+		if (bTemporalReprojection)
+		{
+			historyCount = prevFrame.historyCount;
+			prevWo = prevFrame.color;
+		}
+		
+		Wo = lerp(prevWo, Wo, 1.0 / (1.0 + historyCount));
+		historyCount = min(historyCount + 1, MAX_HISTORY);
+	}
+	
+	// #todo-pathtracing: Should store history in moment texture
+	currentColorTexture[texel] = float4(Wo, historyCount);
+}


### PR DESCRIPTION
1. Previously a raytracing pipeline performed both raytracing and temporal reprojection. Now it performs only raytracing and a subsequent compute pipeline performs temporal reprojection.
2. Previously color history textures stored both color and history count. Now it only stores color. Moments and history count are stored in moment textures. (moments are not used yet)
3. Use motion vector texture instead of camera math for temporal reprojection.
