### PR TITLE
Feature/97 Allow buffer dealloc from global buffer pool

### DIFF
--- a/projects/Cyseal/Cyseal.vcxproj
+++ b/projects/Cyseal/Cyseal.vcxproj
@@ -268,6 +268,7 @@
     <ClCompile Include="src\render\util\texture_sequence.cpp" />
     <ClCompile Include="src\render\util\volatile_descriptor.cpp" />
     <ClCompile Include="src\rhi\barrier_tracker.cpp" />
+    <ClCompile Include="src\rhi\buffer.cpp" />
     <ClCompile Include="src\rhi\denoiser_device.cpp" />
     <ClCompile Include="src\rhi\dx12\d3d_pipeline_state.cpp" />
     <ClCompile Include="src\rhi\global_descriptor_heaps.cpp" />

--- a/projects/Cyseal/Cyseal.vcxproj.filters
+++ b/projects/Cyseal/Cyseal.vcxproj.filters
@@ -677,6 +677,9 @@
     <ClCompile Include="src\render\util\clear_resource_pass.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\rhi\buffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/projects/Cyseal/src/render/static_mesh.cpp
+++ b/projects/Cyseal/src/render/static_mesh.cpp
@@ -79,6 +79,21 @@ static Texture* getAlbedoTexture(const SharedPtr<MaterialAsset>& material)
 	return nullptr;
 }
 
+StaticMesh::~StaticMesh()
+{
+	// Just wanna rely on auto destruction but something funky happens :(
+	// Manually unregister buffers from buffer pools before buffer destructors are called.
+	for (const auto& lod : LODs)
+	{
+		for (const auto& sec : lod.sections)
+		{
+			sec.positionBuffer->getGPUResource()->destroy();
+			sec.nonPositionBuffer->getGPUResource()->destroy();
+			sec.indexBuffer->getGPUResource()->destroy();
+		}
+	}
+}
+
 void StaticMesh::updateGPUSceneResidency(SceneProxy* sceneProxy, GPUSceneItemIndexAllocator* gpuSceneItemIndexAllocator)
 {
 	// NOTE: activeLOD should have been updated already.

--- a/projects/Cyseal/src/render/static_mesh.cpp
+++ b/projects/Cyseal/src/render/static_mesh.cpp
@@ -87,9 +87,9 @@ StaticMesh::~StaticMesh()
 	{
 		for (const auto& sec : lod.sections)
 		{
-			sec.positionBuffer->getGPUResource()->destroy();
-			sec.nonPositionBuffer->getGPUResource()->destroy();
-			sec.indexBuffer->getGPUResource()->destroy();
+			sec.positionBuffer->getGPUResource()->removeFromPool();
+			sec.nonPositionBuffer->getGPUResource()->removeFromPool();
+			sec.indexBuffer->getGPUResource()->removeFromPool();
 		}
 	}
 }

--- a/projects/Cyseal/src/render/static_mesh.h
+++ b/projects/Cyseal/src/render/static_mesh.h
@@ -45,6 +45,8 @@ struct StaticMeshProxy
 class StaticMesh
 {
 public:
+	~StaticMesh();
+
 	void updateGPUSceneResidency(SceneProxy* sceneProxy, GPUSceneItemIndexAllocator* gpuSceneItemIndexAllocator);
 	StaticMeshProxy* createStaticMeshProxy(StackAllocator* allocator) const;
 

--- a/projects/Cyseal/src/rhi/buffer.cpp
+++ b/projects/Cyseal/src/rhi/buffer.cpp
@@ -3,18 +3,28 @@
 
 VertexBuffer::~VertexBuffer()
 {
+	destroy();
+}
+
+void VertexBuffer::destroy()
+{
 	if (parentPool != nullptr)
 	{
-		parentPool->release(this);
+		CHECK(parentPool->release(this));
 		parentPool = nullptr;
 	}
 }
 
 IndexBuffer::~IndexBuffer()
 {
+	destroy();
+}
+
+void IndexBuffer::destroy()
+{
 	if (parentPool != nullptr)
 	{
-		parentPool->release(this);
+		CHECK(parentPool->release(this));
 		parentPool = nullptr;
 	}
 }

--- a/projects/Cyseal/src/rhi/buffer.cpp
+++ b/projects/Cyseal/src/rhi/buffer.cpp
@@ -1,0 +1,20 @@
+#include "buffer.h"
+#include "vertex_buffer_pool.h"
+
+VertexBuffer::~VertexBuffer()
+{
+	if (parentPool != nullptr)
+	{
+		parentPool->release(this);
+		parentPool = nullptr;
+	}
+}
+
+IndexBuffer::~IndexBuffer()
+{
+	if (parentPool != nullptr)
+	{
+		parentPool->release(this);
+		parentPool = nullptr;
+	}
+}

--- a/projects/Cyseal/src/rhi/buffer.cpp
+++ b/projects/Cyseal/src/rhi/buffer.cpp
@@ -3,28 +3,35 @@
 
 VertexBuffer::~VertexBuffer()
 {
-	destroy();
+	removeFromPool();
 }
 
-void VertexBuffer::destroy()
+bool VertexBuffer::removeFromPool()
 {
 	if (parentPool != nullptr)
 	{
 		CHECK(parentPool->release(this));
 		parentPool = nullptr;
+		bRemovedFromPool = true;
+		return true;
 	}
+	return false;
 }
 
 IndexBuffer::~IndexBuffer()
 {
-	destroy();
+	removeFromPool();
 }
 
-void IndexBuffer::destroy()
+bool IndexBuffer::removeFromPool()
 {
 	if (parentPool != nullptr)
 	{
 		CHECK(parentPool->release(this));
 		parentPool = nullptr;
+		bRemovedFromPool = true;
+		return true;
 	}
+	return false;
 }
+

--- a/projects/Cyseal/src/rhi/buffer.h
+++ b/projects/Cyseal/src/rhi/buffer.h
@@ -62,7 +62,7 @@ class VertexBuffer : public GPUResource
 public:
 	~VertexBuffer();
 
-	void destroy();
+	bool removeFromPool();
 
 	virtual void initialize(uint32 sizeInBytes, EBufferAccessFlags usageFlags) = 0;
 	
@@ -83,6 +83,7 @@ public:
 protected:
 	// Null if a committed resource.
 	VertexBufferPool* parentPool = nullptr;
+	bool bRemovedFromPool = false;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -102,7 +103,7 @@ class IndexBuffer : public GPUResource
 public:
 	~IndexBuffer();
 
-	void destroy();
+	bool removeFromPool();
 
 	virtual void initialize(uint32 sizeInBytes, EPixelFormat format, EBufferAccessFlags usageFlags) = 0;
 
@@ -126,6 +127,7 @@ public:
 protected:
 	// Null if a committed resource.
 	IndexBufferPool* parentPool = nullptr;
+	bool bRemovedFromPool = false;
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/projects/Cyseal/src/rhi/buffer.h
+++ b/projects/Cyseal/src/rhi/buffer.h
@@ -60,6 +60,8 @@ class VertexBuffer : public GPUResource
 {
 	friend class VertexBufferPool;
 public:
+	~VertexBuffer();
+
 	virtual void initialize(uint32 sizeInBytes, EBufferAccessFlags usageFlags) = 0;
 	
 	virtual void initializeWithinPool(VertexBufferPool* pool, uint64 offsetInPool, uint32 sizeInBytes) = 0;
@@ -96,6 +98,8 @@ class IndexBuffer : public GPUResource
 {
 	friend class IndexBufferPool;
 public:
+	~IndexBuffer();
+
 	virtual void initialize(uint32 sizeInBytes, EPixelFormat format, EBufferAccessFlags usageFlags) = 0;
 
 	virtual void initializeWithinPool(
@@ -110,6 +114,8 @@ public:
 
 	virtual uint64 getBufferOffsetInBytes() const = 0; // offsetInPool
 	virtual uint32 getBufferSizeInBytes() const = 0;
+
+	IndexBufferPool* internal_getParentPool() const { return parentPool; }
 
 	virtual uint64 internal_getGPUVirtualAddress() const = 0;
 

--- a/projects/Cyseal/src/rhi/buffer.h
+++ b/projects/Cyseal/src/rhi/buffer.h
@@ -62,6 +62,8 @@ class VertexBuffer : public GPUResource
 public:
 	~VertexBuffer();
 
+	void destroy();
+
 	virtual void initialize(uint32 sizeInBytes, EBufferAccessFlags usageFlags) = 0;
 	
 	virtual void initializeWithinPool(VertexBufferPool* pool, uint64 offsetInPool, uint32 sizeInBytes) = 0;
@@ -99,6 +101,8 @@ class IndexBuffer : public GPUResource
 	friend class IndexBufferPool;
 public:
 	~IndexBuffer();
+
+	void destroy();
 
 	virtual void initialize(uint32 sizeInBytes, EPixelFormat format, EBufferAccessFlags usageFlags) = 0;
 

--- a/projects/Cyseal/src/rhi/dx12/d3d_buffer.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_buffer.cpp
@@ -113,6 +113,7 @@ void D3DVertexBuffer::initializeWithinPool(VertexBufferPool* pool, uint64 offset
 
 void D3DVertexBuffer::updateData(RenderCommandList* commandList, void* data, uint32 strideInBytes)
 {
+	CHECK(!bRemovedFromPool);
 	auto cmdList = static_cast<D3DRenderCommandList*>(commandList)->getRaw();
 
 	updateDefaultBuffer(device, cmdList, defaultBuffer, uploadBuffer,
@@ -158,6 +159,7 @@ void D3DIndexBuffer::initializeWithinPool(IndexBufferPool* pool, uint64 offsetIn
 
 void D3DIndexBuffer::updateData(RenderCommandList* commandList, void* data, EPixelFormat format)
 {
+	CHECK(!bRemovedFromPool);
 	CHECK(indexFormat == format);
 
 	DXGI_FORMAT d3dFormat = DXGI_FORMAT_UNKNOWN;

--- a/projects/Cyseal/src/rhi/vertex_buffer_pool.cpp
+++ b/projects/Cyseal/src/rhi/vertex_buffer_pool.cpp
@@ -8,7 +8,60 @@
 VertexBufferPool* gVertexBufferPool = nullptr;
 IndexBufferPool* gIndexBufferPool = nullptr;
 
-//////////////////////////////////////////////////////////////////////////
+// --------------------------------------------------------
+// BufferPoolAllocator
+
+// Do [x0, x1) and [y0, y1) intersect?
+static bool rangeOverlaps(uint64 x0, uint64 x1, uint64 y0, uint64 y1)
+{
+	return x1 > y0 && y1 > x0;
+}
+
+BufferPoolItem BufferPoolAllocator::allocate(uint32 sizeInBytes)
+{
+	uint64 offset = 0;
+	auto it = items.begin();
+	for (; it != items.end(); ++it)
+	{
+		if (rangeOverlaps(offset, offset + sizeInBytes, it->offset, it->offset + it->size))
+		{
+			offset = it->offset + it->size;
+		}
+		else
+		{
+			break;
+		}
+	}
+	if (it != items.end())
+	{
+		BufferPoolItem item{ offset, sizeInBytes };
+		items.insert(it, item);
+		bytesAllocated += sizeInBytes;
+		return item;
+	}
+	if (offset + sizeInBytes <= bytesTotal)
+	{
+		BufferPoolItem item{ offset, sizeInBytes };
+		items.push_back(item);
+		bytesAllocated += sizeInBytes;
+		return item;
+	}
+	return BufferPoolItem{ 0, 0 };
+}
+
+
+bool BufferPoolAllocator::release(const BufferPoolItem& item)
+{
+	auto it = std::find(items.begin(), items.end(), item);
+	if (it != items.end())
+	{
+		items.erase(it);
+		return true;
+	}
+	return false;
+}
+
+// --------------------------------------------------------
 // VertexBufferPool
 
 void VertexBufferPool::initialize(uint64 totalBytes)
@@ -17,7 +70,6 @@ void VertexBufferPool::initialize(uint64 totalBytes)
 
 	const EBufferAccessFlags usageFlags = EBufferAccessFlags::COPY_DST | EBufferAccessFlags::SRV;
 
-	poolSize = totalBytes;
 	pool = gRenderDevice->createVertexBuffer((uint32)totalBytes, usageFlags, L"GlobalVertexBufferPool");
 	
 	// Create raw view (ByteAddressBuffer)
@@ -32,6 +84,8 @@ void VertexBufferPool::initialize(uint64 totalBytes)
 
 		srv = UniquePtr<ShaderResourceView>(gRenderDevice->createSRV(pool, srvDesc));
 	}
+
+	allocator.initialize(totalBytes);
 
 	const float size_mb = (float)totalBytes / (1024 * 1024);
 	CYLOG(LogEngine, Log, L"Vertex buffer pool: %.2f MiB", size_mb);
@@ -48,17 +102,22 @@ void VertexBufferPool::destroy()
 
 VertexBuffer* VertexBufferPool::suballocate(uint32 sizeInBytes)
 {
-	if (currentOffset + sizeInBytes >= poolSize)
+	BufferPoolItem item = allocator.allocate(sizeInBytes);
+	if (item.isValid() == false)
 	{
-		// Out of memory
 		CHECK_NO_ENTRY();
 		return nullptr;
 	}
 
-	VertexBuffer* buffer = gRenderDevice->createVertexBuffer(this, currentOffset, sizeInBytes);
-	currentOffset += sizeInBytes;
-
+	VertexBuffer* buffer = gRenderDevice->createVertexBuffer(this, item.offset, item.size);
 	return buffer;
+}
+
+bool VertexBufferPool::release(VertexBuffer* buffer)
+{
+	CHECK(buffer->internal_getParentPool() == this);
+	BufferPoolItem item{ buffer->getBufferOffsetInBytes(), buffer->getBufferSizeInBytes() };
+	return allocator.release(item);
 }
 
 ShaderResourceView* VertexBufferPool::getByteAddressBufferView() const
@@ -66,7 +125,7 @@ ShaderResourceView* VertexBufferPool::getByteAddressBufferView() const
 	return srv.get();
 }
 
-//////////////////////////////////////////////////////////////////////////
+// --------------------------------------------------------
 // IndexBufferPool
 
 void IndexBufferPool::initialize(uint64 totalBytes)
@@ -75,7 +134,6 @@ void IndexBufferPool::initialize(uint64 totalBytes)
 
 	const EBufferAccessFlags usageFlags = EBufferAccessFlags::COPY_DST | EBufferAccessFlags::SRV;
 
-	poolSize = totalBytes;
 	pool = gRenderDevice->createIndexBuffer(
 		(uint32)totalBytes,
 		EPixelFormat::R32_UINT,
@@ -95,6 +153,8 @@ void IndexBufferPool::initialize(uint64 totalBytes)
 		srv = UniquePtr<ShaderResourceView>(gRenderDevice->createSRV(pool, srvDesc));
 	}
 
+	allocator.initialize(totalBytes);
+
 	const float size_mb = (float)totalBytes / (1024 * 1024);
 	CYLOG(LogEngine, Log, L"Index buffer pool: %.2f MiB", size_mb);
 }
@@ -110,22 +170,22 @@ void IndexBufferPool::destroy()
 
 IndexBuffer* IndexBufferPool::suballocate(uint32 sizeInBytes, EPixelFormat format)
 {
-	if (currentOffset + sizeInBytes >= poolSize)
+	BufferPoolItem item = allocator.allocate(sizeInBytes);
+	if (item.isValid() == false)
 	{
-		// Out of memory
 		CHECK_NO_ENTRY();
 		return nullptr;
 	}
 
-	IndexBuffer* buffer = gRenderDevice->createIndexBuffer(
-		this,
-		currentOffset,
-		sizeInBytes,
-		format);
-	
-	currentOffset += sizeInBytes;
-
+	IndexBuffer* buffer = gRenderDevice->createIndexBuffer(this, item.offset, item.size, format);
 	return buffer;
+}
+
+bool IndexBufferPool::release(IndexBuffer* buffer)
+{
+	CHECK(buffer->internal_getParentPool() == this);
+	BufferPoolItem item{ buffer->getBufferOffsetInBytes(), buffer->getBufferSizeInBytes() };
+	return allocator.release(item);
 }
 
 ShaderResourceView* IndexBufferPool::getByteAddressBufferView() const

--- a/projects/Cyseal/src/rhi/vertex_buffer_pool.cpp
+++ b/projects/Cyseal/src/rhi/vertex_buffer_pool.cpp
@@ -17,6 +17,8 @@ static bool rangeOverlaps(uint64 x0, uint64 x1, uint64 y0, uint64 y1)
 	return x1 > y0 && y1 > x0;
 }
 
+// #todo-vram-pool: Implement better data structure.
+// I have other things to do so here's a super naive linked list approach written in 5 minutes :(
 BufferPoolItem BufferPoolAllocator::allocate(uint32 sizeInBytes)
 {
 	uint64 offset = 0;

--- a/projects/Cyseal/src/rhi/vertex_buffer_pool.h
+++ b/projects/Cyseal/src/rhi/vertex_buffer_pool.h
@@ -12,17 +12,47 @@
 #include "gpu_resource_binding.h"
 #include "core/smart_pointer.h"
 
-#include <vector>
+#include <list>
 
 class VertexBuffer;
 class IndexBuffer;
 class ShaderResourceView;
 
 // #todo-vram-pool: Implement free list with this.
+
 struct BufferPoolItem
 {
 	uint64 offset;
 	uint32 size;
+
+	inline bool isValid() const { return size > 0; }
+
+	inline bool operator==(const BufferPoolItem& other) const { return offset == other.offset && size == other.size; }
+	inline bool operator!=(const BufferPoolItem& other) const { return !(*this == other); }
+};
+
+class BufferPoolAllocator
+{
+public:
+	void initialize(uint64 inTotalBytes)
+	{
+		bytesTotal = inTotalBytes;
+		items.clear();
+	}
+
+	BufferPoolItem allocate(uint32 sizeInBytes);
+
+	bool release(const BufferPoolItem& item);
+
+	inline uint64 getTotalBytes() const { return bytesTotal; }
+	inline uint64 getUsedBytes() const { return bytesAllocated; }
+	// Does not guarantee that we can further allocate all of them due to internal fragmentation.
+	inline uint64 getAvailableBytes() const { return bytesTotal - bytesAllocated; }
+
+private:
+	std::list<BufferPoolItem> items; // ascending order by BufferPoolItem::offset.
+	uint64 bytesTotal = 0;
+	uint64 bytesAllocated = 0;
 };
 
 class VertexBufferPool final
@@ -32,13 +62,13 @@ public:
 	void destroy();
 
 	VertexBuffer* suballocate(uint32 sizeInBytes);
-	
-	// #todo-vram-pool: deallocate()
-	// ...
 
-	inline uint64 getTotalBytes() const { return poolSize; }
-	inline uint64 getUsedBytes() const { return currentOffset; }
-	inline uint64 getAvailableBytes() const { return poolSize - currentOffset; }
+	bool release(VertexBuffer* buffer);
+
+	inline uint64 getTotalBytes() const { return allocator.getTotalBytes(); }
+	inline uint64 getUsedBytes() const { return allocator.getUsedBytes(); }
+	// Does not guarantee that we can further allocate all of them due to internal fragmentation.
+	inline uint64 getAvailableBytes() const { return allocator.getAvailableBytes(); }
 
 	ShaderResourceView* getByteAddressBufferView() const;
 	
@@ -46,14 +76,10 @@ public:
 	VertexBuffer* internal_getPoolBuffer() const { return pool; }
 
 private:
-	uint64 poolSize = 0;
 	VertexBuffer* pool = nullptr;
-
 	UniquePtr<ShaderResourceView> srv; // ByteAddressBuffer view
-	
-	// #todo-vram-pool: Only increment for now. Need a free list.
-	uint64 currentOffset = 0;
-	//std::vector<BufferPoolItem> items;
+
+	BufferPoolAllocator allocator;
 };
 
 class IndexBufferPool final
@@ -64,12 +90,12 @@ public:
 
 	IndexBuffer* suballocate(uint32 sizeInBytes, EPixelFormat format);
 
-	// #todo-vram-pool: deallocate()
-	// ...
+	bool release(IndexBuffer* buffer);
 
-	inline uint64 getTotalBytes() const { return poolSize; }
-	inline uint64 getUsedBytes() const { return currentOffset; }
-	inline uint64 getAvailableBytes() const { return poolSize - currentOffset; }
+	inline uint64 getTotalBytes() const { return allocator.getTotalBytes(); }
+	inline uint64 getUsedBytes() const { return allocator.getUsedBytes(); }
+	// Does not guarantee that we can further allocate all of them due to internal fragmentation.
+	inline uint64 getAvailableBytes() const { return allocator.getAvailableBytes(); }
 
 	ShaderResourceView* getByteAddressBufferView() const;
 
@@ -77,14 +103,10 @@ public:
 	IndexBuffer* internal_getPoolBuffer() const { return pool; }
 
 private:
-	uint64 poolSize = 0;
 	IndexBuffer* pool = nullptr;
-
 	UniquePtr<ShaderResourceView> srv; // ByteAddressBuffer view
 
-	// #todo-vram-pool: Only increment for now. Need a free list.
-	uint64 currentOffset = 0;
-	//std::vector<BufferPoolItem> items;
+	BufferPoolAllocator allocator;
 };
 
 extern VertexBufferPool* gVertexBufferPool;

--- a/projects/Cyseal/src/rhi/vertex_buffer_pool.h
+++ b/projects/Cyseal/src/rhi/vertex_buffer_pool.h
@@ -18,8 +18,6 @@ class VertexBuffer;
 class IndexBuffer;
 class ShaderResourceView;
 
-// #todo-vram-pool: Implement free list with this.
-
 struct BufferPoolItem
 {
 	uint64 offset;

--- a/projects/Cyseal/src/rhi/vulkan/vk_buffer.cpp
+++ b/projects/Cyseal/src/rhi/vulkan/vk_buffer.cpp
@@ -292,6 +292,7 @@ void VulkanVertexBuffer::updateData(
 	void* data,
 	uint32 strideInBytes)
 {
+	CHECK(!bRemovedFromPool);
 	vertexCount = (uint32)(bufferSize / strideInBytes);
 
 	VulkanVertexBuffer* bufferOwner = (parentPool == nullptr) ? this : static_cast<VulkanVertexBuffer*>(parentPool->internal_getPoolBuffer());
@@ -347,6 +348,7 @@ void VulkanIndexBuffer::updateData(
 	void* data,
 	EPixelFormat format)
 {
+	CHECK(!bRemovedFromPool);
 	vkIndexType = VK_INDEX_TYPE_MAX_ENUM;
 	switch (format)
 	{
@@ -366,6 +368,7 @@ void VulkanIndexBuffer::updateData(
 
 VkBuffer VulkanIndexBuffer::getVkBuffer() const
 {
+	CHECK(!bRemovedFromPool);
 	const VulkanIndexBuffer* bufferOwner = (parentPool == nullptr) ? this : static_cast<VulkanIndexBuffer*>(parentPool->internal_getPoolBuffer());
 	return (VkBuffer)bufferOwner->internalBuffer->getRawResource();
 }

--- a/projects/UnitTest/UnitTest.vcxproj
+++ b/projects/UnitTest/UnitTest.vcxproj
@@ -144,6 +144,7 @@
     <ClCompile Include="src\render\TestVisibilityBuffer.cpp" />
     <ClCompile Include="src\render\test_render_utils.cpp" />
     <ClCompile Include="src\rhi\TestBarrier.cpp" />
+    <ClCompile Include="src\rhi\TestBufferPool.cpp" />
     <ClCompile Include="src\rhi\TestBufferUpload.cpp" />
     <ClCompile Include="src\rhi\test_rhi_utils.cpp" />
     <ClCompile Include="src\shader\TestShaderCodegen.cpp" />

--- a/projects/UnitTest/UnitTest.vcxproj.filters
+++ b/projects/UnitTest/UnitTest.vcxproj.filters
@@ -113,6 +113,9 @@
     <ClCompile Include="src\render\TestVisibilityBuffer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\rhi\TestBufferPool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/projects/UnitTest/src/rhi/TestBufferPool.cpp
+++ b/projects/UnitTest/src/rhi/TestBufferPool.cpp
@@ -1,0 +1,78 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+#include "test_rhi_utils.h"
+#include "rhi/buffer.h"
+#include "rhi/vertex_buffer_pool.h"
+#include "rhi/global_descriptor_heaps.h"
+
+#include "rhi/dx12/d3d_device.h"
+#include "rhi/vulkan/vk_device.h"
+
+namespace UnitTest
+{
+	template<ERenderDeviceRawAPI graphicsAPI>
+	class TestBufferPoolBase
+	{
+	protected:
+		void SuballocateAndRelease()
+		{
+			RenderDevice* renderDevice = rhi_test::createHeadlessDevice(graphicsAPI);
+			gRenderDevice = renderDevice;
+
+			gDescriptorHeaps = new GlobalDescriptorHeaps;
+			gDescriptorHeaps->initialize();
+
+			gVertexBufferPool = new VertexBufferPool;
+			gVertexBufferPool->initialize(65536);
+
+			gIndexBufferPool = new IndexBufferPool;
+			gIndexBufferPool->initialize(65536);
+
+			auto vbuf0 = gVertexBufferPool->suballocate(512);
+			auto vbuf1 = gVertexBufferPool->suballocate(1024);
+			auto ibuf0 = gIndexBufferPool->suballocate(10240, EPixelFormat::R32_UINT);
+
+			Assert::IsNotNull(vbuf0);
+			Assert::IsNotNull(vbuf1);
+			Assert::IsNotNull(ibuf0);
+
+			Assert::IsTrue(vbuf0->removeFromPool());
+			Assert::IsTrue(vbuf1->removeFromPool());
+			Assert::IsTrue(ibuf0->removeFromPool());
+
+			delete vbuf0;
+			delete vbuf1;
+			delete ibuf0;
+
+			gVertexBufferPool->destroy();
+			delete gVertexBufferPool;
+
+			gIndexBufferPool->destroy();
+			delete gIndexBufferPool;
+
+			renderDevice->destroy();
+			delete renderDevice;
+			gRenderDevice = nullptr;
+		}
+	};
+
+	TEST_CLASS(TestBufferPoolD3D12), TestBufferPoolBase<ERenderDeviceRawAPI::DirectX12>
+	{
+	public:
+		TEST_METHOD(SuballocateAndRelease)
+		{
+			TestBufferPoolBase::SuballocateAndRelease();
+		}
+	};
+
+	TEST_CLASS(TestBufferPoolVulkan), TestBufferPoolBase<ERenderDeviceRawAPI::Vulkan>
+	{
+	public:
+		TEST_METHOD(SuballocateAndRelease)
+		{
+			TestBufferPoolBase::SuballocateAndRelease();
+		}
+	};
+}


### PR DESCRIPTION
- Buffers suballocated from global vertex/index buffer pools were not able to be deallocated. This PR allows it by managing allocations using really naive free list.
- Add unit test: TestBufferPool.