### PR TITLE
Feature/81 Unit test for indirect specular pass

### DIFF
--- a/projects/Cyseal/src/render/raytracing/indirect_specular_pass.cpp
+++ b/projects/Cyseal/src/render/raytracing/indirect_specular_pass.cpp
@@ -179,6 +179,8 @@ void IndirecSpecularPass::initialize(RenderDevice* inRenderDevice)
 		return;
 	}
 
+	rng = RNG<float>(0.0f, 1.0f);
+
 	initializeClassifierPipeline();
 	initializeRaytracingPipeline();
 	initializeTemporalPipeline();
@@ -206,6 +208,11 @@ void IndirecSpecularPass::renderIndirectSpecular(RenderCommandList* commandList,
 	{
 		// #todo-zero-size: Release resources if any.
 		return;
+	}
+
+	if (passInput.randomSeed > 0)
+	{
+		rng.resetSeed(passInput.randomSeed);
 	}
 
 	prepareRaytracingResources(commandList, swapchainIndex, passInput);
@@ -854,8 +861,8 @@ void IndirecSpecularPass::raytracingPhase(RenderCommandList* commandList, uint32
 
 		for (uint32 i = 0; i < RANDOM_SEQUENCE_LENGTH; ++i)
 		{
-			uboData->randFloats0[i] = Cymath::randFloat();
-			uboData->randFloats1[i] = Cymath::randFloat();
+			uboData->randFloats0[i] = rng.get();
+			uboData->randFloats1[i] = rng.get();
 		}
 		uboData->renderTargetWidth = sceneWidth;
 		uboData->renderTargetHeight = sceneHeight;

--- a/projects/Cyseal/src/render/raytracing/indirect_specular_pass.h
+++ b/projects/Cyseal/src/render/raytracing/indirect_specular_pass.h
@@ -2,6 +2,7 @@
 
 #include "core/int_types.h"
 #include "core/matrix.h"
+#include "core/cymath.h"
 #include "core/smart_pointer.h"
 #include "rhi/rhi_forward.h"
 #include "rhi/pipeline_state.h"
@@ -20,6 +21,7 @@ struct IndirectSpecularInput
 {
 	const SceneProxy*      scene;
 	EIndirectSpecularMode  mode;
+	uint32                 randomSeed;
 
 	uint32                 unscaledRenderWidth;
 	uint32                 unscaledRenderHeight;
@@ -95,6 +97,8 @@ private:
 
 private:
 	RenderDevice*                            device = nullptr;
+
+	RNG<float>                               rng;
 
 	// Tile classification pass
 	UniquePtr<ComputePipelineState>          classifierPipeline;

--- a/projects/Cyseal/src/render/renderer_options.h
+++ b/projects/Cyseal/src/render/renderer_options.h
@@ -210,6 +210,7 @@ struct RendererOptions
 	EIndirectDiffuseMode      indirectDiffuse = EIndirectDiffuseMode::Disabled;
 	uint32                    indirectDiffuseRandomSeed = 0;
 	EIndirectSpecularMode     indirectSpecular = EIndirectSpecularMode::ForceMirror;
+	uint32                    indirectSpecularRandomSeed = 0;
 
 	// Path tracing
 	EPathTracingMode          pathTracing = EPathTracingMode::Disabled;

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -719,6 +719,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		IndirectSpecularInput passInput{
 			.scene                   = scene,
 			.mode                    = renderOptions.indirectSpecular,
+			.randomSeed              = renderOptions.indirectSpecularRandomSeed,
 			.unscaledRenderWidth     = unscaledRenderWidth,
 			.unscaledRenderHeight    = unscaledRenderHeight,
 			.sceneWidth              = sceneWidth,

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -734,7 +734,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.gbuffer0Texture         = currentGBufferTexture0,
 			.gbuffer1Texture         = currentGBufferTexture1,
 			.gbuffer0SRV             = currentGBufferSRV0,
-			.gbuffer1SRV             = currentGBufferSRV0,
+			.gbuffer1SRV             = currentGBufferSRV1,
 			.normalTexture           = historyResources.currNormal,
 			.normalSRV               = historyResources.currNormalSRV,
 			.roughnessTexture        = historyResources.currRoughness,

--- a/projects/UnitTest/UnitTest.vcxproj
+++ b/projects/UnitTest/UnitTest.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="src\render\TestGpuDriven.cpp" />
     <ClCompile Include="src\render\TestImageComparison.cpp" />
     <ClCompile Include="src\render\TestIndirectDiffuse.cpp" />
+    <ClCompile Include="src\render\TestIndirectSpecular.cpp" />
     <ClCompile Include="src\render\TestRayTracedShadows.cpp" />
     <ClCompile Include="src\render\TestSkybox.cpp" />
     <ClCompile Include="src\render\test_render_utils.cpp" />

--- a/projects/UnitTest/UnitTest.vcxproj.filters
+++ b/projects/UnitTest/UnitTest.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="src\render\TestIndirectDiffuse.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\render\TestIndirectSpecular.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/projects/UnitTest/src/render/TestIndirectSpecular.cpp
+++ b/projects/UnitTest/src/render/TestIndirectSpecular.cpp
@@ -272,6 +272,7 @@ private:
 
 			auto M_ground = makeShared<MaterialAsset>();
 			M_ground->albedoTexture = baseTextures[0];
+			M_ground->albedoMultiplier = vec3(0.2f, 0.1f, 0.1f);
 			M_ground->roughness = 0.05f;
 
 			MesoGeometryAssets::addStaticMeshSections(staticMesh, 0, geomAssets, M_ground);

--- a/projects/UnitTest/src/render/TestIndirectSpecular.cpp
+++ b/projects/UnitTest/src/render/TestIndirectSpecular.cpp
@@ -34,9 +34,8 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 #define CAMERA_Z_NEAR        0.01f
 #define CAMERA_Z_FAR         10000.0f
 
-// #wip: Reduce to 256x256 after bugfix.
-#define WINDOW_WIDTH         1024
-#define WINDOW_HEIGHT        1024
+#define WINDOW_WIDTH         256
+#define WINDOW_HEIGHT        256
 #define ASPECT_RATIO         ((float)WINDOW_WIDTH / (float)WINDOW_HEIGHT)
 
 const int32 captureFrames[] = { 1, 4, 16, 32, 64 };
@@ -105,6 +104,7 @@ protected:
 
 		createScene();
 
+		frameCounter = 0;
 		numCaptured = 0;
 		actualImage->init(NUM_CAPTURE_FRAMES, WINDOW_WIDTH, WINDOW_HEIGHT);
 

--- a/projects/UnitTest/src/render/TestIndirectSpecular.cpp
+++ b/projects/UnitTest/src/render/TestIndirectSpecular.cpp
@@ -1,0 +1,464 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+#include "test_render_utils.h"
+#include "../rhi/test_rhi_utils.h"
+
+#include "core/engine.h"
+#include "core/smart_pointer.h"
+#include "core/console_application.h"
+#include "geometry/meso_geometry.h"
+#include "geometry/primitive.h"
+#include "geometry/procedural.h"
+#include "world/scene.h"
+#include "world/camera.h"
+#include "world/material_asset.h"
+#include "loader/image_loader.h"
+#include "render/static_mesh.h"
+#include "rhi/render_command.h"
+#include "rhi/texture_manager.h"
+#include "rhi/dx12/d3d_device.h"
+#include "rhi/vulkan/vk_device.h"
+#include "util/string_conversion.h"
+
+#include <array>
+
+#define SUN_DIRECTION        normalize(vec3(1.0f, -5.0f, 1.0f))
+#define SUN_ILLUMINANCE      (10.0f * vec3(1.0f, 1.0f, 1.0f))
+
+#define CAMERA_POSITION      vec3(0.0f, 0.0f, 50.0f)
+#define CAMERA_LOOKAT        vec3(0.0f, 0.0f, 0.0f)
+#define CAMERA_UP            vec3(0.0f, 1.0f, 0.0f)
+#define CAMERA_FOV_Y         70.0f
+#define CAMERA_Z_NEAR        0.01f
+#define CAMERA_Z_FAR         10000.0f
+
+// #wip: Reduce to 256x256 after bugfix.
+#define WINDOW_WIDTH         1024
+#define WINDOW_HEIGHT        1024
+#define ASPECT_RATIO         ((float)WINDOW_WIDTH / (float)WINDOW_HEIGHT)
+
+const int32 captureFrames[] = { 1, 4, 16, 32, 64 };
+#define NUM_CAPTURE_FRAMES _countof(captureFrames)
+
+struct ActualImage_IndirectSpecular
+{
+	void init(size_t imageCount, uint32 inWidth, uint32 inHeight)
+	{
+		images.resize(imageCount);
+		actualTags.resize(imageCount);
+		refTags.resize(imageCount);
+		width = inWidth;
+		height = inHeight;
+	}
+
+	std::vector<std::vector<uint8>> images;
+	std::vector<std::wstring> actualTags;
+	std::vector<std::wstring> refTags;
+	uint32 width;
+	uint32 height;
+};
+
+static const std::wstring skyboxFilepaths[] = {
+	L"skybox_Footballfield/posx.jpg", L"skybox_Footballfield/negx.jpg",
+	L"skybox_Footballfield/posy.jpg", L"skybox_Footballfield/negy.jpg",
+	L"skybox_Footballfield/posz.jpg", L"skybox_Footballfield/negz.jpg",
+};
+
+class IndirectSpecularApplication : public ConsoleApplication
+{
+public:
+	IndirectSpecularApplication(
+		CysealEngine* inEngine, ERenderDeviceRawAPI inGraphicsAPI, ActualImage_IndirectSpecular* inActualImage, bool bInSpecularOnly, bool bInForceMirror)
+		: cysealEngine(inEngine)
+		, graphicsAPI(inGraphicsAPI)
+		, actualImage(inActualImage)
+		, bSpecularOnly(bInSpecularOnly)
+		, bForceMirror(bInForceMirror)
+	{
+	}
+
+protected:
+	virtual void onExecute() override
+	{
+		onInitialize();
+		while (onTick()) {}
+		onTerminate();
+	}
+
+	bool onInitialize()
+	{
+		CysealEngineCreateParams engineInit{
+			.renderDevice = RenderDeviceCreateParams{
+				.swapChainParams  = SwapChainCreateParams::noSwapChain(),
+				.rawAPI           = graphicsAPI,
+			},
+			.rendererType = ERendererType::Standard,
+		};
+
+		cysealEngine->startup(engineInit);
+		cysealEngine->setRenderResolution(WINDOW_WIDTH, WINDOW_HEIGHT);
+
+		camera.lookAt(CAMERA_POSITION, CAMERA_LOOKAT, CAMERA_UP);
+		camera.perspective(CAMERA_FOV_Y, ASPECT_RATIO, CAMERA_Z_NEAR, CAMERA_Z_FAR);
+
+		createScene();
+
+		numCaptured = 0;
+		actualImage->init(NUM_CAPTURE_FRAMES, WINDOW_WIDTH, WINDOW_HEIGHT);
+
+		TextureCreateParams cameraColorParams = TextureCreateParams::texture2D(
+			EPixelFormat::R8G8B8A8_UNORM,
+			ETextureAccessFlags::RTV | ETextureAccessFlags::CPU_READBACK,
+			actualImage->width, actualImage->height);
+		cameraColor = gRenderDevice->createTexture(cameraColorParams);
+
+		return true;
+	}
+
+	void onTerminate()
+	{
+		delete cameraColor;
+		for (StaticMesh* sm : staticMeshes)
+		{
+			delete sm;
+		}
+		scene.skyboxTexture = nullptr;
+		cysealEngine->shutdown();
+	}
+
+	bool onTick()
+	{
+		bool bNeedReadback = frameCounter == captureFrames[numCaptured];
+
+		SceneProxy* sceneProxy = scene.createProxy();
+		RendererOptions rendererOptions{};
+		rendererOptions.finalRenderTarget = cameraColor;
+		rendererOptions.rayTracedShadows = ERayTracedShadowsMode::Disabled;
+		rendererOptions.indirectDiffuse = EIndirectDiffuseMode::Disabled;
+		rendererOptions.indirectSpecular = bForceMirror ? EIndirectSpecularMode::ForceMirror : EIndirectSpecularMode::BRDF;
+		if (frameCounter == 0) rendererOptions.indirectSpecularRandomSeed = 5982;
+		rendererOptions.pathTracing = EPathTracingMode::Disabled;
+		if (bNeedReadback)
+		{
+			rendererOptions.bufferVisualization = bSpecularOnly ? EBufferVisualizationMode::IndirectSpecular : EBufferVisualizationMode::None;
+		}
+
+		cysealEngine->beginImguiNewFrame();
+		/* It won't intervene the result as there's no GUI if I invoke nothing in ImGui. */
+		cysealEngine->renderImgui();
+
+		cysealEngine->renderScene(sceneProxy, &camera, rendererOptions);
+
+		delete sceneProxy;
+
+		if (bNeedReadback)
+		{
+			RenderCommandList* commandList = beginRendering();
+			auto handle = cameraColor->requestReadback(commandList, Texture::ReadbackRegion::mip0(cameraColor));
+			finishRendering(commandList);
+			Assert::IsTrue(handle->bAvailable);
+
+			const int32 configIndex = numCaptured;
+
+			uint8* readbackData = reinterpret_cast<uint8*>(handle->readbackData);
+			
+			std::vector<uint8>& targetImage = actualImage->images[configIndex];
+			std::wstring& actualTag = actualImage->actualTags[configIndex];
+			std::wstring& refTag = actualImage->refTags[configIndex];
+			
+			targetImage.assign(readbackData, readbackData + handle->totalBytes);
+
+			const char* sApi = (graphicsAPI == ERenderDeviceRawAPI::DirectX12) ? "d3d" : "vk";
+			const char* sDebugVis = bSpecularOnly ? "indirectSpecularOnly" : "fullColor";
+			const char* sForceMirror = bForceMirror ? "forceMirror" : "brdf";
+
+			char msg[256]; std::wstring wMsg;
+			sprintf_s(msg, "TestIndirectSpecular/%s/%s_%s_%d.png", sApi, sDebugVis, sForceMirror, frameCounter);
+			str_to_wstr(msg, wMsg);
+			actualTag = wMsg;
+			sprintf_s(msg, "TestIndirectSpecular/%s_%s_%d.png", sDebugVis, sForceMirror, frameCounter);
+			str_to_wstr(msg, wMsg);
+			refTag = wMsg;
+
+			if (++numCaptured == NUM_CAPTURE_FRAMES) return false;
+		}
+
+		++frameCounter;
+		return true;
+	}
+
+private:
+	void createScene()
+	{
+		DirectionalLight sun;
+		sun.direction = SUN_DIRECTION;
+		sun.illuminance = SUN_ILLUMINANCE;
+
+		SharedPtr<TextureAsset> baseTextures[] = {
+			gTextureManager->getSystemTextureWhite2D(),
+			gTextureManager->getSystemTextureRed2D(),
+			gTextureManager->getSystemTextureGreen2D(),
+			gTextureManager->getSystemTextureBlue2D(),
+		};
+		std::vector<SharedPtr<MaterialAsset>> baseMaterials;
+		for (const auto& baseTex : baseTextures)
+		{
+			auto material = makeShared<MaterialAsset>();
+			material->albedoTexture = baseTex;
+			material->albedoMultiplier = vec3(0.2f);
+			material->roughness = 0.1f;
+			baseMaterials.push_back(material);
+		}
+
+		struct CreateParams
+		{
+			vec3 center;
+			float radius;
+			float height;
+			uint32 numLoop;
+			uint32 numMeshes;
+		};
+		CreateParams createParams{
+			.center = vec3(0.0f, -12.0f, 0.0f),
+			.radius = 24.0f,
+			.height = 40.0f,
+			.numLoop = 2,
+			.numMeshes = 32
+		};
+
+		for (uint32 meshIx = 0; meshIx < createParams.numMeshes; ++meshIx)
+		{
+			StaticMesh* staticMesh = new StaticMesh;
+
+			for (uint32 lod = 0; lod < 2; ++lod)
+			{
+				Geometry* geom = new Geometry;
+				if (meshIx % 2)
+				{
+					ProceduralGeometry::icosphere(*geom, lod == 0 ? 3 : 1);
+				}
+				else
+				{
+					ProceduralGeometry::cube(*geom, 1.0f, 1.0f, 1.0f);
+				}
+
+				auto material = baseMaterials[meshIx % baseMaterials.size()];
+				MesoGeometryAssets geomAssets = MesoGeometryAssets::createFrom(geom);
+				MesoGeometryAssets::addStaticMeshSections(staticMesh, lod, geomAssets, material);
+			}
+
+			float k = meshIx / (float)createParams.numMeshes;
+			float theta = (float)createParams.numLoop * (2.0f * Cymath::PI) * k;
+			vec3 deltaPos = createParams.radius * vec3(Cymath::cos(theta), 0.0f, Cymath::sin(theta));
+			deltaPos.y += createParams.height * k;
+			vec3 startPos = createParams.center + deltaPos;
+
+			staticMesh->setPosition(startPos);
+			staticMesh->setRotation(normalize(vec3(0.5f, 1.0f, 0.3f)), k * 360.0f);
+			staticMesh->setScale(3.0f);
+
+			staticMeshes.push_back(staticMesh);
+		}
+
+		// Ground
+		{
+			StaticMesh* staticMesh = new StaticMesh;
+
+			Geometry* geom = new Geometry;
+			ProceduralGeometry::plane(*geom, 1, 1, 1, 1, ProceduralGeometry::EPlaneNormal::Y);
+			MesoGeometryAssets geomAssets = MesoGeometryAssets::createFrom(geom);
+
+			auto M_ground = makeShared<MaterialAsset>();
+			M_ground->albedoTexture = baseTextures[0];
+			M_ground->roughness = 0.05f;
+
+			MesoGeometryAssets::addStaticMeshSections(staticMesh, 0, geomAssets, M_ground);
+
+			staticMesh->setPosition(vec3(0, -5.0f, 0));
+			staticMesh->setRotation(vec3(1, 0, 0), -5.0f);
+			staticMesh->setScale(100.0f);
+			staticMeshes.push_back(staticMesh);
+		}
+
+		scene.sun = std::move(sun);
+		scene.skyboxTexture = createSkybox();
+		for (StaticMesh* sm : staticMeshes) scene.addStaticMesh(sm);
+	}
+
+	SharedPtr<TextureAsset> createSkybox()
+	{
+		ImageLoader imageLoader;
+		std::array<ImageLoadData*, 6> skyboxBlobs = { nullptr, };
+		bool bValidSkyboxBlobs = true;
+		for (uint32 i = 0; i < 6; ++i)
+		{
+			skyboxBlobs[i] = imageLoader.load(skyboxFilepaths[i]);
+			bValidSkyboxBlobs = bValidSkyboxBlobs
+				&& (skyboxBlobs[i] != nullptr)
+				&& (skyboxBlobs[i]->width == skyboxBlobs[0]->width)
+				&& (skyboxBlobs[i]->height == skyboxBlobs[0]->height);
+		}
+		Assert::IsTrue(bValidSkyboxBlobs, L"Failed to load skybox images");
+
+		SharedPtr<TextureAsset> skyboxTexture = makeShared<TextureAsset>();
+		ENQUEUE_RENDER_COMMAND(CreateSkybox)(
+			[texWeak = WeakPtr<TextureAsset>(skyboxTexture), skyboxBlobs](RenderCommandList& commandList)
+			{
+				SharedPtr<TextureAsset> tex = texWeak.lock();
+				CHECK(tex != nullptr);
+
+				TextureCreateParams params = TextureCreateParams::textureCube(
+					EPixelFormat::R8G8B8A8_UNORM,
+					ETextureAccessFlags::SRV | ETextureAccessFlags::CPU_WRITE,
+					skyboxBlobs[0]->width, skyboxBlobs[0]->height, 1);
+
+				Texture* texture = gRenderDevice->createTexture(params);
+				for (uint32 i = 0; i < 6; ++i)
+				{
+					texture->uploadData(&commandList,
+						skyboxBlobs[i]->buffer,
+						skyboxBlobs[i]->getRowPitch(),
+						skyboxBlobs[i]->getSlicePitch(),
+						i);
+				}
+				texture->setDebugName(TEXT("Texture_skybox"));
+
+				tex->setGPUResource(SharedPtr<Texture>(texture));
+
+				for (ImageLoadData* imageBlob : skyboxBlobs)
+				{
+					commandList.enqueueDeferredDealloc(imageBlob);
+				}
+			}
+		);
+
+		return skyboxTexture;
+	}
+
+	RenderCommandList* beginRendering()
+	{
+		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
+
+		commandList->reset(commandAllocator);
+		return commandList;
+	}
+	void finishRendering(RenderCommandList* commandList)
+	{
+		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
+		RenderCommandQueue* commandQueue = gRenderDevice->getCommandQueue();
+		SwapChain* nullSwapChain = nullptr;
+
+		commandList->close();
+		commandAllocator->markValid();
+		commandQueue->executeCommandList(commandList, nullSwapChain);
+		gRenderDevice->flushCommandQueue();
+	}
+
+private:
+	CysealEngine* cysealEngine = nullptr;
+	ERenderDeviceRawAPI graphicsAPI;
+	bool bSpecularOnly;
+	bool bForceMirror;
+
+	Scene scene;
+	Camera camera;
+	std::vector<StaticMesh*> staticMeshes;
+	int32 frameCounter = 0;
+	int32 numCaptured = 0;
+
+	Texture* cameraColor = nullptr;
+	ActualImage_IndirectSpecular* actualImage = nullptr;
+};
+
+namespace UnitTest
+{
+	template<ERenderDeviceRawAPI graphicsAPI>
+	class TestIndirectSpecularBase
+	{
+	protected:
+		// bSpecularOnly: Capture only indirect specular lighting.
+		// bForceMirror: Force mirror reflection (override all roughness values with 0).
+		void RenderIndirectSpecular(bool bSpecularOnly, bool bForceMirror)
+		{
+			ActualImage_IndirectSpecular actualImage;
+
+			HWND nativeWindowHandle = NULL;
+
+			CysealEngine cysealEngine;
+
+			ConsoleApplication* app = new IndirectSpecularApplication(
+				&cysealEngine, graphicsAPI, &actualImage, bSpecularOnly, bForceMirror);
+
+			ApplicationCreateParams createParams;
+			createParams.nativeWindowHandle = nativeWindowHandle;
+			createParams.applicationName = L"TestIndirectSpecular";
+
+			// Enters the main loop.
+			EApplicationReturnCode ret = app->launch(createParams);
+			static_cast<void>(ret);
+
+			Assert::IsTrue(ret == EApplicationReturnCode::Ok);
+
+			int32 invalidImgCount = 0;
+			for (int32 i = 0; i < actualImage.images.size(); ++i)
+			{
+				std::vector<uint8>& image = actualImage.images[i];
+				const std::wstring& actualTag = actualImage.actualTags[i];
+				const std::wstring& refTag = actualImage.refTags[i];
+				uint32 numDiff = render_test::compareRefImageToRgba8ui(refTag.data(), image.data());
+				render_test::saveRgba8uiImage(actualTag.data(), image.data(), actualImage.width, actualImage.height);
+				
+				invalidImgCount += (0 != numDiff) ? 1 : 0;
+			}
+			Assert::AreEqual(0, invalidImgCount);
+		}
+	};
+
+	TEST_CLASS(TestIndirectSpecularD3D12), TestIndirectSpecularBase<ERenderDeviceRawAPI::DirectX12>
+	{
+	public:
+		TEST_METHOD(RenderIndirectSpecularBRDF)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(false, false);
+		}
+		TEST_METHOD(RenderIndirectSpecularForceMirror)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(false, true);
+		}
+		TEST_METHOD(RenderIndirectSpecularDebugVisBRDF)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(true, false);
+		}
+		TEST_METHOD(RenderIndirectSpecularDebugVisForceMirror)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(true, true);
+		}
+	};
+
+	// #todo-test: VK can't run SceneRenderer yet.
+#if 0
+	TEST_CLASS(TestIndirectSpecularVulkan), TestIndirectSpecularBase<ERenderDeviceRawAPI::Vulkan>
+	{
+	public:
+		TEST_METHOD(RenderIndirectSpecularBRDF)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(false, false);
+		}
+		TEST_METHOD(RenderIndirectSpecularForceMirror)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(false, true);
+		}
+		TEST_METHOD(RenderIndirectSpecularDebugVisBRDF)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(true, false);
+		}
+		TEST_METHOD(RenderIndirectSpecularDebugVisForceMirror)
+		{
+			TestIndirectSpecularBase::RenderIndirectSpecular(true, true);
+		}
+	};
+#endif
+}

--- a/shaders/indirect_specular_reflection.hlsl
+++ b/shaders/indirect_specular_reflection.hlsl
@@ -168,6 +168,11 @@ float2 getScreenUV(uint2 texel)
 float2 getRandoms(uint2 texel, uint bounce)
 {
 	uint first = texel.x + passUniform.renderTargetWidth * texel.y;
+	
+	// Correlation is too obvious when render resolution is multiple of RANDOM_SEQUENCE_WIDTH and/or RANDOM_SEQUENCE_HEIGHT.
+	// Try to randomize it.
+	first = first + (first & 0x3F) * (texel.x * 13 + texel.y + 19);
+	
 	uint seq0 = (first + bounce) % RANDOM_SEQUENCE_LENGTH;
 	uint seq1 = (first + bounce) % RANDOM_SEQUENCE_LENGTH;
 	float rand0 = passUniform.randFloats0[seq0 / 4][seq0 % 4];

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_1.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8e5404b473098fa2d867f2b5ee4b2d81de7e5f95199d6b43efee8b5211e088a
+size 81983

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_16.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:394d0da464e8696dc4bfd0654b37bba6a24963f9b520197fc7934ef16465d687
+size 128351

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_32.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:597317c3d53a7a0e0af688cabc9eb7ced610018695f914544341f90158deecfc
+size 128361

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_4.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddf8df1e16ca24ce25aae48b0fb3f65858b7ea412f48462a17a5da5cf1e39035
+size 129226

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_64.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_brdf_64.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec930dcc91d9ec9a6d00cefe0faac7b9249d6066137bf478d9f71fa0eed825e1
+size 127835

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_1.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8e5404b473098fa2d867f2b5ee4b2d81de7e5f95199d6b43efee8b5211e088a
+size 81983

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_16.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78eb143bd2c2f8160a66098f3f1e86266a57d0cfb047422697474ad167fd5a57
+size 115196

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_32.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78eb143bd2c2f8160a66098f3f1e86266a57d0cfb047422697474ad167fd5a57
+size 115196

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_4.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78eb143bd2c2f8160a66098f3f1e86266a57d0cfb047422697474ad167fd5a57
+size 115196

--- a/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_64.png
+++ b/tests/referenceImages/TestIndirectSpecular/fullColor_forceMirror_64.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78eb143bd2c2f8160a66098f3f1e86266a57d0cfb047422697474ad167fd5a57
+size 115196

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_1.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0381761598a8a2b38efc8a8736000bb22910ce0c92d9378efbbd747afa5cafd
+size 2822

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_16.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bcde0dcc5879cfbbab2ae6ad8723fd635a1b38ecc4995ef2fe39bd90c9f1586
+size 69254

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_32.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c074be704d0ce0aa40fa5cf2a7faa36dec6fc8b8f12c5ba71c873e4150df030
+size 69597

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_4.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4cd392a63cca0039384a265caee11538eb38ce6a962b0c5fc4e42cb49c2eee0
+size 70430

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_64.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_brdf_64.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f4a0cfc6f3b2de92959f8f48a3fae045a61c5f739070453edfe1ef5dc01d99
+size 68546

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_1.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0381761598a8a2b38efc8a8736000bb22910ce0c92d9378efbbd747afa5cafd
+size 2822

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_16.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59219ba0d38c8ce638385ef5d5cb0a8a1e812485917e22e17a4d51ef9e4fd25
+size 70430

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_32.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59219ba0d38c8ce638385ef5d5cb0a8a1e812485917e22e17a4d51ef9e4fd25
+size 70430

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_4.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59219ba0d38c8ce638385ef5d5cb0a8a1e812485917e22e17a4d51ef9e4fd25
+size 70430

--- a/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_64.png
+++ b/tests/referenceImages/TestIndirectSpecular/indirectSpecularOnly_forceMirror_64.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59219ba0d38c8ce638385ef5d5cb0a8a1e812485917e22e17a4d51ef9e4fd25
+size 70430


### PR DESCRIPTION
Test
- Add unit test TestIndirectSpecular.

Bugfix
- Fix a bug by stupid typo that binding gbuffe0 texture for gbuffer1 slot, and making indirect specular reflection totally broken.
- More randomize sampling directions because correlation is too obvious when render resolution is multiple of random sequence width/height.

Misc
- Allow random seed reset for indirect specular pass.

Gbuffer binding bug was resolved here, but it needs more bugfix and improvements, which will be done in https://github.com/codeonwort/Cyseal/issues/45.