### PR TITLE
Feature/96 Change world at runtime

### DIFF
--- a/projects/Cyseal/src/loader/image_loader.h
+++ b/projects/Cyseal/src/loader/image_loader.h
@@ -9,7 +9,7 @@ struct ImageLoadData
 	{
 		if (buffer != nullptr)
 		{
-			free(buffer);
+			delete buffer;
 			buffer = nullptr;
 		}
 	}

--- a/projects/Cyseal/src/memory/free_number_list.h
+++ b/projects/Cyseal/src/memory/free_number_list.h
@@ -159,6 +159,11 @@ public:
 		head = nullptr;
 	}
 
+	bool isEmpty() const
+	{
+		return head == nullptr;
+	}
+
 private:
 	uint32 maxNumber;
 	EMemoryTag memoryTag;

--- a/projects/Cyseal/src/render/gpu_scene.cpp
+++ b/projects/Cyseal/src/render/gpu_scene.cpp
@@ -170,7 +170,7 @@ void GPUScene::renderGPUScene(RenderCommandList* commandList, uint32 swapchainIn
 		numMeshSections += (uint32)(sm->getSections().size());
 	}
 
-	if (numMeshSections == 0)
+	if (numMeshSections == 0 && scene->hasAnyGPUSceneCommands() == false)
 	{
 		// #todo-zero-size: Release resources if any.
 		return;

--- a/projects/Cyseal/src/render/static_mesh.cpp
+++ b/projects/Cyseal/src/render/static_mesh.cpp
@@ -240,6 +240,12 @@ void StaticMesh::updateGPUSceneResidency(SceneProxy* sceneProxy, GPUSceneItemInd
 	}
 }
 
+void StaticMesh::markToEvictFromGPUScene()
+{
+	CHECK(gpuSceneResidency.phase != EGPUResidencyPhase::NeedToEvict && gpuSceneResidency.phase != EGPUResidencyPhase::NotAllocated);
+	gpuSceneResidency.phase = EGPUResidencyPhase::NeedToEvict;
+}
+
 StaticMeshProxy* StaticMesh::createStaticMeshProxy(StackAllocator* allocator) const
 {
 	StaticMeshProxy* proxy = static_cast<StaticMeshProxy*>(allocator->alloc(sizeof(StaticMeshProxy)));

--- a/projects/Cyseal/src/render/static_mesh.h
+++ b/projects/Cyseal/src/render/static_mesh.h
@@ -48,6 +48,8 @@ public:
 	~StaticMesh();
 
 	void updateGPUSceneResidency(SceneProxy* sceneProxy, GPUSceneItemIndexAllocator* gpuSceneItemIndexAllocator);
+	void markToEvictFromGPUScene();
+	inline bool isMarkedToBeEvictedFromGPUScene() const { return gpuSceneResidency.phase == EGPUResidencyPhase::NeedToEvict; }
 	StaticMeshProxy* createStaticMeshProxy(StackAllocator* allocator) const;
 
 	void addSection(

--- a/projects/Cyseal/src/rhi/descriptor_heap.h
+++ b/projects/Cyseal/src/rhi/descriptor_heap.h
@@ -77,6 +77,12 @@ public:
 		return freeNumberList.deallocate(index + 1);
 	}
 
+	// Returns true if no descriptor is allocated.
+	bool isEmpty() const
+	{
+		return freeNumberList.isEmpty();
+	}
+
 	void resetAllDescriptors()
 	{
 		freeNumberList.clear();

--- a/projects/Cyseal/src/rhi/global_descriptor_heaps.h
+++ b/projects/Cyseal/src/rhi/global_descriptor_heaps.h
@@ -18,7 +18,7 @@ public:
 	uint32 allocateDSVIndex();
 	uint32 allocateUAVIndex();
 
-	// #todo-renderdevice: Free unused descriptors
+	// #wip: Free unused descriptors?
 	//void freeSRVIndex(uint32 index);
 	//void freeRTVIndex(uint32 index);
 	//void freeDSVIndex(uint32 index);

--- a/projects/Cyseal/src/rhi/global_descriptor_heaps.h
+++ b/projects/Cyseal/src/rhi/global_descriptor_heaps.h
@@ -18,12 +18,6 @@ public:
 	uint32 allocateDSVIndex();
 	uint32 allocateUAVIndex();
 
-	// #wip: Free unused descriptors?
-	//void freeSRVIndex(uint32 index);
-	//void freeRTVIndex(uint32 index);
-	//void freeDSVIndex(uint32 index);
-	//void freeUAVIndex(uint32 index);
-
 	DescriptorHeap* getSRVHeap() const { return srvHeap.get(); }
 	DescriptorHeap* getRTVHeap() const { return rtvHeap.get(); }
 	DescriptorHeap* getDSVHeap() const { return dsvHeap.get(); }

--- a/projects/Cyseal/src/world/scene.cpp
+++ b/projects/Cyseal/src/world/scene.cpp
@@ -123,3 +123,8 @@ void Scene::clearStaticMeshes()
 	}
 	staticMeshes.clear();
 }
+
+void Scene::clearSkybox()
+{
+	skyboxTexture.reset();
+}

--- a/projects/Cyseal/src/world/scene.cpp
+++ b/projects/Cyseal/src/world/scene.cpp
@@ -17,6 +17,12 @@ static uint32 calculateLOD(const StaticMesh* mesh, const Camera& camera)
 	return lod;
 }
 
+Scene::~Scene()
+{
+	CHECK(staticMeshes.size() == 0);
+	CHECK(staticMeshesToRemove.size() == 0);
+}
+
 void Scene::updateMeshLODs(const Camera& camera, const RendererOptions& rendererOptions)
 {
 	size_t numStaticMeshes = staticMeshes.size();
@@ -49,6 +55,13 @@ SceneProxy* Scene::createProxy()
 
 	const uint32 stackAllocatorSize = (uint32)(totalActiveMeshSections * sizeof(StaticMeshProxy));
 	proxy->staticMeshProxyAllocator = new(EMemoryTag::Renderer) StackAllocator(stackAllocatorSize);
+
+	for (StaticMesh* sm : staticMeshesToRemove)
+	{
+		CHECK(sm->isMarkedToBeEvictedFromGPUScene());
+		sm->updateGPUSceneResidency(proxy, &gpuSceneItemIndexAllocator);
+	}
+	staticMeshesToRemove.clear();
 
 	std::vector<StaticMeshProxy*> staticMeshProxyList;
 	uint32 totalMeshSectionsLOD0 = 0;
@@ -88,4 +101,25 @@ void Scene::addStaticMesh(StaticMesh* staticMesh)
 	staticMeshes.push_back(staticMesh);
 	bRebuildGPUScene = true;
 	bRebuildRaytracingScene = true;
+}
+
+void Scene::removeStaticMesh(StaticMesh* staticMesh)
+{
+	auto it = std::find(staticMeshes.begin(), staticMeshes.end(), staticMesh);
+	if (it != staticMeshes.end())
+	{
+		staticMeshes.erase(it);
+		staticMeshesToRemove.push_back(staticMesh);
+		staticMesh->markToEvictFromGPUScene();
+	}
+}
+
+void Scene::clearStaticMeshes()
+{
+	staticMeshesToRemove = std::move(staticMeshes);
+	for (StaticMesh* sm : staticMeshesToRemove)
+	{
+		sm->markToEvictFromGPUScene();
+	}
+	staticMeshes.clear();
 }

--- a/projects/Cyseal/src/world/scene.h
+++ b/projects/Cyseal/src/world/scene.h
@@ -56,6 +56,7 @@ public:
 	void removeStaticMesh(StaticMesh* staticMesh);
 
 	void clearStaticMeshes();
+	void clearSkybox();
 
 public:
 	DirectionalLight sun;

--- a/projects/Cyseal/src/world/scene.h
+++ b/projects/Cyseal/src/world/scene.h
@@ -45,13 +45,17 @@ private:
 class Scene
 {
 public:
+	~Scene();
+
 	void updateMeshLODs(const Camera& camera, const RendererOptions& rendererOptions);
 
 	SceneProxy* createProxy();
 
 	void addStaticMesh(StaticMesh* staticMesh);
 
-	// #wip: Need removeStaticMesh().
+	void removeStaticMesh(StaticMesh* staticMesh);
+
+	void clearStaticMeshes();
 
 public:
 	DirectionalLight sun;
@@ -61,6 +65,8 @@ private:
 	std::vector<StaticMesh*> staticMeshes;
 	bool bRebuildGPUScene = false;
 	bool bRebuildRaytracingScene = false;
+
+	std::vector<StaticMesh*> staticMeshesToRemove;
 
 	GPUSceneItemIndexAllocator gpuSceneItemIndexAllocator;
 };

--- a/projects/Cyseal/src/world/scene.h
+++ b/projects/Cyseal/src/world/scene.h
@@ -51,6 +51,8 @@ public:
 
 	void addStaticMesh(StaticMesh* staticMesh);
 
+	// #wip: Need removeStaticMesh().
+
 public:
 	DirectionalLight sun;
 	SharedPtr<TextureAsset> skyboxTexture;

--- a/projects/Cyseal/src/world/scene_proxy.h
+++ b/projects/Cyseal/src/world/scene_proxy.h
@@ -34,6 +34,15 @@ public:
 	StackAllocator* staticMeshProxyAllocator;
 
 public:
+	inline bool hasAnyGPUSceneCommands() const
+	{
+		return gpuSceneEvictCommands.size() > 0
+			|| gpuSceneAllocCommands.size() > 0
+			|| gpuSceneUpdateCommands.size() > 0
+			|| gpuSceneEvictMaterialCommands.size() > 0
+			|| gpuSceneMaterialCommands.size() > 0;
+	}
+
 	std::vector<GPUSceneEvictCommand>         gpuSceneEvictCommands;
 	std::vector<GPUSceneAllocCommand>         gpuSceneAllocCommands;
 	std::vector<GPUSceneUpdateCommand>        gpuSceneUpdateCommands;

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -132,7 +132,7 @@ void TestApplication::onTick(float deltaSeconds)
 		scene.clearStaticMeshes();
 		scene.clearSkybox();
 		SceneProxy* sceneProxy = scene.createProxy();
-		// #wip: How to update gpu scene only, without executing other render passes?
+		// #todo-renderer: How to update gpu scene only, without executing other render passes?
 		cysealEngine.renderScene(sceneProxy, &camera, appState.rendererOptions);
 		delete sceneProxy;
 
@@ -141,7 +141,6 @@ void TestApplication::onTick(float deltaSeconds)
 
 		resetSceneAndCamera();
 
-		// #wip: memory leak when switching scenes, possibly due to PBRT.
 		world = createWorldInstance((EWorldIndex)appState.currentWorldIndex);
 		world->preinitialize(&scene, &camera, &appState);
 		world->onInitialize();

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -8,6 +8,9 @@
 #include "util/profiling.h"
 #include "imgui.h"
 
+// #wip: Temp include for isEmpty check
+#include "rhi/global_descriptor_heaps.h"
+
 /* -------------------------------------------------------
 					CONFIGURATION
 --------------------------------------------------------*/
@@ -131,6 +134,7 @@ void TestApplication::onTick(float deltaSeconds)
 		// Clear GPU scene residency.
 		scene.clearStaticMeshes();
 		SceneProxy* sceneProxy = scene.createProxy();
+		// #wip: How to update gpu scene only, without executing other render passes?
 		cysealEngine.renderScene(sceneProxy, &camera, appState.rendererOptions);
 
 		world->onTerminate();
@@ -138,8 +142,12 @@ void TestApplication::onTick(float deltaSeconds)
 
 		resetSceneAndCamera();
 
-		// #wip: start with world1 -> switch to world2 -> switch2 to world1 crashes.
-		// #wip: start with world1 -> switch to world2 -> terminate then there are live d3d12 objects.
+		// #wip: Gotcha; start with world1 -> switch to world2 -> terminate then there are live d3d12 objects.
+		CHECK(gDescriptorHeaps->getSRVHeap()->isEmpty());
+		CHECK(gDescriptorHeaps->getRTVHeap()->isEmpty());
+		CHECK(gDescriptorHeaps->getDSVHeap()->isEmpty());
+		CHECK(gDescriptorHeaps->getUAVHeap()->isEmpty());
+
 		world = createWorldInstance((EWorldIndex)appState.currentWorldIndex);
 		world->preinitialize(&scene, &camera, &appState);
 		world->onInitialize();

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -134,13 +134,14 @@ void TestApplication::onTick(float deltaSeconds)
 		SceneProxy* sceneProxy = scene.createProxy();
 		// #wip: How to update gpu scene only, without executing other render passes?
 		cysealEngine.renderScene(sceneProxy, &camera, appState.rendererOptions);
+		delete sceneProxy;
 
 		world->onTerminate();
 		delete world;
 
 		resetSceneAndCamera();
 
-		// #wip: No d3d12 live objects anymore but memory leak when switching between scenes :(
+		// #wip: memory leak when switching scenes, possibly due to PBRT.
 		world = createWorldInstance((EWorldIndex)appState.currentWorldIndex);
 		world->preinitialize(&scene, &camera, &appState);
 		world->onInitialize();

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -8,9 +8,6 @@
 #include "util/profiling.h"
 #include "imgui.h"
 
-// #wip: Temp include for isEmpty check
-#include "rhi/global_descriptor_heaps.h"
-
 /* -------------------------------------------------------
 					CONFIGURATION
 --------------------------------------------------------*/
@@ -133,6 +130,7 @@ void TestApplication::onTick(float deltaSeconds)
 	{
 		// Clear GPU scene residency.
 		scene.clearStaticMeshes();
+		scene.clearSkybox();
 		SceneProxy* sceneProxy = scene.createProxy();
 		// #wip: How to update gpu scene only, without executing other render passes?
 		cysealEngine.renderScene(sceneProxy, &camera, appState.rendererOptions);
@@ -142,12 +140,7 @@ void TestApplication::onTick(float deltaSeconds)
 
 		resetSceneAndCamera();
 
-		// #wip: Gotcha; start with world1 -> switch to world2 -> terminate then there are live d3d12 objects.
-		CHECK(gDescriptorHeaps->getSRVHeap()->isEmpty());
-		CHECK(gDescriptorHeaps->getRTVHeap()->isEmpty());
-		CHECK(gDescriptorHeaps->getDSVHeap()->isEmpty());
-		CHECK(gDescriptorHeaps->getUAVHeap()->isEmpty());
-
+		// #wip: No d3d12 live objects anymore but memory leak when switching between scenes :(
 		world = createWorldInstance((EWorldIndex)appState.currentWorldIndex);
 		world->preinitialize(&scene, &camera, &appState);
 		world->onInitialize();

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -128,13 +128,18 @@ void TestApplication::onTick(float deltaSeconds)
 
 	if (bChangeWorld)
 	{
+		// Clear GPU scene residency.
+		scene.clearStaticMeshes();
+		SceneProxy* sceneProxy = scene.createProxy();
+		cysealEngine.renderScene(sceneProxy, &camera, appState.rendererOptions);
+
 		world->onTerminate();
 		delete world;
 
-		// #wip: GPU resources related to current scene objects need to be destroyed.
-		// I even don't have Scene::removeStaticMesh() yet. :(
 		resetSceneAndCamera();
 
+		// #wip: start with world1 -> switch to world2 -> switch2 to world1 crashes.
+		// #wip: start with world1 -> switch to world2 -> terminate then there are live d3d12 objects.
 		world = createWorldInstance((EWorldIndex)appState.currentWorldIndex);
 		world->preinitialize(&scene, &camera, &appState);
 		world->onInitialize();

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -42,9 +42,34 @@
 #define CAMERA_SPEED_UP      20.0f
 #define CAMERA_SPEED_RIGHT   20.0f
 
-// #todo-world: Select world
-#define WORLD_CLASS          World1
-//#define WORLD_CLASS          World2
+enum class EWorldIndex : uint32
+{
+	World1 = 0,
+	World2 = 1,
+
+	Count,
+};
+static const char** getWorldNames()
+{
+	static const char* names[] = {
+		"World1",
+		"World2",
+	};
+	static_assert(_countof(names) == (int)EWorldIndex::Count);
+	return names;
+}
+World* createWorldInstance(EWorldIndex worldIndex)
+{
+	switch (worldIndex)
+	{
+		case EWorldIndex::World1: return new(EMemoryTag::World) World1;
+		case EWorldIndex::World2: return new(EMemoryTag::World) World2;
+		case EWorldIndex::Count:
+		default:
+			CHECK_NO_ENTRY();
+	}
+	return nullptr;
+}
 
 
 /* -------------------------------------------------------
@@ -53,6 +78,16 @@
 CysealEngine cysealEngine;
 
 DEFINE_LOG_CATEGORY_STATIC(LogApplication);
+
+void TestApplication::resetSceneAndCamera()
+{
+	// World instances will add various objects to the scene.
+	scene = Scene{};
+
+	// May overwritten by world.
+	camera.lookAt(CAMERA_POSITION, CAMERA_LOOKAT, CAMERA_UP);
+	camera.perspective(CAMERA_FOV_Y, getAspectRatio(), CAMERA_Z_NEAR, CAMERA_Z_FAR);
+}
 
 bool TestApplication::onInitialize()
 {
@@ -78,11 +113,9 @@ bool TestApplication::onInitialize()
 	newViewportWidth = getWindowWidth();
 	newViewportHeight = getWindowHeight();
 
-	// May overwritten by world.
-	camera.lookAt(CAMERA_POSITION, CAMERA_LOOKAT, CAMERA_UP);
-	camera.perspective(CAMERA_FOV_Y, getAspectRatio(), CAMERA_Z_NEAR, CAMERA_Z_FAR);
+	resetSceneAndCamera();
 
-	world = new(EMemoryTag::World) WORLD_CLASS;
+	world = createWorldInstance((EWorldIndex)appState.currentWorldIndex);
 	world->preinitialize(&scene, &camera, &appState);
 	world->onInitialize();
 
@@ -92,6 +125,20 @@ bool TestApplication::onInitialize()
 void TestApplication::onTick(float deltaSeconds)
 {
 	// #todo-renderthread: Start to render using prev frame's scene proxy.
+
+	if (bChangeWorld)
+	{
+		world->onTerminate();
+		delete world;
+
+		// #wip: GPU resources related to current scene objects need to be destroyed.
+		// I even don't have Scene::removeStaticMesh() yet. :(
+		resetSceneAndCamera();
+
+		world = createWorldInstance((EWorldIndex)appState.currentWorldIndex);
+		world->preinitialize(&scene, &camera, &appState);
+		world->onInitialize();
+	}
 
 	{
 		SCOPED_CPU_EVENT(WorldLogic);
@@ -305,6 +352,17 @@ void TestApplication::onTick(float deltaSeconds)
 				appState.rendererOptions.bCameraHasMoved = true;
 			}
 			ImGui::Text("Frames: %u", appState.pathTracingNumFrames);
+
+			ImGui::SeparatorText("World");
+			if (ImGui::BeginTable("##World", 2))
+			{
+				int32 oldWorldIndex = appState.currentWorldIndex;
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn(); ImGui::Text("World");
+				ImGui::TableNextColumn(); ImGui::Combo("##World Name", &appState.currentWorldIndex, getWorldNames(), (int32)EWorldIndex::Count);
+				ImGui::EndTable();
+				bChangeWorld = oldWorldIndex != appState.currentWorldIndex;
+			}
 
 			ImGui::SeparatorText("Control");
 			ImGui::Text("WASD : move camera");

--- a/projects/TestApplication/src/app.h
+++ b/projects/TestApplication/src/app.h
@@ -7,6 +7,7 @@
 
 struct AppState
 {
+	// Rendering related
 	RendererOptions rendererOptions;
 	int32 displayScale                    = 100;
 	int32 renderResolutionScale           = 100;
@@ -19,6 +20,8 @@ struct AppState
 	int32 selectedPathTracingKernel       = 0;
 	uint32 pathTracingNumFrames           = 0;
 	int32 pathTracingMaxFrames            = 64;
+	// World management
+	int32 currentWorldIndex               = 0; // EWorldIndex
 };
 
 class TestApplication : public WindowsApplication
@@ -32,11 +35,15 @@ protected:
 	virtual void onWindowResize(uint32 newWidth, uint32 newHeight) override;
 
 private:
+	void resetSceneAndCamera();
+
+private:
 	Scene scene;
 	Camera camera;
 	AppState appState;
 
 	class World* world = nullptr;
+	bool bChangeWorld = false;
 
 	bool bViewportNeedsResize = false;
 	uint32 newViewportWidth = 0;

--- a/projects/TestApplication/src/world1.cpp
+++ b/projects/TestApplication/src/world1.cpp
@@ -21,6 +21,7 @@
 
 #define LOAD_PBRT_FILE       1
 #define CREATE_TEST_MESHES   1
+#define CREATE_SKYBOX        1
 #define MESH_SPLATTING_DELAY 0
 #define PBRT_LOAD_DELAY      30
 
@@ -60,18 +61,17 @@ void World1::onTick(float deltaSeconds)
 		static float elapsed = 0.0f;
 		elapsed += deltaSeconds;
 
-		if (CREATE_TEST_MESHES)
-		{
-			//ground->getTransform().setScale(1.0f + 0.2f * cosf(elapsed));
-			ground->setRotation(vec3(0.0f, 1.0f, 0.0f), elapsed * 15.0f);
+#if CREATE_TEST_MESHES
+		//ground->getTransform().setScale(1.0f + 0.2f * cosf(elapsed));
+		ground->setRotation(vec3(0.0f, 1.0f, 0.0f), elapsed * 15.0f);
 
-			// Animate balls to see if update of BLAS instance transforms is going well.
-			if (meshSplattingDelay == 0) meshSplatting.tick(deltaSeconds);
-			else if (--meshSplattingDelay == 0)
-			{
-				createMeshSplatting();
-			}
+		// Animate balls to see if update of BLAS instance transforms is going well.
+		if (meshSplattingDelay == 0) meshSplatting.tick(deltaSeconds);
+		else if (--meshSplattingDelay == 0)
+		{
+			createMeshSplatting();
 		}
+#endif
 
 #if LOAD_PBRT_FILE
 		if (pbrtLoadDelay > 0)
@@ -87,14 +87,12 @@ void World1::onTick(float deltaSeconds)
 
 void World1::onTerminate()
 {
-	if (CREATE_TEST_MESHES)
-	{
-		meshSplatting.destroyResources();
-		delete ground;
-		delete wallA;
-		delete glassBox;
-	}
-
+#if CREATE_TEST_MESHES
+	meshSplatting.destroyResources();
+	delete ground;
+	delete wallA;
+	delete glassBox;
+#endif
 #if LOAD_PBRT_FILE
 	for (StaticMesh* pbrtMesh : pbrtMeshes)
 	{
@@ -113,8 +111,12 @@ void World1::onTerminate()
 
 void World1::prepareScene()
 {
-	if (CREATE_TEST_MESHES) createTestMeshes();
+#if CREATE_TEST_MESHES
+	createTestMeshes();
+#endif
+#if CREATE_SKYBOX
 	createSkybox();
+#endif
 #if LOAD_PBRT_FILE
 	if (pbrtLoadDelay == 0) createPbrtResources();
 #endif

--- a/projects/TestApplication/src/world2.cpp
+++ b/projects/TestApplication/src/world2.cpp
@@ -19,13 +19,14 @@
 #define CAMERA_Z_FAR         10000.0f
 #define BALL_ROWS            4
 #define BALL_COLS            6
-#define BALL_NUM_LOD         3
+#define CREATE_GROUND        1
 
 void World2::onInitialize()
 {
 	camera->lookAt(CAMERA_POSITION, CAMERA_LOOKAT, CAMERA_UP);
 	camera->perspective(CAMERA_FOV_Y, camera->getAspectRatio(), CAMERA_Z_NEAR, CAMERA_Z_FAR);
 
+#if CREATE_GROUND
 	{
 		Geometry* planeGeometry = new Geometry;
 		ProceduralGeometry::plane(*planeGeometry,
@@ -44,9 +45,9 @@ void World2::onInitialize()
 
 		scene->addStaticMesh(ground);
 	}
+#endif
 	{
 		const uint32 TOTAL_BALLS = BALL_ROWS * BALL_COLS;
-		//const uint32 TOTAL_MESHES = BALL_NUM_LOD * TOTAL_BALLS;
 		
 		SharedPtr<TextureAsset> baseTextures[] = {
 			gTextureManager->getSystemTextureWhite2D(),


### PR DESCRIPTION
Changes
- Allow switching worlds at runtime via GUI.
- Implement `Scene::removeStaticMesh()`.
- Fix false memory leak. (replace `free()` with `delete` to correctly track memory deallocation)

Known issues
- Switching world requires gpu scene update, but to do so all passes in scene renderer are executed when only gpu scene pass is enough. Need to extract gpu scene update from `SceneRenderer::render()`.