### PR TITLE
Feature/65 [FSR3] Generate interpolated frames

### DIFF
--- a/projects/Cyseal/Cyseal.vcxproj
+++ b/projects/Cyseal/Cyseal.vcxproj
@@ -133,6 +133,7 @@
     <ClInclude Include="src\render\hiz_pass.h" />
     <ClInclude Include="src\material\material_shader.h" />
     <ClInclude Include="src\material\material_database.h" />
+    <ClInclude Include="src\render\optical_flow_common.h" />
     <ClInclude Include="src\render\optical_flow_pass.h" />
     <ClInclude Include="src\render\renderer_constants.h" />
     <ClInclude Include="src\render\util\clear_resource_pass.h" />
@@ -256,6 +257,7 @@
     <ClCompile Include="src\render\frame_gen_pass.cpp" />
     <ClCompile Include="src\render\gpu_culling.cpp" />
     <ClCompile Include="src\render\hiz_pass.cpp" />
+    <ClCompile Include="src\render\optical_flow_common.cpp" />
     <ClCompile Include="src\render\optical_flow_pass.cpp" />
     <ClCompile Include="src\render\pathtracing\denoiser_plugin_pass.cpp" />
     <ClCompile Include="src\render\pathtracing\path_tracing_pass.cpp" />

--- a/projects/Cyseal/Cyseal.vcxproj.filters
+++ b/projects/Cyseal/Cyseal.vcxproj.filters
@@ -408,6 +408,9 @@
     <ClInclude Include="src\render\util\clear_resource_pass.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\render\optical_flow_common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\memory\mem_alloc.cpp">
@@ -678,6 +681,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\rhi\buffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\render\optical_flow_common.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/projects/Cyseal/src/render/buffer_visualization.cpp
+++ b/projects/Cyseal/src/render/buffer_visualization.cpp
@@ -95,7 +95,8 @@ void BufferVisualization::renderVisualization(RenderCommandList* commandList, ui
 	SPT.texture("barycentricCoord", passInput.barycentricCoordSRV);
 	SPT.texture("visGBuffer0", passInput.visGbuffer0SRV);
 	SPT.texture("visGBuffer1", passInput.visGbuffer1SRV);
-	SPT.texture("opticalFlowVector", passInput.opticalFlowVectorSRV);
+	SPT.texture("opticalFlowVectorX", passInput.opticalFlowVectorXSRV);
+	SPT.texture("opticalFlowVectorY", passInput.opticalFlowVectorYSRV);
 	SPT.texture("interpolatedFrame", passInput.interpolatedFrameSRV);
 
 	uint32 requiredVolatiles = SPT.totalDescriptors();

--- a/projects/Cyseal/src/render/buffer_visualization.cpp
+++ b/projects/Cyseal/src/render/buffer_visualization.cpp
@@ -96,6 +96,7 @@ void BufferVisualization::renderVisualization(RenderCommandList* commandList, ui
 	SPT.texture("visGBuffer0", passInput.visGbuffer0SRV);
 	SPT.texture("visGBuffer1", passInput.visGbuffer1SRV);
 	SPT.texture("opticalFlowVector", passInput.opticalFlowVectorSRV);
+	SPT.texture("interpolatedFrame", passInput.interpolatedFrameSRV);
 
 	uint32 requiredVolatiles = SPT.totalDescriptors();
 	passDescriptor.resizeDescriptorHeap(swapchainIndex, requiredVolatiles);

--- a/projects/Cyseal/src/render/buffer_visualization.h
+++ b/projects/Cyseal/src/render/buffer_visualization.h
@@ -13,26 +13,27 @@ class ShaderResourceView;
 
 struct BufferVisualizationInput
 {
-	Texture*                 renderTarget           = nullptr;
-	EBufferVisualizationMode mode                   = EBufferVisualizationMode::None;
-	uint32                   textureWidth           = 0;
-	uint32                   textureHeight          = 0;
-	ConstantBufferView*      sceneUniformCBV        = nullptr;
-	ShaderResourceView*      gbuffer0SRV            = nullptr;
-	ShaderResourceView*      gbuffer1SRV            = nullptr;
-	ShaderResourceView*      sceneColorSRV          = nullptr;
-	ShaderResourceView*      shadowMaskSRV          = nullptr;
-	ShaderResourceView*      indirectDiffuseSRV     = nullptr;
-	ShaderResourceView*      indirectSpecularSRV    = nullptr;
-	ShaderResourceView*      velocityMapSRV         = nullptr;
-	ShaderResourceView*      visibilityBufferSRV    = nullptr;
-	ShaderResourceView*      barycentricCoordSRV    = nullptr;
-	ShaderResourceView*      visGbuffer0SRV         = nullptr;
-	ShaderResourceView*      visGbuffer1SRV         = nullptr;
-	ShaderResourceView*      opticalFlowVectorSRV   = nullptr;
-	uint32                   opticalFlowVectorSizeX = 0;
-	uint32                   opticalFlowVectorSizeY = 0;
-	ShaderResourceView*      interpolatedFrameSRV   = nullptr;
+	Texture*                 renderTarget             = nullptr;
+	EBufferVisualizationMode mode                     = EBufferVisualizationMode::None;
+	uint32                   textureWidth             = 0;
+	uint32                   textureHeight            = 0;
+	ConstantBufferView*      sceneUniformCBV          = nullptr;
+	ShaderResourceView*      gbuffer0SRV              = nullptr;
+	ShaderResourceView*      gbuffer1SRV              = nullptr;
+	ShaderResourceView*      sceneColorSRV            = nullptr;
+	ShaderResourceView*      shadowMaskSRV            = nullptr;
+	ShaderResourceView*      indirectDiffuseSRV       = nullptr;
+	ShaderResourceView*      indirectSpecularSRV      = nullptr;
+	ShaderResourceView*      velocityMapSRV           = nullptr;
+	ShaderResourceView*      visibilityBufferSRV      = nullptr;
+	ShaderResourceView*      barycentricCoordSRV      = nullptr;
+	ShaderResourceView*      visGbuffer0SRV           = nullptr;
+	ShaderResourceView*      visGbuffer1SRV           = nullptr;
+	ShaderResourceView*      opticalFlowVectorXSRV    = nullptr;
+	ShaderResourceView*      opticalFlowVectorYSRV    = nullptr;
+	uint32                   opticalFlowVectorSizeX   = 0;
+	uint32                   opticalFlowVectorSizeY   = 0;
+	ShaderResourceView*      interpolatedFrameSRV     = nullptr;
 };
 
 // Visualize intermediate rendering data during frame rendering.

--- a/projects/Cyseal/src/render/buffer_visualization.h
+++ b/projects/Cyseal/src/render/buffer_visualization.h
@@ -32,6 +32,7 @@ struct BufferVisualizationInput
 	ShaderResourceView*      opticalFlowVectorSRV   = nullptr;
 	uint32                   opticalFlowVectorSizeX = 0;
 	uint32                   opticalFlowVectorSizeY = 0;
+	ShaderResourceView*      interpolatedFrameSRV   = nullptr;
 };
 
 // Visualize intermediate rendering data during frame rendering.

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -176,38 +176,8 @@ void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchain
 // See ffxFrameInterpolationDispatch.
 void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
-	FrameInterpUniform uniformData{
-		.renderSize                 = { passInput.renderSizeX, passInput.renderSizeY },
-		.displaySize                = { passInput.displaySizeX, passInput.displaySizeY },
-		.displaySizeRcp             = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
-		.cameraNear                 = passInput.camera->getZNear(),
-		.cameraFar                  = passInput.camera->getZFar(),
-		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #todo-fsr3-framegen: upscale target size
-		.Mode                       = 0, // #todo-fsr3-framegen: What is this? No shader accesses it, even ffx source code does not use it.
-		.reset                      = 0, // #todo-fsr3-framegen: reset, see ffxFrameInterpolationDispatch
-		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #todo-fsr3-framegen: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
-		.deltaTime                  = passInput.deltaTime, // #todo-fsr3-framegen: Unit of deltaTime?
-		.HUDLessAttachedFactor      = 0,
-		.distortionFieldSize        = { 1, 1 },
-		.opticalFlowScale           = { 1.0f, 1.0f }, // #todo-fsr3-framegen: opticalFlowScale
-		.opticalFlowBlockSize       = passInput.opticalFlowBlockSize,
-		.dispatchFlags              = passInput.dispatchFlags,
-		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
-		.opticalFlowHalfResMode     = 0, // #todo-fsr3-framegen: opticalFlowHalfResMode
-		.NumInstances               = 0, // #todo-fsr3-framegen: NumInstances unused?
-		.interpolationRectBase      = { 0, 0 },
-		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
-		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
-		.backBufferTransferFunction = (uint32)passInput.backBufferTransferFunction,
-		.minMaxLuminance            = { 0.0f, 65000.0f }, // #todo-fsr: minMaxLuminance
-		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
-		._pad1                      = 0,
-		.fJitter                    = { 0, 0 }, // #todo-fsr3-framegen: jitter
-		.fMotionVectorScale         = { 1.0f, 1.0f },
-	};
-
-	ConstantBufferView* passUniformCBV = frameInterpDescriptor.getUniformCBV(swapchainIndex);
-	passUniformCBV->writeToGPU(commandList, &uniformData, sizeof(uniformData));
+	ConstantBufferView* frameInterpUniformCBV = getCurrentFrameInterpUniformCBV();
+	ConstantBufferView* inpaintingPyramidUniformCBV = getCurrentInpaintingPyramidUniformCBV();
 
 	const uint32 displayDispatchSizeX = (passInput.displaySizeX + 7) / 8;
 	const uint32 displayDispatchSizeY = (passInput.displaySizeY + 7) / 8;

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -86,7 +86,7 @@ void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swa
 	recreateResources(commandList, passInput);
 
 	updateUniforms(commandList, passInput);
-	//preparePhase(commandList, swapchainIndex, passInput);
+	preparePhase(commandList, swapchainIndex, passInput);
 	//dispatchPhase(commandList, swapchainIndex, passInput);
 
 	cpuFrameIndex += 1;
@@ -96,9 +96,9 @@ void FrameGenPass::initializePipelines()
 {
 	const uint32 swapchainCount = 2;//device->maxFramesInFlight(); // Always need 2
 
-	prepareDescriptor.initialize(L"FSR3_Prepare", swapchainCount, 0);
-	frameInterpDescriptor.initialize(L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
-	inpaintingPyramidDescriptor.initialize(L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
+	prepareDescriptor.initialize(device, L"FSR3_Prepare", swapchainCount, 0);
+	frameInterpDescriptor.initialize(device, L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
+	inpaintingPyramidDescriptor.initialize(device, L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -417,10 +417,10 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 ConstantBufferView* FrameGenPass::getCurrentFrameInterpUniformCBV()
 {
-	return frameInterpDescriptor.getUniformCBV(cpuFrameIndex);
+	return frameInterpDescriptor.getUniformCBV(cpuFrameIndex & 1);
 }
 
 ConstantBufferView* FrameGenPass::getCurrentInpaintingPyramidUniformCBV()
 {
-	return inpaintingPyramidDescriptor.getUniformCBV(cpuFrameIndex);
+	return inpaintingPyramidDescriptor.getUniformCBV(cpuFrameIndex & 1);
 }

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -62,19 +62,23 @@ struct InpaintingPyramidUniform
 void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 {
 	device = inRenderDevice;
+	cpuFrameIndex = 0;
 
 	initializePipelines();
 }
 
 void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
+	updateUniforms(commandList, passInput);
 	//preparePhase(commandList, swapchainIndex, passInput);
 	//dispatchPhase(commandList, swapchainIndex, passInput);
+
+	cpuFrameIndex += 1;
 }
 
 void FrameGenPass::initializePipelines()
 {
-	const uint32 swapchainCount = device->maxFramesInFlight();
+	const uint32 swapchainCount = 2;//device->maxFramesInFlight(); // Always need 2
 
 	frameInterpDescriptor.initialize(L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
 	inpaintingPyramidDescriptor.initialize(L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
@@ -106,11 +110,67 @@ void FrameGenPass::initializePipelines()
 	createPipeline("FSR3DebugViewPipelineCS", L"amd/ffx_frameinterpolation_debug_view_pass.hlsl", debugViewPipeline);
 }
 
-// See ffxFrameInterpolationPrepare.
+void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
+{
+	ConstantBufferView* frameInterpUniformCBV = getCurrentFrameInterpUniformCBV();
+	ConstantBufferView* inpaintingPyramidUniformCBV = getCurrentInpaintingPyramidUniformCBV();
+
+	FrameInterpUniform fiUniformData{
+		.renderSize                 = { passInput.renderSizeX, passInput.renderSizeY },
+		.displaySize                = { passInput.displaySizeX, passInput.displaySizeY },
+		.displaySizeRcp             = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
+		.cameraNear                 = passInput.camera->getZNear(),
+		.cameraFar                  = passInput.camera->getZFar(),
+		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #todo-fsr3-framegen: upscale target size
+		.Mode                       = 0, // #todo-fsr3-framegen: What is this? No shader accesses it, even ffx source code does not use it.
+		.reset                      = 0, // #todo-fsr3-framegen: reset, see ffxFrameInterpolationDispatch
+		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #todo-fsr3-framegen: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
+		.deltaTime                  = passInput.deltaTime, // #todo-fsr3-framegen: Unit of deltaTime?
+		.HUDLessAttachedFactor      = 0,
+		.distortionFieldSize        = { 1, 1 },
+		.opticalFlowScale           = { 1.0f, 1.0f }, // #todo-fsr3-framegen: opticalFlowScale
+		.opticalFlowBlockSize       = passInput.opticalFlowBlockSize,
+		.dispatchFlags              = passInput.dispatchFlags,
+		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
+		.opticalFlowHalfResMode     = 0, // #todo-fsr3-framegen: opticalFlowHalfResMode
+		.NumInstances               = 0, // #todo-fsr3-framegen: NumInstances unused?
+		.interpolationRectBase      = { 0, 0 },
+		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
+		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
+		.backBufferTransferFunction = (uint32)passInput.backBufferTransferFunction,
+		.minMaxLuminance            = { 0.0f, 65000.0f }, // #todo-fsr: minMaxLuminance
+		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
+		._pad1                      = 0,
+		.fJitter                    = { 0, 0 }, // #todo-fsr3-framegen: jitter
+		.fMotionVectorScale         = { 1.0f, 1.0f },
+	};
+	frameInterpUniformCBV->writeToGPU(commandList, &fiUniformData, sizeof(fiUniformData));
+
+	uint32 dispatchThreadGroupCountXY[2];
+	uint32 workGroupOffset[2];
+	uint32 numWorkGroupsAndMips[2];
+	uint32 rectInfo[4] = { 0, 0, (uint32)passInput.renderSizeX, (uint32)passInput.renderSizeY };
+	ffxSpdSetup(dispatchThreadGroupCountXY, workGroupOffset, numWorkGroupsAndMips, rectInfo, -1);
+
+	InpaintingPyramidUniform ipUniformData{
+		.mips            = numWorkGroupsAndMips[1],
+		.numWorkGroups   = numWorkGroupsAndMips[0],
+		.workGroupOffset = { workGroupOffset[0], workGroupOffset[1] },
+	};
+	inpaintingPyramidUniformCBV->writeToGPU(commandList, &ipUniformData, sizeof(ipUniformData));
+}
+
+// See ffxFrameInterpolationPrepare().
 // Generate FSR3 upscaler resources.
 void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
 	// #todo-fsr3-framegen: Dispatch reconstructAndDilatePipeline
+	// Texture2D<float4> r_input_motion_vectors (FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_MOTION_VECTORS)
+	// Texture2D<float> r_input_depth (FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_DEPTH)
+	// RWTexture2D<uint> rw_reconstructed_depth_previous_frame (FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME)
+	// RWTexture2D<float2> rw_dilated_motion_vectors (FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_MOTION_VECTORS)
+	// RWTexture2D<float> rw_dilated_depth (FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_DEPTH)
+	// cbuffer cbFI (FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION)
 }
 
 // See ffxFrameInterpolationDispatch.
@@ -138,7 +198,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		.interpolationRectBase      = { 0, 0 },
 		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
 		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
-		.backBufferTransferFunction = passInput.backBufferTransferFunction,
+		.backBufferTransferFunction = (uint32)passInput.backBufferTransferFunction,
 		.minMaxLuminance            = { 0.0f, 65000.0f }, // #todo-fsr: minMaxLuminance
 		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
 		._pad1                      = 0,
@@ -161,7 +221,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	// #todo-fsr3-framegen: Dispatch setupPipeline (renderDispatchSizeX/Y)
 	// #todo-fsr3-framegen: Dispatch gameVectorFieldInpaintingPyramidPipeline
 
-	if (uniformData.reset == 0)
+	if (passInput.bReset)
 	{
 		// #todo-fsr3-framegen: Clear estimated depth resources
 		// ...
@@ -191,4 +251,14 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	}
 
 	// #todo-fsr3-framegen: Store current buffer
+}
+
+ConstantBufferView* FrameGenPass::getCurrentFrameInterpUniformCBV()
+{
+	return frameInterpDescriptor.getUniformCBV(cpuFrameIndex);
+}
+
+ConstantBufferView* FrameGenPass::getCurrentInpaintingPyramidUniformCBV()
+{
+	return inpaintingPyramidDescriptor.getUniformCBV(cpuFrameIndex);
 }

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -34,7 +34,7 @@ struct FrameInterpUniform
 
 	float           opticalFlowScale[2];
 	int32           opticalFlowBlockSize;
-	uint32          dispatchFlags; // #wip: FfxFrameInterpolationDispatchFlags (FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_TEAR_LINES, FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_VIEW)
+	uint32          dispatchFlags;
 
 	int32           maxRenderSize[2];
 	int32           opticalFlowHalfResMode;

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -211,6 +211,30 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			|| texture->getCreateParams().height != height;
 	};
 
+	auto createAllMipsSRV = [device = device](Texture* texture) -> UniquePtr<ShaderResourceView> {
+		return UniquePtr<ShaderResourceView>(device->createSRV(texture,
+			ShaderResourceViewDesc{
+				.format        = texture->getCreateParams().format,
+				.viewDimension = ESRVDimension::Texture2D,
+				.texture2D     = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = texture->getCreateParams().mipLevels,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
+	};
+	auto createSingleMipUAV = [device = device](Texture* texture, uint32 mip) -> UniquePtr<UnorderedAccessView> {
+		return UniquePtr<UnorderedAccessView>(device->createUAV(texture,
+			UnorderedAccessViewDesc{
+				.format         = texture->getCreateParams().format,
+				.viewDimension  = EUAVDimension::Texture2D,
+				.texture2D      = Texture2DUAVDesc{ .mipSlice = mip, .planeSlice = 0 },
+			}
+		));
+	};
+
 	for (size_t i = 0; i < reconstructedPrevDepthTextures.size(); ++i)
 	{
 		if (nullOrWrongSize(reconstructedPrevDepthTextures[i], passInput.displaySizeX, passInput.displaySizeY))
@@ -229,27 +253,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_ReconstructedPrevDepth_%u", (uint32)i);
 			reconstructedPrevDepthTextures[i]->setDebugName(debugName);
 
-			reconstructedPrevDepthSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
-				reconstructedPrevDepthTextures[i].get(),
-				ShaderResourceViewDesc{
-					.format              = reconstructedPrevDepthTextures[i]->getCreateParams().format,
-					.viewDimension       = ESRVDimension::Texture2D,
-					.texture2D           = Texture2DSRVDesc{
-						.mostDetailedMip = 0,
-						.mipLevels       = 1,
-						.planeSlice      = 0,
-						.minLODClamp     = 0.0f,
-					},
-				}
-			));
-			reconstructedPrevDepthUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
-				reconstructedPrevDepthTextures[i].get(),
-				UnorderedAccessViewDesc{
-					.format         = reconstructedPrevDepthTextures[i]->getCreateParams().format,
-					.viewDimension  = EUAVDimension::Texture2D,
-					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-				}
-			));
+			reconstructedPrevDepthSRVs[i] = createAllMipsSRV(reconstructedPrevDepthTextures[i].get());
+			reconstructedPrevDepthUAVs[i] = createSingleMipUAV(reconstructedPrevDepthTextures[i].get(), 0);
 		}
 	}
 
@@ -266,27 +271,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		reconstructedDepthInterpolatedFrameTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		reconstructedDepthInterpolatedFrameTexture->setDebugName(L"RT_FSR3_ReconstructedDepthInterpolatedFrame");
 
-		reconstructedDepthInterpolatedFrameSRV = UniquePtr<ShaderResourceView>(device->createSRV(
-			reconstructedDepthInterpolatedFrameTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = reconstructedDepthInterpolatedFrameTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = 1,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
-		reconstructedDepthInterpolatedFrameUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
-			reconstructedDepthInterpolatedFrameTexture.get(),
-			UnorderedAccessViewDesc{
-				.format         = reconstructedDepthInterpolatedFrameTexture->getCreateParams().format,
-				.viewDimension  = EUAVDimension::Texture2D,
-				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-			}
-		));
+		reconstructedDepthInterpolatedFrameSRV = createAllMipsSRV(reconstructedDepthInterpolatedFrameTexture.get());
+		reconstructedDepthInterpolatedFrameUAV = createSingleMipUAV(reconstructedDepthInterpolatedFrameTexture.get(), 0);
 	}
 
 	for (size_t i = 0; i < dilatedMotionVectorTextures.size(); ++i)
@@ -307,27 +293,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_DilatedMotionVector_%u", (uint32)i);
 			dilatedMotionVectorTextures[i]->setDebugName(debugName);
 			
-			dilatedMotionVectorSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
-				dilatedMotionVectorTextures[i].get(),
-				ShaderResourceViewDesc{
-					.format              = dilatedMotionVectorTextures[i]->getCreateParams().format,
-					.viewDimension       = ESRVDimension::Texture2D,
-					.texture2D           = Texture2DSRVDesc{
-						.mostDetailedMip = 0,
-						.mipLevels       = 1,
-						.planeSlice      = 0,
-						.minLODClamp     = 0.0f,
-					},
-				}
-			));
-			dilatedMotionVectorUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
-				dilatedMotionVectorTextures[i].get(),
-				UnorderedAccessViewDesc{
-					.format         = dilatedMotionVectorTextures[i]->getCreateParams().format,
-					.viewDimension  = EUAVDimension::Texture2D,
-					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-				}
-			));
+			dilatedMotionVectorSRVs[i] = createAllMipsSRV(dilatedMotionVectorTextures[i].get());
+			dilatedMotionVectorUAVs[i] = createSingleMipUAV(dilatedMotionVectorTextures[i].get(), 0);
 		}
 	}
 
@@ -349,27 +316,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_DilatedDepth_%u", (uint32)i);
 			dilatedDepthTextures[i]->setDebugName(debugName);
 			
-			dilatedDepthSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
-				dilatedDepthTextures[i].get(),
-				ShaderResourceViewDesc{
-					.format              = dilatedDepthTextures[i]->getCreateParams().format,
-					.viewDimension       = ESRVDimension::Texture2D,
-					.texture2D           = Texture2DSRVDesc{
-						.mostDetailedMip = 0,
-						.mipLevels       = 1,
-						.planeSlice      = 0,
-						.minLODClamp     = 0.0f,
-					},
-				}
-			));
-			dilatedDepthUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
-				dilatedDepthTextures[i].get(),
-				UnorderedAccessViewDesc{
-					.format         = dilatedDepthTextures[i]->getCreateParams().format,
-					.viewDimension  = EUAVDimension::Texture2D,
-					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-				}
-			));
+			dilatedDepthSRVs[i] = createAllMipsSRV(dilatedDepthTextures[i].get());
+			dilatedDepthUAVs[i] = createSingleMipUAV(dilatedDepthTextures[i].get(), 0);
 		}
 	}
 
@@ -391,27 +339,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_GameMotionVectorField_%s", i == 0 ? L"X" : L"Y");
 			gameMotionVectorFieldTextures[i]->setDebugName(debugName);
 
-			gameMotionVectorFieldSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
-				gameMotionVectorFieldTextures[i].get(),
-				ShaderResourceViewDesc{
-					.format              = gameMotionVectorFieldTextures[i]->getCreateParams().format,
-					.viewDimension       = ESRVDimension::Texture2D,
-					.texture2D           = Texture2DSRVDesc{
-						.mostDetailedMip = 0,
-						.mipLevels       = 1,
-						.planeSlice      = 0,
-						.minLODClamp     = 0.0f,
-					},
-				}
-			));
-			gameMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
-				gameMotionVectorFieldTextures[i].get(),
-				UnorderedAccessViewDesc{
-					.format         = gameMotionVectorFieldTextures[i]->getCreateParams().format,
-					.viewDimension  = EUAVDimension::Texture2D,
-					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-				}
-			));
+			gameMotionVectorFieldSRVs[i] = createAllMipsSRV(gameMotionVectorFieldTextures[i].get());
+			gameMotionVectorFieldUAVs[i] = createSingleMipUAV(gameMotionVectorFieldTextures[i].get(), 0);
 		}
 	}
 
@@ -435,27 +364,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_OpticalFlowMotionVectorField_%s", i == 0 ? L"X" : L"Y");
 			opticalFlowMotionVectorFieldTextures[i]->setDebugName(debugName);
 
-			opticalFlowMotionVectorFieldSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
-				opticalFlowMotionVectorFieldTextures[i].get(),
-				ShaderResourceViewDesc{
-					.format              = opticalFlowMotionVectorFieldTextures[i]->getCreateParams().format,
-					.viewDimension       = ESRVDimension::Texture2D,
-					.texture2D           = Texture2DSRVDesc{
-						.mostDetailedMip = 0,
-						.mipLevels       = 1,
-						.planeSlice      = 0,
-						.minLODClamp     = 0.0f,
-					},
-				}
-			));
-			opticalFlowMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
-				opticalFlowMotionVectorFieldTextures[i].get(),
-				UnorderedAccessViewDesc{
-					.format         = opticalFlowMotionVectorFieldTextures[i]->getCreateParams().format,
-					.viewDimension  = EUAVDimension::Texture2D,
-					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-				}
-			));
+			opticalFlowMotionVectorFieldSRVs[i] = createAllMipsSRV(opticalFlowMotionVectorFieldTextures[i].get());
+			opticalFlowMotionVectorFieldUAVs[i] = createSingleMipUAV(opticalFlowMotionVectorFieldTextures[i].get(), 0);
 		}
 	}
 
@@ -472,27 +382,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		disocclusionMaskTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		disocclusionMaskTexture->setDebugName(L"RT_FSR3_DisocclusionMask");
 
-		disocclusionMaskSRV = UniquePtr<ShaderResourceView>(device->createSRV(
-			disocclusionMaskTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = disocclusionMaskTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = 1,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
-		disocclusionMaskUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
-			disocclusionMaskTexture.get(),
-			UnorderedAccessViewDesc{
-				.format         = disocclusionMaskTexture->getCreateParams().format,
-				.viewDimension  = EUAVDimension::Texture2D,
-				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-			}
-		));
+		disocclusionMaskSRV = createAllMipsSRV(disocclusionMaskTexture.get());
+		disocclusionMaskUAV = createSingleMipUAV(disocclusionMaskTexture.get(), 0);
 	}
 
 	// 2 uints. See COUNTER_SPD and COUNTER_FRAME_INDEX_SINCE_LAST_RESET.
@@ -542,19 +433,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		defaultDistortionFieldTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		defaultDistortionFieldTexture->setDebugName(L"RT_FSR3_DefaultDistortionField");
 		
-		defaultDistortionFieldSRV = UniquePtr<ShaderResourceView>(device->createSRV(
-			defaultDistortionFieldTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = defaultDistortionFieldTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = 1,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
+		defaultDistortionFieldSRV = createAllMipsSRV(defaultDistortionFieldTexture.get());
 	}
 
 	if (nullOrWrongSize(prevInterpolationSourceTexture, passInput.displaySizeX, passInput.displaySizeY))
@@ -570,27 +449,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		prevInterpolationSourceTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		prevInterpolationSourceTexture->setDebugName(L"RT_FSR3_PrevInterpolationSource");
 		
-		prevInterpolationSourceSRV = UniquePtr<ShaderResourceView>(device->createSRV(
-			prevInterpolationSourceTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = prevInterpolationSourceTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = 1,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
-		prevInterpolationSourceUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
-			prevInterpolationSourceTexture.get(),
-			UnorderedAccessViewDesc{
-				.format         = prevInterpolationSourceTexture->getCreateParams().format,
-				.viewDimension  = EUAVDimension::Texture2D,
-				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-			}
-		));
+		prevInterpolationSourceSRV = createAllMipsSRV(prevInterpolationSourceTexture.get());
+		prevInterpolationSourceUAV = createSingleMipUAV(prevInterpolationSourceTexture.get(), 0);
 	}
 
 	const uint32 inpaintingPyramidSizeX = passInput.displaySizeX / 2;
@@ -598,6 +458,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 	if (nullOrWrongSize(inpaintingPyramidTexture, inpaintingPyramidSizeX, inpaintingPyramidSizeY))
 	{
 		commandList->enqueueDeferredDealloc(inpaintingPyramidTexture.release(), true);
+		commandList->enqueueDeferredDealloc(inpaintingPyramidSRV.release(), true);
 		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
 		{
 			commandList->enqueueDeferredDealloc(inpaintingPyramidUAVs[i].release(), true);
@@ -612,30 +473,10 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		inpaintingPyramidTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		inpaintingPyramidTexture->setDebugName(L"RT_FSR3_InpaintingPyramidTexture");
 
-		inpaintingPyramidSRV = UniquePtr<ShaderResourceView>(device->createSRV(
-			inpaintingPyramidTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = inpaintingPyramidTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = inpaintingPyramidTexture->getCreateParams().mipLevels,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
-		
+		inpaintingPyramidSRV = createAllMipsSRV(inpaintingPyramidTexture.get());
 		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
 		{
-			inpaintingPyramidUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
-				inpaintingPyramidTexture.get(),
-				UnorderedAccessViewDesc{
-					.format         = inpaintingPyramidTexture->getCreateParams().format,
-					.viewDimension  = EUAVDimension::Texture2D,
-					.texture2D      = Texture2DUAVDesc{ .mipSlice = (uint32)i, .planeSlice = 0 },
-				}
-			));
+			inpaintingPyramidUAVs[i] = createSingleMipUAV(inpaintingPyramidTexture.get(), (uint32)i);
 		}
 	}
 
@@ -659,19 +500,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		opticalFlowConfidenceTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		opticalFlowConfidenceTexture->setDebugName(L"RT_FSR3_OpticalFlowConfidence");
 
-		opticalFlowConfidenceSRV = UniquePtr<ShaderResourceView>(device->createSRV(
-			opticalFlowConfidenceTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = opticalFlowConfidenceTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = 1,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
+		opticalFlowConfidenceSRV = createAllMipsSRV(opticalFlowConfidenceTexture.get());
 	}
 
 	if (nullOrWrongSize(interpolationOutputTexture, passInput.displaySizeX, passInput.displaySizeY))
@@ -687,27 +516,8 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		interpolationOutputTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		interpolationOutputTexture->setDebugName(L"RT_FSR3_InterpolationOutput");
 		
-		interpolationOutputSRV = UniquePtr<ShaderResourceView>(device->createSRV(
-			interpolationOutputTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = interpolationOutputTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = 1,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
-		interpolationOutputUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
-			interpolationOutputTexture.get(),
-			UnorderedAccessViewDesc{
-				.format         = interpolationOutputTexture->getCreateParams().format,
-				.viewDimension  = EUAVDimension::Texture2D,
-				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-			}
-		));
+		interpolationOutputSRV = createAllMipsSRV(interpolationOutputTexture.get());
+		interpolationOutputUAV = createSingleMipUAV(interpolationOutputTexture.get(), 0);
 	}
 }
 

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -1,6 +1,56 @@
 #include "frame_gen_pass.h"
 #include "rhi/render_device.h"
 
+// FFX_DECLARE_CB(FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION)
+struct FrameInterpUniform
+{
+	int32           renderSize[2];
+	int32           displaySize[2];
+
+	float           displaySizeRcp[2];
+	float           cameraNear;
+	float           cameraFar;
+
+	int32           upscalerTargetSize[2];
+	int32           Mode;
+	int32           reset;
+
+	float           fDeviceToViewDepth[4];
+
+	float           deltaTime;
+	int32           HUDLessAttachedFactor;
+	int32           distortionFieldSize[2];
+
+	float           opticalFlowScale[2];
+	int32           opticalFlowBlockSize;
+	uint32          dispatchFlags;
+
+	int32           maxRenderSize[2];
+	int32           opticalFlowHalfResMode;
+	int32           NumInstances;
+
+	int32           interpolationRectBase[2];
+	int32           interpolationRectSize[2];
+
+	float           debugBarColor[3];
+	uint32          backBufferTransferFunction;
+
+	float           minMaxLuminance[2];
+	float           fTanHalfFOV;
+	int32           _pad1;
+
+	float           fJitter[2];
+	float           fMotionVectorScale[2];
+};
+
+// FFX_DECLARE_CB(FFX_FRAMEINTERPOLATION_BIND_CB_INPAINTING_PYRAMID)
+struct InpaintingPyramidUniform
+{
+	uint32          mips;
+	uint32          numWorkGroups;
+	uint32          workGroupOffset[2];
+};
+
 void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 {
 	device = inRenderDevice;
@@ -17,9 +67,8 @@ void FrameGenPass::initializePipelines()
 {
 	const uint32 swapchainCount = device->maxFramesInFlight();
 
-	// #todo-fsr3: VolatileDescriptorHelperfor for cbuffers:
-	// FFX_DECLARE_CB(FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION)
-	// FFX_DECLARE_CB(FFX_FRAMEINTERPOLATION_BIND_CB_INPAINTING_PYRAMID)
+	frameInterpDescriptor.initialize(L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
+	inpaintingPyramidDescriptor.initialize(L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
 
 	// reconstructAndDilatePipeline
 	{

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -1,4 +1,6 @@
 #include "frame_gen_pass.h"
+#include "render/util/clear_resource_pass.h"
+#include "rhi/rhi_policy.h"
 #include "rhi/render_device.h"
 #include "rhi/render_command.h"
 #include "world/camera.h"
@@ -94,6 +96,7 @@ void FrameGenPass::initializePipelines()
 {
 	const uint32 swapchainCount = 2;//device->maxFramesInFlight(); // Always need 2
 
+	prepareDescriptor.initialize(L"FSR3_Prepare", swapchainCount, 0);
 	frameInterpDescriptor.initialize(L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
 	inpaintingPyramidDescriptor.initialize(L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
 
@@ -315,13 +318,51 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 // Generate FSR3 upscaler resources.
 void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
-	// #wip: Dispatch reconstructAndDilatePipeline
-	// Texture2D<float4> r_input_motion_vectors (FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_MOTION_VECTORS)
-	// Texture2D<float> r_input_depth (FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_DEPTH)
-	// RWTexture2D<uint> rw_reconstructed_depth_previous_frame (FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME)
-	// RWTexture2D<float2> rw_dilated_motion_vectors (FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_MOTION_VECTORS)
-	// RWTexture2D<float> rw_dilated_depth (FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_DEPTH)
-	// cbuffer cbFI (FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION)
+	SCOPED_DRAW_EVENT(commandList, FrameGenPrepare);
+
+	const uint32 currResourceIndex = (cpuFrameIndex & 1);
+	const uint32 prevResourceIndex = ((cpuFrameIndex + 1) & 1);
+
+	auto uniformCBV = getCurrentFrameInterpUniformCBV();
+	auto reconstructedPrevDepthTexture = reconstructedPrevDepthTextures[currResourceIndex].get();
+	auto reconstructedPrevDepthUAV = reconstructedPrevDepthUAVs[currResourceIndex].get();
+	auto dilatedMotionVectorTexture = dilatedMotionVectorTextures[currResourceIndex].get();
+	auto dilatedMotionVectorUAV = dilatedMotionVectorUAVs[currResourceIndex].get();
+	auto dilatedDepthTexture = dilatedDepthTextures[currResourceIndex].get();
+	auto dilatedDepthUAV = dilatedDepthUAVs[currResourceIndex].get();
+
+	// Clear estimated depth resources.
+	auto fClearZero = ClearResourcePass::floatClearValue(getDeviceFarDepth(), 0, 0, 0);
+	passInput.clearResourcePass->enqueueClear(reconstructedPrevDepthTexture, reconstructedPrevDepthUAV, fClearZero);
+	passInput.clearResourcePass->executeClears(commandList, swapchainIndex);
+
+	TextureBarrierAuto textureBarriers[] = {
+		TextureBarrierAuto::toShaderResource(passInput.motionVectorTexture, EBarrierSync::COMPUTE_SHADING),
+		TextureBarrierAuto::toShaderResource(passInput.sceneDepthTexture, EBarrierSync::COMPUTE_SHADING),
+		TextureBarrierAuto::toUnorderedAccess(reconstructedPrevDepthTexture, EBarrierSync::COMPUTE_SHADING),
+		TextureBarrierAuto::toUnorderedAccess(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
+		TextureBarrierAuto::toUnorderedAccess(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+	};
+	commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+	ShaderParameterTable SPT{};
+	SPT.constantBuffer("cbFI", uniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+	SPT.texture("r_input_motion_vectors", passInput.motionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_MOTION_VECTORS
+	SPT.texture("r_input_depth", passInput.sceneDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_DEPTH
+	SPT.rwTexture("rw_reconstructed_depth_previous_frame", reconstructedPrevDepthUAV); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME
+	SPT.rwTexture("rw_dilated_motion_vectors", dilatedMotionVectorUAV); // FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_MOTION_VECTORS
+	SPT.rwTexture("rw_dilated_depth", dilatedDepthUAV); // FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_DEPTH
+
+	prepareDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+	auto descriptorHeap = prepareDescriptor.getDescriptorHeap(swapchainIndex);
+	auto pipeline = reconstructAndDilatePipeline.get();
+
+	commandList->setComputePipelineState(pipeline);
+	commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+	uint32 dispatchX = (passInput.renderSizeX + 7) / 8;
+	uint32 dispatchY = (passInput.renderSizeY + 7) / 8;
+	commandList->dispatchCompute(dispatchX, dispatchY, 1);
 }
 
 // See ffxFrameInterpolationDispatch.

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -299,8 +299,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 			TextureCreateParams texDesc = TextureCreateParams::texture2D(
 				EPixelFormat::R16G16_FLOAT,
-				// #wip: (FFX_RESOURCE_USAGE_RENDERTARGET | FFX_RESOURCE_USAGE_UAV | FFX_RESOURCE_USAGE_DCC_RENDERTARGET) ???
-				ETextureAccessFlags::RTV | ETextureAccessFlags::UAV,
+				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 				passInput.displaySizeX, passInput.displaySizeY);
 			dilatedMotionVectorTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
@@ -342,8 +341,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 			TextureCreateParams texDesc = TextureCreateParams::texture2D(
 				EPixelFormat::R32_FLOAT,
-				// #wip: (FFX_RESOURCE_USAGE_RENDERTARGET | FFX_RESOURCE_USAGE_UAV | FFX_RESOURCE_USAGE_DCC_RENDERTARGET) ???
-				ETextureAccessFlags::RTV | ETextureAccessFlags::UAV,
+				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 				passInput.displaySizeX, passInput.displaySizeY);
 			dilatedDepthTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
@@ -385,7 +383,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 			TextureCreateParams texDesc = TextureCreateParams::texture2D(
 				EPixelFormat::R32_UINT,
-				ETextureAccessFlags::UAV,
+				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 				passInput.displaySizeX, passInput.displaySizeY);
 			gameMotionVectorFieldTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
@@ -419,17 +417,18 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 	for (uint32 i = 0; i < 2; ++i)
 	{
-		if (nullOrWrongSize(opticalFlowMotionVectorFieldTextures[i], passInput.displaySizeX, passInput.displaySizeY))
+		const uint32 targetSizeX = (passInput.displaySizeX + 7) / 8;
+		const uint32 targetSizeY = (passInput.displaySizeY + 7) / 8;
+		if (nullOrWrongSize(opticalFlowMotionVectorFieldTextures[i], targetSizeX, targetSizeY))
 		{
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldTextures[i].release(), true);
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldSRVs[i].release(), true);
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldUAVs[i].release(), true);
 
-			// #wip: Too big? (xy + 7) / 8 is enough?
 			TextureCreateParams texDesc = TextureCreateParams::texture2D(
 				EPixelFormat::R32_UINT,
-				ETextureAccessFlags::UAV,
-				passInput.displaySizeX, passInput.displaySizeY);
+				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+				targetSizeX, targetSizeY);
 			opticalFlowMotionVectorFieldTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
 			wchar_t debugName[128];
@@ -468,7 +467,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 		TextureCreateParams texDesc = TextureCreateParams::texture2D(
 			EPixelFormat::R8G8_UNORM,
-			ETextureAccessFlags::UAV,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 			passInput.displaySizeX, passInput.displaySizeY);
 		disocclusionMaskTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		disocclusionMaskTexture->setDebugName(L"RT_FSR3_DisocclusionMask");
@@ -594,7 +593,9 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		));
 	}
 
-	if (nullOrWrongSize(inpaintingPyramidTexture, passInput.displaySizeX, passInput.displaySizeY))
+	const uint32 inpaintingPyramidSizeX = passInput.displaySizeX / 2;
+	const uint32 inpaintingPyramidSizeY = passInput.displaySizeY / 2;
+	if (nullOrWrongSize(inpaintingPyramidTexture, inpaintingPyramidSizeX, inpaintingPyramidSizeY))
 	{
 		commandList->enqueueDeferredDealloc(inpaintingPyramidTexture.release(), true);
 		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
@@ -604,9 +605,9 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 		TextureCreateParams texDesc = TextureCreateParams::texture2D(
 			EPixelFormat::R16G16B16A16_FLOAT,
-			ETextureAccessFlags::UAV,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 			// #wip: What if inpaintingPyramid is not large enough to contain 13 mips?
-			passInput.displaySizeX / 2, passInput.displaySizeY / 2, _countof(inpaintingPyramidUAVs));
+			inpaintingPyramidSizeX, inpaintingPyramidSizeY, _countof(inpaintingPyramidUAVs));
 
 		inpaintingPyramidTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		inpaintingPyramidTexture->setDebugName(L"RT_FSR3_InpaintingPyramidTexture");

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -104,6 +104,7 @@ void FrameGenPass::initializePipelines()
 	reconstructPrevDepthDescriptor.initialize(device, L"FSR3_ReconstructPrevDepth", swapchainCount, 0);
 	gameMotionVectorFieldDescriptor.initialize(device, L"FSR3_GameMotionVectorField", swapchainCount, 0);
 	gameMotionVectorFieldInpaintingPyramidDescriptor.initialize(device, L"FSR3_GameMotionVectorFieldInpaintingPyramid", swapchainCount, 0);
+	opticalFlowVectorFieldDescriptor.initialize(device, L"FSR3_OpticalFlowVectorField", swapchainCount, 0);
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -751,6 +752,9 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		Texture* dilatedDepthTexture = dilatedDepthTextures[currResourceIndex].get();
 		ShaderResourceView* dilatedDepthSRV = dilatedDepthSRVs[currResourceIndex].get();
 
+		Texture* currInterpolationSourceTexture = passInput.sceneColorTexture;
+		ShaderResourceView* currInterpolationSourceSRV = passInput.sceneColorSRV;
+
 		{
 			SCOPED_DRAW_EVENT(commandList, ReconstructDepthPrevFrame);
 
@@ -760,7 +764,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			TextureBarrierAuto textureBarriers[] = {
 				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(passInput.sceneColorTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toUnorderedAccess(reconstructedDepthInterpolatedFrameTexture.get(), EBarrierSync::COMPUTE_SHADING),
 			};
@@ -771,7 +775,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
 			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			// #wip: not used but declared in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
-			SPT.texture("r_current_interpolation_source", passInput.sceneColorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
 			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
 			SPT.rwTexture("rw_reconstructed_depth_interpolated_frame", reconstructedDepthInterpolatedFrameUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_INTERPOLATED_FRAME
 
@@ -793,7 +797,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(prevInterpolationSourceTexture.get(), EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(passInput.sceneColorTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
@@ -805,7 +809,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
 			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			SPT.texture("r_previous_interpolation_source", prevInterpolationSourceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_PREVIOUS_INTERPOLATION_SOURCE
-			SPT.texture("r_current_interpolation_source", passInput.sceneColorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
 			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
 			SPT.rwTexture("rw_game_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
 			SPT.rwTexture("rw_game_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
@@ -821,7 +825,47 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		scheduleDispatchGameVectorFieldInpaintingPyramid();
 
 		// #wip: Dispatch opticalFlowVectorFieldPipeline
+#if 0
+		{
+			SCOPED_DRAW_EVENT(commandList, OpticalFlowVectorField);
+
+			auto pipeline = opticalFlowVectorFieldPipeline.get();
+			auto& passDescriptor = opticalFlowVectorFieldDescriptor;
+
+			TextureBarrierAuto textureBarriers[] = {
+				TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->opticalFlowVectorTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(opticalFlowConfidenceTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(prevInterpolationSourceTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			};
+			commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+			ShaderParameterTable SPT{};
+			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+			SPT.texture("r_optical_flow", passInput.opticalFlowPassOutput->opticalFlowVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW
+			SPT.texture("r_optical_flow_confidence", opticalFlowConfidenceSRV/*uint2*/); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_CONFIDENCE
+			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_previous_interpolation_source", prevInterpolationSourceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_PREVIOUS_INTERPOLATION_SOURCE
+			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+			SPT.rwTexture("rw_optical_flow_motion_vector_field_x", opticalFlowMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
+			SPT.rwTexture("rw_optical_flow_motion_vector_field_y", opticalFlowMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
+
+			auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+			commandList->setComputePipelineState(pipeline);
+			commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
+		}
+#endif
+
 		// #wip: Dispatch disocclusionMaskPipeline
+		{
+			//
+		}
 	}
 
 	// #wip: Dispatch interpolationPipeline (pipelineFiScfi in ffx)

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -159,6 +159,7 @@ void FrameGenPass::initializePipelines()
 	gameMotionVectorFieldInpaintingPyramidDescriptor.initialize(device, L"FSR3_GameMotionVectorFieldInpaintingPyramid", swapchainCount, 0);
 	opticalFlowVectorFieldDescriptor.initialize(device, L"FSR3_OpticalFlowVectorField", swapchainCount, 0);
 	disocclusionMaskDescriptor.initialize(device, L"FSR3_DisocclusionMask", swapchainCount, 0);
+	interpolationDescriptor.initialize(device, L"FSR3_Interpolation", swapchainCount, 0);
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -413,6 +414,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		if (nullOrWrongSize(opticalFlowMotionVectorFieldTextures[i], passInput.displaySizeX, passInput.displaySizeY))
 		{
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldTextures[i].release(), true);
+			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldSRVs[i].release(), true);
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldUAVs[i].release(), true);
 
 			// #wip: Too big? (xy + 7) / 8 is enough?
@@ -426,6 +428,19 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_OpticalFlowMotionVectorField_%s", i == 0 ? L"X" : L"Y");
 			opticalFlowMotionVectorFieldTextures[i]->setDebugName(debugName);
 
+			opticalFlowMotionVectorFieldSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
+				opticalFlowMotionVectorFieldTextures[i].get(),
+				ShaderResourceViewDesc{
+					.format              = opticalFlowMotionVectorFieldTextures[i]->getCreateParams().format,
+					.viewDimension       = ESRVDimension::Texture2D,
+					.texture2D           = Texture2DSRVDesc{
+						.mostDetailedMip = 0,
+						.mipLevels       = 1,
+						.planeSlice      = 0,
+						.minLODClamp     = 0.0f,
+					},
+				}
+			));
 			opticalFlowMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
 				opticalFlowMotionVectorFieldTextures[i].get(),
 				UnorderedAccessViewDesc{
@@ -440,6 +455,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 	if (nullOrWrongSize(disocclusionMaskTexture, passInput.displaySizeX, passInput.displaySizeY))
 	{
 		commandList->enqueueDeferredDealloc(disocclusionMaskTexture.release(), true);
+		commandList->enqueueDeferredDealloc(disocclusionMaskSRV.release(), true);
 		commandList->enqueueDeferredDealloc(disocclusionMaskUAV.release(), true);
 
 		TextureCreateParams texDesc = TextureCreateParams::texture2D(
@@ -449,6 +465,19 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		disocclusionMaskTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		disocclusionMaskTexture->setDebugName(L"RT_FSR3_DisocclusionMask");
 
+		disocclusionMaskSRV = UniquePtr<ShaderResourceView>(device->createSRV(
+			disocclusionMaskTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = disocclusionMaskTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = 1,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
 		disocclusionMaskUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
 			disocclusionMaskTexture.get(),
 			UnorderedAccessViewDesc{
@@ -471,6 +500,18 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		));
 		counterBuffer->setDebugName(L"Buffer_FSR3_Counter");
 
+		counterSRV = UniquePtr<ShaderResourceView>(device->createSRV(counterBuffer.get(),
+			ShaderResourceViewDesc{
+				.format        = EPixelFormat::UNKNOWN,
+				.viewDimension = ESRVDimension::Buffer,
+				.buffer        = BufferSRVDesc{
+					.firstElement        = 0,
+					.numElements         = 2,
+					.structureByteStride = sizeof(uint32),
+					.flags               = EBufferSRVFlags::None,
+				}
+			}
+		));
 		counterUAV = UniquePtr<UnorderedAccessView>(device->createUAV(counterBuffer.get(),
 			UnorderedAccessViewDesc{
 				.format        = EPixelFormat::UNKNOWN,
@@ -623,6 +664,42 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			}
 		));
 	}
+
+	if (nullOrWrongSize(interpolationOutputTexture, passInput.displaySizeX, passInput.displaySizeY))
+	{
+		commandList->enqueueDeferredDealloc(interpolationOutputTexture.release(), true);
+		commandList->enqueueDeferredDealloc(interpolationOutputSRV.release(), true);
+		commandList->enqueueDeferredDealloc(interpolationOutputUAV.release(), true);
+
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			PF_sceneColor,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		interpolationOutputTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		interpolationOutputTexture->setDebugName(L"RT_FSR3_InterpolationOutput");
+		
+		interpolationOutputSRV = UniquePtr<ShaderResourceView>(device->createSRV(
+			interpolationOutputTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = interpolationOutputTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = 1,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
+		interpolationOutputUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
+			interpolationOutputTexture.get(),
+			UnorderedAccessViewDesc{
+				.format         = interpolationOutputTexture->getCreateParams().format,
+				.viewDimension  = EUAVDimension::Texture2D,
+				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+			}
+		));
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -756,6 +833,22 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 	const bool bExecutePreparationPasses = (false == bReset);
 
+	// #wip: distortion field texture from passInput
+	auto distortionFieldTexture            = defaultDistortionFieldTexture.get();
+	auto distortionFieldSRV                = defaultDistortionFieldSRV.get();
+
+	auto reconstructedPrevDepthTexture     = reconstructedPrevDepthTextures[currResourceIndex].get();
+	auto reconstructedPrevDepthSRV         = reconstructedPrevDepthSRVs[currResourceIndex].get();
+	auto reconstructedPrevDepthUAV         = reconstructedPrevDepthUAVs[currResourceIndex].get();
+	auto dilatedMotionVectorTexture        = dilatedMotionVectorTextures[currResourceIndex].get();
+	auto dilatedMotionVectorSRV            = dilatedMotionVectorSRVs[currResourceIndex].get();
+	auto dilatedMotionVectorUAV            = dilatedMotionVectorUAVs[currResourceIndex].get();
+	auto dilatedDepthTexture               = dilatedDepthTextures[currResourceIndex].get();
+	auto dilatedDepthSRV                   = dilatedDepthSRVs[currResourceIndex].get();
+	auto dilatedDepthUAV                   = dilatedDepthUAVs[currResourceIndex].get();
+	auto currInterpolationSourceTexture    = passInput.sceneColorTexture;
+	auto currInterpolationSourceSRV        = passInput.sceneColorSRV;
+
 	{
 		SCOPED_DRAW_EVENT(commandList, Setup);
 
@@ -847,22 +940,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			reconstructedDepthInterpolatedFrameUAV.get(),
 			ClearResourcePass::floatClearValue(zFar, zFar, zFar, zFar));
 		passInput.clearResourcePass->executeClears(commandList, swapchainIndex);
-
-		// #wip: distortion field texture from passInput
-		Texture* distortionFieldTexture = defaultDistortionFieldTexture.get();
-		ShaderResourceView* distortionFieldSRV = defaultDistortionFieldSRV.get();
-
-		auto reconstructedPrevDepthTexture = reconstructedPrevDepthTextures[currResourceIndex].get();
-		auto reconstructedPrevDepthSRV = reconstructedPrevDepthSRVs[currResourceIndex].get();
-		auto reconstructedPrevDepthUAV = reconstructedPrevDepthUAVs[currResourceIndex].get();
-		auto dilatedMotionVectorTexture = dilatedMotionVectorTextures[currResourceIndex].get();
-		auto dilatedMotionVectorSRV = dilatedMotionVectorSRVs[currResourceIndex].get();
-		auto dilatedMotionVectorUAV = dilatedMotionVectorUAVs[currResourceIndex].get();
-		auto dilatedDepthTexture = dilatedDepthTextures[currResourceIndex].get();
-		auto dilatedDepthSRV = dilatedDepthSRVs[currResourceIndex].get();
-		auto dilatedDepthUAV = dilatedDepthUAVs[currResourceIndex].get();
-		auto currInterpolationSourceTexture = passInput.sceneColorTexture;
-		auto currInterpolationSourceSRV = passInput.sceneColorSRV;
 
 		{
 			SCOPED_DRAW_EVENT(commandList, ReconstructDepthPrevFrame);
@@ -1006,7 +1083,49 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		}
 	}
 
-	// #wip: Dispatch interpolationPipeline (pipelineFiScfi in ffx)
+	// interpolationPipeline (pipelineFiScfi in ffx)
+	{
+		SCOPED_DRAW_EVENT(commandList, Interpolation);
+
+		auto pipeline = interpolationPipeline.get();
+		auto& passDescriptor = interpolationDescriptor;
+
+		BufferBarrierAuto bufferBarriers[] = {
+			{ EBarrierSync::COMPUTE_SHADING, EBarrierAccess::SHADER_RESOURCE, counterBuffer.get() },
+		};
+		TextureBarrierAuto textureBarriers[] = {
+			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(prevInterpolationSourceTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(disocclusionMaskTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
+		};
+		commandList->barrierAuto(_countof(bufferBarriers), bufferBarriers, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+		ShaderParameterTable SPT{};
+		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		SPT.structuredBuffer("r_counters", counterSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_COUNTERS
+		SPT.texture("r_game_motion_vector_field_x", gameMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_X
+		SPT.texture("r_game_motion_vector_field_y", gameMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_Y
+		SPT.texture("r_optical_flow_motion_vector_field_x", opticalFlowMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
+		SPT.texture("r_optical_flow_motion_vector_field_y", opticalFlowMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
+		SPT.texture("r_previous_interpolation_source", prevInterpolationSourceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_PREVIOUS_INTERPOLATION_SOURCE
+		SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+		SPT.texture("r_disocclusion_mask", disocclusionMaskSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISOCCLUSION_MASK
+		SPT.texture("r_inpainting_pyramid", inpaintingPyramidSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPAINTING_PYRAMID
+		SPT.rwTexture("rw_output", interpolationOutputUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OUTPUT
+
+		auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+		commandList->setComputePipelineState(pipeline);
+		commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
+	}
 
 	// inpainting pyramid
 	{

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -23,15 +23,15 @@ struct FrameInterpUniform
 	int32           Mode;
 	int32           reset;
 
-	float           fDeviceToViewDepth[4]; // #todo-fsr3-framegen: setupDeviceDepthToViewSpaceDepthParams
+	float           fDeviceToViewDepth[4]; // #wip: setupDeviceDepthToViewSpaceDepthParams
 
 	float           deltaTime; // In milliseconds
-	int32           HUDLessAttachedFactor; // 1 or 0 (#todo-fsr3-framegen: Is it for HUD upscaling?)
+	int32           HUDLessAttachedFactor; // 1 or 0 (#wip: Is it for HUD upscaling?)
 	int32           distortionFieldSize[2];
 
 	float           opticalFlowScale[2];
 	int32           opticalFlowBlockSize;
-	uint32          dispatchFlags; // #todo-fsr3-framegen: FfxFrameInterpolationDispatchFlags (FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_TEAR_LINES, FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_VIEW)
+	uint32          dispatchFlags; // #wip: FfxFrameInterpolationDispatchFlags (FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_TEAR_LINES, FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_VIEW)
 
 	int32           maxRenderSize[2];
 	int32           opticalFlowHalfResMode;
@@ -121,27 +121,27 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.displaySizeRcp             = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
 		.cameraNear                 = passInput.camera->getZNear(),
 		.cameraFar                  = passInput.camera->getZFar(),
-		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #todo-fsr3-framegen: upscale target size
-		.Mode                       = 0, // #todo-fsr3-framegen: What is this? No shader accesses it, even ffx source code does not use it.
-		.reset                      = 0, // #todo-fsr3-framegen: reset, see ffxFrameInterpolationDispatch
-		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #todo-fsr3-framegen: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
-		.deltaTime                  = passInput.deltaTime, // #todo-fsr3-framegen: Unit of deltaTime?
+		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #wip: upscale target size
+		.Mode                       = 0, // #wip: What is this? No shader accesses it, even ffx source code does not use it.
+		.reset                      = 0, // #wip: reset, see ffxFrameInterpolationDispatch
+		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #wip: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
+		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
 		.HUDLessAttachedFactor      = 0,
 		.distortionFieldSize        = { 1, 1 },
-		.opticalFlowScale           = { 1.0f, 1.0f }, // #todo-fsr3-framegen: opticalFlowScale
-		.opticalFlowBlockSize       = passInput.opticalFlowBlockSize,
+		.opticalFlowScale           = { 1.0f, 1.0f }, // #wip: opticalFlowScale
+		.opticalFlowBlockSize       = kOpticalFlowBlockSize,
 		.dispatchFlags              = passInput.dispatchFlags,
 		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
-		.opticalFlowHalfResMode     = 0, // #todo-fsr3-framegen: opticalFlowHalfResMode
-		.NumInstances               = 0, // #todo-fsr3-framegen: NumInstances unused?
+		.opticalFlowHalfResMode     = 0, // #wip: opticalFlowHalfResMode
+		.NumInstances               = 0, // #wip: NumInstances unused?
 		.interpolationRectBase      = { 0, 0 },
 		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
 		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
 		.backBufferTransferFunction = (uint32)passInput.backBufferTransferFunction,
-		.minMaxLuminance            = { 0.0f, 65000.0f }, // #todo-fsr: minMaxLuminance
+		.minMaxLuminance            = { 0.0f, 65000.0f }, // #wip: minMaxLuminance
 		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
 		._pad1                      = 0,
-		.fJitter                    = { 0, 0 }, // #todo-fsr3-framegen: jitter
+		.fJitter                    = { 0, 0 }, // #wip: jitter
 		.fMotionVectorScale         = { 1.0f, 1.0f },
 	};
 	frameInterpUniformCBV->writeToGPU(commandList, &fiUniformData, sizeof(fiUniformData));
@@ -164,7 +164,7 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 // Generate FSR3 upscaler resources.
 void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
-	// #todo-fsr3-framegen: Dispatch reconstructAndDilatePipeline
+	// #wip: Dispatch reconstructAndDilatePipeline
 	// Texture2D<float4> r_input_motion_vectors (FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_MOTION_VECTORS)
 	// Texture2D<float> r_input_depth (FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_DEPTH)
 	// RWTexture2D<uint> rw_reconstructed_depth_previous_frame (FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME)
@@ -185,42 +185,42 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	const uint32 renderDispatchSizeX = (passInput.renderSizeX + 7) / 8;
 	const uint32 renderDispatchSizeY = (passInput.renderSizeY + 7) / 8;
 
-	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)passInput.opticalFlowBlockSize + 7) / 8;
-	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)passInput.opticalFlowBlockSize + 7) / 8;
+	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)kOpticalFlowBlockSize + 7) / 8;
+	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)kOpticalFlowBlockSize + 7) / 8;
 
-	// #todo-fsr3-framegen: Dispatch setupPipeline (renderDispatchSizeX/Y)
-	// #todo-fsr3-framegen: Dispatch gameVectorFieldInpaintingPyramidPipeline
+	// #wip: Dispatch setupPipeline (renderDispatchSizeX/Y)
+	// #wip: Dispatch gameVectorFieldInpaintingPyramidPipeline
 
 	if (passInput.bReset)
 	{
-		// #todo-fsr3-framegen: Clear estimated depth resources
+		// #wip: Clear estimated depth resources
 		// ...
 
-		// #todo-fsr3-framegen: Dispatch reconstructPrevDepthPipeline
-		// #todo-fsr3-framegen: Dispatch gameMotionVectorFieldPipeline
+		// #wip: Dispatch reconstructPrevDepthPipeline
+		// #wip: Dispatch gameMotionVectorFieldPipeline
 		
-		// #todo-fsr3-framegen: scheduleDispatchGameVectorFieldInpaintingPyramid()
+		// #wip: scheduleDispatchGameVectorFieldInpaintingPyramid()
 
-		// #todo-fsr3-framegen: Dispatch opticalFlowVectorFieldPipeline
-		// #todo-fsr3-framegen: Dispatch disocclusionMaskPipeline
+		// #wip: Dispatch opticalFlowVectorFieldPipeline
+		// #wip: Dispatch disocclusionMaskPipeline
 	}
 
-	// #todo-fsr3-framegen: Dispatch interpolationPipeline (pipelineFiScfi in ffx)
+	// #wip: Dispatch interpolationPipeline (pipelineFiScfi in ffx)
 
 	// inpainting pyramid
 	{
-		// #todo-fsr3-framegen: Auto exposure via SPD
-		// #todo-fsr3-framegen: Dispatch inpaintingPyramidPipeline
+		// #wip: Auto exposure via SPD
+		// #wip: Dispatch inpaintingPyramidPipeline
 	}
 
-	// #todo-fsr3-framegen: inpaintingPipeline
+	// #wip: inpaintingPipeline
 
 	if (false /* draw debug view */)
 	{
-		// #todo-fsr3-framegen: Dispatch debugViewPipeline
+		// #wip: Dispatch debugViewPipeline
 	}
 
-	// #todo-fsr3-framegen: Store current buffer
+	// #wip: Store current buffer
 }
 
 ConstantBufferView* FrameGenPass::getCurrentFrameInterpUniformCBV()

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -87,7 +87,7 @@ void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swa
 
 	updateUniforms(commandList, passInput);
 	preparePhase(commandList, swapchainIndex, passInput);
-	//dispatchPhase(commandList, swapchainIndex, passInput);
+	dispatchPhase(commandList, swapchainIndex, passInput);
 
 	cpuFrameIndex += 1;
 }
@@ -129,11 +129,15 @@ void FrameGenPass::initializePipelines()
 
 void FrameGenPass::recreateResources(RenderCommandList* commandList, const FrameGenPassInput& passInput)
 {
+	auto nullOrWrongSize = [](const UniquePtr<Texture>& texture, uint32 width, uint32 height) -> bool {
+		return texture == nullptr
+			|| texture->getCreateParams().width != width
+			|| texture->getCreateParams().height != height;
+	};
+
 	for (size_t i = 0; i < reconstructedPrevDepthTextures.size(); ++i)
 	{
-		if (reconstructedPrevDepthTextures[i] == nullptr
-			|| reconstructedPrevDepthTextures[i]->getCreateParams().width != passInput.displaySizeX
-			|| reconstructedPrevDepthTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		if (nullOrWrongSize(reconstructedPrevDepthTextures[i], passInput.displaySizeX, passInput.displaySizeY))
 		{
 			commandList->enqueueDeferredDealloc(reconstructedPrevDepthTextures[i].release(), true);
 			commandList->enqueueDeferredDealloc(reconstructedPrevDepthSRVs[i].release(), true);
@@ -146,7 +150,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			reconstructedPrevDepthTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
 			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_ReconstructedPrevDepth_%u", (uint32)i);
+			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_ReconstructedPrevDepth_%u", (uint32)i);
 			reconstructedPrevDepthTextures[i]->setDebugName(debugName);
 
 			reconstructedPrevDepthSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
@@ -175,9 +179,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 	for (size_t i = 0; i < dilatedMotionVectorTextures.size(); ++i)
 	{
-		if (dilatedMotionVectorTextures[i] == nullptr
-			|| dilatedMotionVectorTextures[i]->getCreateParams().width != passInput.displaySizeX
-			|| dilatedMotionVectorTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		if (nullOrWrongSize(dilatedMotionVectorTextures[i], passInput.displaySizeX, passInput.displaySizeY))
 		{
 			commandList->enqueueDeferredDealloc(dilatedMotionVectorTextures[i].release(), true);
 			commandList->enqueueDeferredDealloc(dilatedMotionVectorSRVs[i].release(), true);
@@ -191,7 +193,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			dilatedMotionVectorTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
 			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_DilatedMotionVector_%u", (uint32)i);
+			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_DilatedMotionVector_%u", (uint32)i);
 			dilatedMotionVectorTextures[i]->setDebugName(debugName);
 			
 			dilatedMotionVectorSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
@@ -220,9 +222,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 	for (size_t i = 0; i < dilatedDepthTextures.size(); ++i)
 	{
-		if (dilatedDepthTextures[i] == nullptr
-			|| dilatedDepthTextures[i]->getCreateParams().width != passInput.displaySizeX
-			|| dilatedDepthTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		if (nullOrWrongSize(dilatedDepthTextures[i], passInput.displaySizeX, passInput.displaySizeY))
 		{
 			commandList->enqueueDeferredDealloc(dilatedDepthTextures[i].release(), true);
 			commandList->enqueueDeferredDealloc(dilatedDepthSRVs[i].release(), true);
@@ -236,7 +236,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			dilatedDepthTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
 			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_DilatedDepth_%u", (uint32)i);
+			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_DilatedDepth_%u", (uint32)i);
 			dilatedDepthTextures[i]->setDebugName(debugName);
 			
 			dilatedDepthSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
@@ -265,9 +265,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 	for (uint32 i = 0; i < 2; ++i)
 	{
-		if (gameMotionVectorFieldTextures[i] == nullptr
-			|| gameMotionVectorFieldTextures[i]->getCreateParams().width != passInput.displaySizeX
-			|| gameMotionVectorFieldTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		if (nullOrWrongSize(gameMotionVectorFieldTextures[i], passInput.displaySizeX, passInput.displaySizeY))
 		{
 			commandList->enqueueDeferredDealloc(gameMotionVectorFieldTextures[i].release(), true);
 			commandList->enqueueDeferredDealloc(gameMotionVectorFieldUAVs[i].release(), true);
@@ -279,7 +277,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			gameMotionVectorFieldTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
 			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_GameMotionVectorField_%s", i == 0 ? L"X" : L"Y");
+			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_GameMotionVectorField_%s", i == 0 ? L"X" : L"Y");
 			gameMotionVectorFieldTextures[i]->setDebugName(debugName);
 
 			gameMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
@@ -295,9 +293,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 	for (uint32 i = 0; i < 2; ++i)
 	{
-		if (opticalFlowMotionVectorFieldTextures[i] == nullptr
-			|| opticalFlowMotionVectorFieldTextures[i]->getCreateParams().width != passInput.displaySizeX
-			|| opticalFlowMotionVectorFieldTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		if (nullOrWrongSize(opticalFlowMotionVectorFieldTextures[i], passInput.displaySizeX, passInput.displaySizeY))
 		{
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldTextures[i].release(), true);
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldUAVs[i].release(), true);
@@ -309,7 +305,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			opticalFlowMotionVectorFieldTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
 
 			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_OpticalFlowMotionVectorField_%s", i == 0 ? L"X" : L"Y");
+			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_OpticalFlowMotionVectorField_%s", i == 0 ? L"X" : L"Y");
 			opticalFlowMotionVectorFieldTextures[i]->setDebugName(debugName);
 
 			opticalFlowMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
@@ -321,6 +317,28 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 				}
 			));
 		}
+	}
+
+	if (nullOrWrongSize(disocclusionMaskTexture, passInput.displaySizeX, passInput.displaySizeY))
+	{
+		commandList->enqueueDeferredDealloc(disocclusionMaskTexture.release(), true);
+		commandList->enqueueDeferredDealloc(disocclusionMaskUAV.release(), true);
+
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R8G8_UNORM,
+			ETextureAccessFlags::UAV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		disocclusionMaskTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		disocclusionMaskTexture->setDebugName(L"RT_FSR3_DisocclusionMask");
+
+		disocclusionMaskUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
+			disocclusionMaskTexture.get(),
+			UnorderedAccessViewDesc{
+				.format         = disocclusionMaskTexture->getCreateParams().format,
+				.viewDimension  = EUAVDimension::Texture2D,
+				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+			}
+		));
 	}
 }
 
@@ -460,6 +478,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(disocclusionMaskTexture.get(), EBarrierSync::COMPUTE_SHADING),
 		};
 		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
 		
@@ -471,7 +490,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		SPT.rwTexture("rw_game_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
 		SPT.rwTexture("rw_optical_flow_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
 		SPT.rwTexture("rw_optical_flow_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
-		// "rw_disocclusion_mask" FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
+		SPT.rwTexture("rw_disocclusion_mask", disocclusionMaskUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
 		// "rw_counters" FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
 		
 		frameInterpDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -2,7 +2,12 @@
 #include "rhi/render_device.h"
 #include "world/camera.h"
 
-// See sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp
+// doc: docs/techniques/frame-interpolation.md
+// src: sdk/src/components/frameinterpolation/ffx_frameinterpolation.cpp
+
+// Input: 2 back buffers + several resources shared with FSR3Upscaler and FfxOpticalFlow
+// Output: An interpolated image between the 2 back buffers
+// 
 
 // FFX_DECLARE_CB(FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION)
 struct FrameInterpUniform
@@ -18,15 +23,15 @@ struct FrameInterpUniform
 	int32           Mode;
 	int32           reset;
 
-	float           fDeviceToViewDepth[4]; // #wip: setupDeviceDepthToViewSpaceDepthParams
+	float           fDeviceToViewDepth[4]; // #todo-fsr3-framegen: setupDeviceDepthToViewSpaceDepthParams
 
-	float           deltaTime;
-	int32           HUDLessAttachedFactor; // 1 or 0 (#wip: Is it for HUD upscaling?)
+	float           deltaTime; // In milliseconds
+	int32           HUDLessAttachedFactor; // 1 or 0 (#todo-fsr3-framegen: Is it for HUD upscaling?)
 	int32           distortionFieldSize[2];
 
 	float           opticalFlowScale[2];
 	int32           opticalFlowBlockSize;
-	uint32          dispatchFlags;
+	uint32          dispatchFlags; // #todo-fsr3-framegen: FfxFrameInterpolationDispatchFlags (FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_TEAR_LINES, FFX_FRAMEINTERPOLATION_DISPATCH_DRAW_DEBUG_VIEW)
 
 	int32           maxRenderSize[2];
 	int32           opticalFlowHalfResMode;
@@ -36,9 +41,9 @@ struct FrameInterpUniform
 	int32           interpolationRectSize[2];
 
 	float           debugBarColor[3];
-	uint32          backBufferTransferFunction;
+	uint32          backBufferTransferFunction; // Transfer fn to convert interpolation source color data to linear RGB
 
-	float           minMaxLuminance[2];
+	float           minMaxLuminance[2]; // Used when converting HDR colors to linear RGB
 	float           fTanHalfFOV;
 	int32           _pad1;
 
@@ -63,8 +68,8 @@ void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 
 void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
-	preparePhase(commandList, swapchainIndex, passInput);
-	dispatchPhase(commandList, swapchainIndex, passInput);
+	//preparePhase(commandList, swapchainIndex, passInput);
+	//dispatchPhase(commandList, swapchainIndex, passInput);
 }
 
 void FrameGenPass::initializePipelines()
@@ -252,9 +257,10 @@ void FrameGenPass::initializePipelines()
 }
 
 // See ffxFrameInterpolationPrepare.
+// Generate FSR3 upscaler resources.
 void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
-	// #wip: Dispatch reconstructAndDilatePipeline
+	// #todo-fsr3-framegen: Dispatch reconstructAndDilatePipeline
 }
 
 // See ffxFrameInterpolationDispatch.
@@ -266,19 +272,19 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		.displaySizeRcp             = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
 		.cameraNear                 = passInput.camera->getZNear(),
 		.cameraFar                  = passInput.camera->getZFar(),
-		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #wip: upscale target size
-		.Mode                       = 0, // #wip: What is this? No shader accesses it, even ffx source code does not use it.
-		.reset                      = 0, // #wip: reset, see ffxFrameInterpolationDispatch
-		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #wip: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
-		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
+		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #todo-fsr3-framegen: upscale target size
+		.Mode                       = 0, // #todo-fsr3-framegen: What is this? No shader accesses it, even ffx source code does not use it.
+		.reset                      = 0, // #todo-fsr3-framegen: reset, see ffxFrameInterpolationDispatch
+		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #todo-fsr3-framegen: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
+		.deltaTime                  = passInput.deltaTime, // #todo-fsr3-framegen: Unit of deltaTime?
 		.HUDLessAttachedFactor      = 0,
 		.distortionFieldSize        = { 1, 1 },
-		.opticalFlowScale           = { 1.0f, 1.0f }, // #wip: opticalFlowScale
+		.opticalFlowScale           = { 1.0f, 1.0f }, // #todo-fsr3-framegen: opticalFlowScale
 		.opticalFlowBlockSize       = passInput.opticalFlowBlockSize,
 		.dispatchFlags              = passInput.dispatchFlags,
 		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
-		.opticalFlowHalfResMode     = 0, // #wip: opticalFlowHalfResMode
-		.NumInstances               = 0, // #wip: NumInstances unused?
+		.opticalFlowHalfResMode     = 0, // #todo-fsr3-framegen: opticalFlowHalfResMode
+		.NumInstances               = 0, // #todo-fsr3-framegen: NumInstances unused?
 		.interpolationRectBase      = { 0, 0 },
 		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
 		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
@@ -286,7 +292,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		.minMaxLuminance            = { 0.0f, 65000.0f }, // #todo-fsr: minMaxLuminance
 		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
 		._pad1                      = 0,
-		.fJitter                    = { 0, 0 }, // #wip: jitter
+		.fJitter                    = { 0, 0 }, // #todo-fsr3-framegen: jitter
 		.fMotionVectorScale         = { 1.0f, 1.0f },
 	};
 
@@ -302,37 +308,37 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)passInput.opticalFlowBlockSize + 7) / 8;
 	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)passInput.opticalFlowBlockSize + 7) / 8;
 
-	// #wip: Dispatch setupPipeline (renderDispatchSizeX/Y)
-	// #wip: Dispatch gameVectorFieldInpaintingPyramidPipeline
+	// #todo-fsr3-framegen: Dispatch setupPipeline (renderDispatchSizeX/Y)
+	// #todo-fsr3-framegen: Dispatch gameVectorFieldInpaintingPyramidPipeline
 
 	if (uniformData.reset == 0)
 	{
-		// #wip: Clear estimated depth resources
+		// #todo-fsr3-framegen: Clear estimated depth resources
 		// ...
 
-		// #wip: Dispatch reconstructPrevDepthPipeline
-		// #wip: Dispatch gameMotionVectorFieldPipeline
+		// #todo-fsr3-framegen: Dispatch reconstructPrevDepthPipeline
+		// #todo-fsr3-framegen: Dispatch gameMotionVectorFieldPipeline
 		
-		// #wip: scheduleDispatchGameVectorFieldInpaintingPyramid()
+		// #todo-fsr3-framegen: scheduleDispatchGameVectorFieldInpaintingPyramid()
 
-		// #wip: Dispatch opticalFlowVectorFieldPipeline
-		// #wip: Dispatch disocclusionMaskPipeline
+		// #todo-fsr3-framegen: Dispatch opticalFlowVectorFieldPipeline
+		// #todo-fsr3-framegen: Dispatch disocclusionMaskPipeline
 	}
 
-	// #wip: Dispatch interpolationPipeline (pipelineFiScfi in ffx)
+	// #todo-fsr3-framegen: Dispatch interpolationPipeline (pipelineFiScfi in ffx)
 
 	// inpainting pyramid
 	{
-		// #wip: Auto exposure via SPD
-		// #wip: Dispatch inpaintingPyramidPipeline
+		// #todo-fsr3-framegen: Auto exposure via SPD
+		// #todo-fsr3-framegen: Dispatch inpaintingPyramidPipeline
 	}
 
-	// #wip: inpaintingPipeline
+	// #todo-fsr3-framegen: inpaintingPipeline
 
 	if (false /* draw debug view */)
 	{
-		// #wip: Dispatch debugViewPipeline
+		// #todo-fsr3-framegen: Dispatch debugViewPipeline
 	}
 
-	// #wip: Store current buffer
+	// #todo-fsr3-framegen: Store current buffer
 }

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -1,5 +1,6 @@
 #include "frame_gen_pass.h"
 #include "render/util/clear_resource_pass.h"
+#include "render/renderer_constants.h"
 #include "rhi/rhi_policy.h"
 #include "rhi/render_device.h"
 #include "rhi/render_command.h"
@@ -101,6 +102,7 @@ void FrameGenPass::initializePipelines()
 	inpaintingPyramidDescriptor.initialize(device, L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
 
 	reconstructPrevDepthDescriptor.initialize(device, L"FSR3_ReconstructPrevDepth", swapchainCount, 0);
+	gameMotionVectorFieldDescriptor.initialize(device, L"FSR3_GameMotionVectorField", swapchainCount, 0);
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -449,6 +451,42 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			}
 		));
 	}
+
+	if (nullOrWrongSize(prevInterpolationSourceTexture, passInput.displaySizeX, passInput.displaySizeY))
+	{
+		commandList->enqueueDeferredDealloc(prevInterpolationSourceTexture.release(), true);
+		commandList->enqueueDeferredDealloc(prevInterpolationSourceSRV.release(), true);
+		commandList->enqueueDeferredDealloc(prevInterpolationSourceUAV.release(), true);
+
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			PF_sceneColor,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		prevInterpolationSourceTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		prevInterpolationSourceTexture->setDebugName(L"RT_FSR3_PrevInterpolationSource");
+		
+		prevInterpolationSourceSRV = UniquePtr<ShaderResourceView>(device->createSRV(
+			prevInterpolationSourceTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = prevInterpolationSourceTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = 1,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
+		prevInterpolationSourceUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
+			prevInterpolationSourceTexture.get(),
+			UnorderedAccessViewDesc{
+				.format         = prevInterpolationSourceTexture->getCreateParams().format,
+				.viewDimension  = EUAVDimension::Texture2D,
+				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+			}
+		));
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -664,6 +702,16 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			ClearResourcePass::floatClearValue(zFar, zFar, zFar, zFar));
 		passInput.clearResourcePass->executeClears(commandList, swapchainIndex);
 
+		// #wip: distortion field texture from passInput
+		Texture* distortionFieldTexture = defaultDistortionFieldTexture.get();
+		ShaderResourceView* distortionFieldSRV = defaultDistortionFieldSRV.get();
+
+		Texture* dilatedMotionVectorTexture = dilatedMotionVectorTextures[currResourceIndex].get();
+		ShaderResourceView* dilatedMotionVectorSRV = dilatedMotionVectorSRVs[currResourceIndex].get();
+
+		Texture* dilatedDepthTexture = dilatedDepthTextures[currResourceIndex].get();
+		ShaderResourceView* dilatedDepthSRV = dilatedDepthSRVs[currResourceIndex].get();
+
 		{
 			SCOPED_DRAW_EVENT(commandList, ReconstructDepthPrevFrame);
 
@@ -671,21 +719,21 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			auto& passDescriptor = reconstructPrevDepthDescriptor;
 
 			TextureBarrierAuto textureBarriers[] = {
-				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTextures[currResourceIndex].get(), EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(dilatedDepthTextures[currResourceIndex].get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(passInput.sceneColorTexture, EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(defaultDistortionFieldTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toUnorderedAccess(reconstructedDepthInterpolatedFrameTexture.get(), EBarrierSync::COMPUTE_SHADING),
 			};
 			commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
 
 			ShaderParameterTable SPT{};
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
-			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRVs[currResourceIndex].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
-			SPT.texture("r_dilated_depth", dilatedDepthSRVs[currResourceIndex].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
+			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			// #wip: not used but declared in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
 			SPT.texture("r_current_interpolation_source", passInput.sceneColorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
-			SPT.texture("r_input_distortion_field", defaultDistortionFieldSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
+			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
 			SPT.rwTexture("rw_reconstructed_depth_interpolated_frame", reconstructedDepthInterpolatedFrameUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_INTERPOLATED_FRAME
 
 			auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
@@ -696,7 +744,40 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 		}
 
-		// #wip: Dispatch gameMotionVectorFieldPipeline
+		{
+			SCOPED_DRAW_EVENT(commandList, GameMotionVector);
+
+			auto pipeline = gameMotionVectorFieldPipeline.get();
+			auto& passDescriptor = gameMotionVectorFieldDescriptor;
+
+			TextureBarrierAuto textureBarriers[] = {
+				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(prevInterpolationSourceTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(passInput.sceneColorTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			};
+			commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+			ShaderParameterTable SPT{};
+			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
+			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_previous_interpolation_source", prevInterpolationSourceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_PREVIOUS_INTERPOLATION_SOURCE
+			SPT.texture("r_current_interpolation_source", passInput.sceneColorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
+			SPT.rwTexture("rw_game_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
+			SPT.rwTexture("rw_game_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
+
+			auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+			commandList->setComputePipelineState(pipeline);
+			commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
+		}
 		
 		//scheduleDispatchGameVectorFieldInpaintingPyramid();
 

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -146,8 +146,10 @@ FrameGenPassOutput FrameGenPass::runFrameGeneration(RenderCommandList* commandLi
 	cpuFrameIndex += 1;
 
 	return FrameGenPassOutput{
-		.interpolatedFrameTexture = interpolationOutputTexture.get(),
-		.interpolatedFrameSRV     = interpolationOutputSRV.get(),
+		.interpolatedFrameTexture             = interpolationOutputTexture.get(),
+		.interpolatedFrameSRV                 = interpolationOutputSRV.get(),
+		.opticalFlowMotionVectorFieldTextures = { opticalFlowMotionVectorFieldTextures[0].get(), opticalFlowMotionVectorFieldTextures[1].get() },
+		.opticalFlowMotionVectorFieldSRVs     = { opticalFlowMotionVectorFieldSRVs[0].get(), opticalFlowMotionVectorFieldSRVs[1].get() },
 	};
 }
 
@@ -877,8 +879,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		SPT.rwBuffer("rw_counters", counterUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
 		SPT.rwTexture("rw_game_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
 		SPT.rwTexture("rw_game_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
-		SPT.rwTexture("rw_optical_flow_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
-		SPT.rwTexture("rw_optical_flow_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
+		SPT.rwTexture("rw_optical_flow_motion_vector_field_x", opticalFlowMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
+		SPT.rwTexture("rw_optical_flow_motion_vector_field_y", opticalFlowMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
 		SPT.rwTexture("rw_disocclusion_mask", disocclusionMaskUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
 		
 		frameInterpDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -496,6 +496,14 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 	ConstantBufferView* frameInterpUniformCBV = getCurrentFrameInterpUniformCBV();
 	ConstantBufferView* inpaintingPyramidUniformCBV = getCurrentInpaintingPyramidUniformCBV();
 
+	bResetCurrentFrame = (interpolationDispatchCount == 0) || passInput.bReset;
+
+	const bool bFrameID_decreased = passInput.frameID < prevFrameID;
+	const bool bFrameID_skipped = (passInput.frameID - prevFrameID) > 1;
+	const bool bDisjointFrameID = bFrameID_decreased || bFrameID_skipped;
+	prevFrameID = passInput.frameID;
+	interpolationDispatchCount++;
+
 	FrameInterpUniform fiUniformData{
 		.renderSize                 = { passInput.renderSizeX, passInput.renderSizeY },
 		.displaySize                = { passInput.displaySizeX, passInput.displaySizeY },
@@ -504,7 +512,7 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.cameraFar                  = passInput.camera->getZFar(),
 		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #wip: upscale target size
 		.Mode                       = 0, // #wip: What is this? No shader accesses it, even ffx source code does not use it.
-		.reset                      = passInput.bReset,
+		.reset                      = bResetCurrentFrame || bDisjointFrameID,
 		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // Set below
 		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
 		.HUDLessAttachedFactor      = 0,
@@ -591,14 +599,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	ConstantBufferView* frameInterpUniformCBV = getCurrentFrameInterpUniformCBV();
 	ConstantBufferView* inpaintingPyramidUniformCBV = getCurrentInpaintingPyramidUniformCBV();
 
-	const bool bReset = (interpolationDispatchCount == 0) || passInput.bReset;
-
-	const bool bFrameID_decreased = passInput.frameID < prevFrameID;
-	const bool bFrameID_skipped = (passInput.frameID - prevFrameID) > 1;
-	const bool bDisjointFrameID = bFrameID_decreased || bFrameID_skipped;
-	prevFrameID = passInput.frameID;
-	interpolationDispatchCount++;
-
 	const uint32 displayDispatchSizeX = (passInput.displaySizeX + 7) / 8;
 	const uint32 displayDispatchSizeY = (passInput.displaySizeY + 7) / 8;
 
@@ -608,7 +608,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)kOpticalFlowBlockSize + 7) / 8;
 	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)kOpticalFlowBlockSize + 7) / 8;
 
-	const bool bExecutePreparationPasses = (false == bReset);
+	const bool bExecutePreparationPasses = (false == bResetCurrentFrame);
 
 	// #wip: distortion field texture from passInput
 	auto distortionFieldTexture            = defaultDistortionFieldTexture.get();

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -103,6 +103,7 @@ void FrameGenPass::initializePipelines()
 
 	reconstructPrevDepthDescriptor.initialize(device, L"FSR3_ReconstructPrevDepth", swapchainCount, 0);
 	gameMotionVectorFieldDescriptor.initialize(device, L"FSR3_GameMotionVectorField", swapchainCount, 0);
+	gameMotionVectorFieldInpaintingPyramidDescriptor.initialize(device, L"FSR3_GameMotionVectorFieldInpaintingPyramid", swapchainCount, 0);
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -487,6 +488,36 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			}
 		));
 	}
+
+	if (nullOrWrongSize(inpaintingPyramidTexture, passInput.displaySizeX, passInput.displaySizeY))
+	{
+		commandList->enqueueDeferredDealloc(inpaintingPyramidTexture.release(), true);
+		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
+		{
+			commandList->enqueueDeferredDealloc(inpaintingPyramidUAVs[i].release(), true);
+		}
+
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R16G16B16A16_FLOAT,
+			ETextureAccessFlags::UAV,
+			// #wip: What if inpaintingPyramid is not large enough to contain 13 mips?
+			passInput.displaySizeX, passInput.displaySizeY, _countof(inpaintingPyramidUAVs));
+
+		inpaintingPyramidTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		inpaintingPyramidTexture->setDebugName(L"RT_FSR3_InpaintingPyramidTexture");
+		
+		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
+		{
+			inpaintingPyramidUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
+				inpaintingPyramidTexture.get(),
+				UnorderedAccessViewDesc{
+					.format         = inpaintingPyramidTexture->getCreateParams().format,
+					.viewDimension  = EUAVDimension::Texture2D,
+					.texture2D      = Texture2DUAVDesc{ .mipSlice = (uint32)i, .planeSlice = 0 },
+				}
+			));
+		}
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -659,12 +690,23 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	{
 		SCOPED_DRAW_EVENT(commandList, GameVectorFieldInpaintingPyramid);
 
+		auto pipeline = gameVectorFieldInpaintingPyramidPipeline.get();
+		auto& passDescriptor = gameMotionVectorFieldInpaintingPyramidDescriptor;
+
+		// Auto exposure
+		uint32 dispatchThreadGroupCountXY[2];
+		uint32 workGroupOffset[2];
+		uint32 numWorkGroupsAndMips[2];
+		uint32 rectInfo[4] = { 0, 0, (uint32)passInput.renderSizeX, (uint32)passInput.renderSizeY };
+		ffxSpdSetup(dispatchThreadGroupCountXY, workGroupOffset, numWorkGroupsAndMips, rectInfo, -1);
+
 		BufferBarrierAuto bufferBarriers[] = {
 			{ EBarrierSync::COMPUTE_SHADING, EBarrierAccess::UNORDERED_ACCESS, counterBuffer.get() },
 		};
 		TextureBarrierAuto textureBarriers[] = {
 			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
 		};
 		commandList->barrierAuto(_countof(bufferBarriers), bufferBarriers, _countof(textureBarriers), textureBarriers, 0, nullptr);
 
@@ -674,23 +716,20 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		SPT.texture("r_game_motion_vector_field_x", gameMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_X
 		SPT.texture("r_game_motion_vector_field_y", gameMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_Y
 		SPT.rwBuffer("rw_counters", counterUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_0             1
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_1             2
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_2             3
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_3             4
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_4             5
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_5             6
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_6             7
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_7             8
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_8             9
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_9             10
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_10            11
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_11            12
-//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_12            13
+		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
+		{
+			// rw_inpainting_pyramid0 ~ rw_inpainting_pyramidN (FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_0 ~ N)
+			char msg[64];
+			std::snprintf(msg, _countof(msg), "rw_inpainting_pyramid%u", (uint32)i);
+			SPT.rwTexture(msg, inpaintingPyramidUAVs[i].get());
+		}
 
-		// pipeline and parameters
+		auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
 
-		// dispatch
+		commandList->setComputePipelineState(pipeline);
+		commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+		commandList->dispatchCompute(dispatchThreadGroupCountXY[0], dispatchThreadGroupCountXY[1], 1);
 	};
 
 	if (bExecutePreparationPasses)
@@ -779,7 +818,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 		}
 		
-		//scheduleDispatchGameVectorFieldInpaintingPyramid();
+		scheduleDispatchGameVectorFieldInpaintingPyramid();
 
 		// #wip: Dispatch opticalFlowVectorFieldPipeline
 		// #wip: Dispatch disocclusionMaskPipeline

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -177,6 +177,42 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		}
 	}
 
+	if (nullOrWrongSize(reconstructedDepthInterpolatedFrameTexture, passInput.displaySizeX, passInput.displaySizeY))
+	{
+		commandList->enqueueDeferredDealloc(reconstructedDepthInterpolatedFrameTexture.release(), true);
+		commandList->enqueueDeferredDealloc(reconstructedDepthInterpolatedFrameSRV.release(), true);
+		commandList->enqueueDeferredDealloc(reconstructedDepthInterpolatedFrameUAV.release(), true);
+
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R32_FLOAT,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		reconstructedDepthInterpolatedFrameTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		reconstructedDepthInterpolatedFrameTexture->setDebugName(L"RT_FSR3_ReconstructedDepthInterpolatedFrame");
+
+		reconstructedDepthInterpolatedFrameSRV = UniquePtr<ShaderResourceView>(device->createSRV(
+			reconstructedDepthInterpolatedFrameTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = reconstructedDepthInterpolatedFrameTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = 1,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
+		reconstructedDepthInterpolatedFrameUAV = UniquePtr<UnorderedAccessView>(device->createUAV(
+			reconstructedDepthInterpolatedFrameTexture.get(),
+			UnorderedAccessViewDesc{
+				.format         = reconstructedDepthInterpolatedFrameTexture->getCreateParams().format,
+				.viewDimension  = EUAVDimension::Texture2D,
+				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+			}
+		));
+	}
+
 	for (size_t i = 0; i < dilatedMotionVectorTextures.size(); ++i)
 	{
 		if (nullOrWrongSize(dilatedMotionVectorTextures[i], passInput.displaySizeX, passInput.displaySizeY))
@@ -268,6 +304,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		if (nullOrWrongSize(gameMotionVectorFieldTextures[i], passInput.displaySizeX, passInput.displaySizeY))
 		{
 			commandList->enqueueDeferredDealloc(gameMotionVectorFieldTextures[i].release(), true);
+			commandList->enqueueDeferredDealloc(gameMotionVectorFieldSRVs[i].release(), true);
 			commandList->enqueueDeferredDealloc(gameMotionVectorFieldUAVs[i].release(), true);
 
 			TextureCreateParams texDesc = TextureCreateParams::texture2D(
@@ -280,6 +317,19 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_GameMotionVectorField_%s", i == 0 ? L"X" : L"Y");
 			gameMotionVectorFieldTextures[i]->setDebugName(debugName);
 
+			gameMotionVectorFieldSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
+				gameMotionVectorFieldTextures[i].get(),
+				ShaderResourceViewDesc{
+					.format              = gameMotionVectorFieldTextures[i]->getCreateParams().format,
+					.viewDimension       = ESRVDimension::Texture2D,
+					.texture2D           = Texture2DSRVDesc{
+						.mostDetailedMip = 0,
+						.mipLevels       = 1,
+						.planeSlice      = 0,
+						.minLODClamp     = 0.0f,
+					},
+				}
+			));
 			gameMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
 				gameMotionVectorFieldTextures[i].get(),
 				UnorderedAccessViewDesc{
@@ -420,7 +470,7 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 }
 
 // See ffxFrameInterpolationPrepare().
-// Generate FSR3 upscaler resources.
+// Generate FSR3 upscaler resources. If upscaler was used, then this method is not needed.
 void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
 	SCOPED_DRAW_EVENT(commandList, FrameGenPrepare);
@@ -493,6 +543,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)kOpticalFlowBlockSize + 7) / 8;
 	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)kOpticalFlowBlockSize + 7) / 8;
 
+	const bool bExecutePreparationPasses = (false == bReset);
+
 	{
 		SCOPED_DRAW_EVENT(commandList, Setup);
 
@@ -530,16 +582,57 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	}
 
 	// #wip: Dispatch gameVectorFieldInpaintingPyramidPipeline
-
-	if (bReset)
+	auto scheduleDispatchGameVectorFieldInpaintingPyramid = [&]()
 	{
-		// #wip: Clear estimated depth resources
-		// ...
+		SCOPED_DRAW_EVENT(commandList, GameVectorFieldInpaintingPyramid);
+
+		BufferBarrierAuto bufferBarriers[] = {
+			{ EBarrierSync::COMPUTE_SHADING, EBarrierAccess::UNORDERED_ACCESS, counterBuffer.get() },
+		};
+		TextureBarrierAuto textureBarriers[] = {
+			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+		};
+		commandList->barrierAuto(_countof(bufferBarriers), bufferBarriers, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+		ShaderParameterTable SPT{};
+		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		SPT.constantBuffer("cbInpaintingPyramid", inpaintingPyramidUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_INPAINTING_PYRAMID
+		SPT.texture("r_game_motion_vector_field_x", gameMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_X
+		SPT.texture("r_game_motion_vector_field_y", gameMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_Y
+		SPT.rwBuffer("rw_counters", counterUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_0             1
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_1             2
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_2             3
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_3             4
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_4             5
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_5             6
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_6             7
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_7             8
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_8             9
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_9             10
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_10            11
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_11            12
+//#define FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_12            13
+
+		// pipeline and parameters
+
+		// dispatch
+	};
+
+	if (bExecutePreparationPasses)
+	{
+		constexpr float zFar = getDeviceFarDepth();
+		passInput.clearResourcePass->enqueueClear(
+			reconstructedDepthInterpolatedFrameTexture.get(),
+			reconstructedDepthInterpolatedFrameUAV.get(),
+			ClearResourcePass::floatClearValue(zFar, zFar, zFar, zFar));
+		passInput.clearResourcePass->executeClears(commandList, swapchainIndex);
 
 		// #wip: Dispatch reconstructPrevDepthPipeline
 		// #wip: Dispatch gameMotionVectorFieldPipeline
 		
-		// #wip: scheduleDispatchGameVectorFieldInpaintingPyramid()
+		//scheduleDispatchGameVectorFieldInpaintingPyramid();
 
 		// #wip: Dispatch opticalFlowVectorFieldPipeline
 		// #wip: Dispatch disocclusionMaskPipeline

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -79,181 +79,31 @@ void FrameGenPass::initializePipelines()
 	frameInterpDescriptor.initialize(L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
 	inpaintingPyramidDescriptor.initialize(L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
 
-	// reconstructAndDilatePipeline
+	auto createPipeline = [device = this->device]
+		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
 	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3ReconstructAndDilateCS");
+		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, debugName);
 		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_reconstruct_and_dilate_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
+		shader->loadFromFile(filepath, "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
 
-		reconstructAndDilatePipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
+		pipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
+			ComputePipelineDesc{ .cs = shader, .nodeMask = 0 }
 		));
 
 		delete shader;
-	}
+	};
 
-	// setupPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3SetupCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_setup_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		setupPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// reconstructPrevDepthPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3ReconstructPrevDepthCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		reconstructPrevDepthPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// gameMotionVectorFieldPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3GameMotionVectorFieldPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_game_motion_vector_field_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		gameMotionVectorFieldPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// opticalFlowVectorFieldPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3OpticalFlowVectorFieldPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_optical_flow_vector_field_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		opticalFlowVectorFieldPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// disocclusionMaskPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3DisocclusionMaskPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_disocclusion_mask_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		disocclusionMaskPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// interpolationPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3InterpolationPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		interpolationPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// inpaintingPyramidPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3InpaintingPyramidPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_compute_inpainting_pyramid_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		inpaintingPyramidPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// inpaintingPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3InpaintingPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_inpainting_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		inpaintingPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// gameVectorFieldInpaintingPyramidPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3GameVectorFieldInpaintingPyramidPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_compute_game_vector_field_inpainting_pyramid_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		gameVectorFieldInpaintingPyramidPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
-
-	// debugViewPipeline
-	{
-		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, "FSR3DebugViewPipelineCS");
-		shader->declarePushConstants();
-		shader->loadFromFile(L"amd/ffx_frameinterpolation_debug_view_pass.hlsl", "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
-
-		debugViewPipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
-			ComputePipelineDesc{
-				.cs       = shader,
-				.nodeMask = 0,
-			}
-		));
-
-		delete shader;
-	}
+	createPipeline("FSR3ReconstructAndDilateCS", L"amd/ffx_frameinterpolation_reconstruct_and_dilate_pass.hlsl", reconstructAndDilatePipeline);
+	createPipeline("FSR3SetupCS", L"amd/ffx_frameinterpolation_setup_pass.hlsl", setupPipeline);
+	createPipeline("FSR3ReconstructPrevDepthCS", L"amd/ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl", reconstructPrevDepthPipeline);
+	createPipeline("FSR3GameMotionVectorFieldPipelineCS", L"amd/ffx_frameinterpolation_game_motion_vector_field_pass.hlsl", gameMotionVectorFieldPipeline);
+	createPipeline("FSR3OpticalFlowVectorFieldPipelineCS", L"amd/ffx_frameinterpolation_optical_flow_vector_field_pass.hlsl", opticalFlowVectorFieldPipeline);
+	createPipeline("FSR3DisocclusionMaskPipelineCS", L"amd/ffx_frameinterpolation_disocclusion_mask_pass.hlsl", disocclusionMaskPipeline);
+	createPipeline("FSR3InterpolationPipelineCS", L"amd/ffx_frameinterpolation_pass.hlsl", interpolationPipeline);
+	createPipeline("FSR3InpaintingPyramidPipelineCS", L"amd/ffx_frameinterpolation_compute_inpainting_pyramid_pass.hlsl", inpaintingPyramidPipeline);
+	createPipeline("FSR3InpaintingPipelineCS", L"amd/ffx_frameinterpolation_inpainting_pass.hlsl", inpaintingPipeline);
+	createPipeline("FSR3GameVectorFieldInpaintingPyramidPipelineCS", L"amd/ffx_frameinterpolation_compute_game_vector_field_inpainting_pyramid_pass.hlsl", gameVectorFieldInpaintingPyramidPipeline);
+	createPipeline("FSR3DebugViewPipelineCS", L"amd/ffx_frameinterpolation_debug_view_pass.hlsl", debugViewPipeline);
 }
 
 // See ffxFrameInterpolationPrepare.

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -135,7 +135,7 @@ void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 	initializePipelines();
 }
 
-void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
+FrameGenPassOutput FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
 	recreateResources(commandList, passInput);
 
@@ -144,6 +144,11 @@ void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swa
 	dispatchPhase(commandList, swapchainIndex, passInput);
 
 	cpuFrameIndex += 1;
+
+	return FrameGenPassOutput{
+		.interpolatedFrameTexture = interpolationOutputTexture.get(),
+		.interpolatedFrameSRV     = interpolationOutputSRV.get(),
+	};
 }
 
 void FrameGenPass::initializePipelines()

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -361,6 +361,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldTextures[i].release(), true);
 			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldUAVs[i].release(), true);
 
+			// #wip: Too big? (xy + 7) / 8 is enough?
 			TextureCreateParams texDesc = TextureCreateParams::texture2D(
 				EPixelFormat::R32_UINT,
 				ETextureAccessFlags::UAV,
@@ -519,6 +520,41 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			));
 		}
 	}
+
+	// #wip: I don't know what this is. FidelityFX does not fill this texture.
+	// The way this resource is used makes no sense.
+	// It's declared as uint2, but LoadOpticalFlowConfidence() reads its y channel and return as float.
+	// Then fConfidenceFactor = ffxMax(FFX_FRAMEINTERPOLATION_EPSILON, LoadOpticalFlowConfidence(samplePos)).
+	// Finally, fConfidenceFactor is just not used at all :(
+	// Let's just assume it's dead code and bind a black texture.
+	if (nullOrWrongSize(opticalFlowConfidenceTexture, passInput.displaySizeX, passInput.displaySizeY))
+	{
+		commandList->enqueueDeferredDealloc(opticalFlowConfidenceTexture.release(), true);
+		commandList->enqueueDeferredDealloc(opticalFlowConfidenceSRV.release(), true);
+
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R16G16_UINT,
+			ETextureAccessFlags::SRV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		texDesc.setOptimalClearColor(0, 0, 0, 0);
+
+		opticalFlowConfidenceTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		opticalFlowConfidenceTexture->setDebugName(L"RT_FSR3_OpticalFlowConfidence");
+
+		opticalFlowConfidenceSRV = UniquePtr<ShaderResourceView>(device->createSRV(
+			opticalFlowConfidenceTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = opticalFlowConfidenceTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = 1,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -534,12 +570,12 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.cameraFar                  = passInput.camera->getZFar(),
 		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #wip: upscale target size
 		.Mode                       = 0, // #wip: What is this? No shader accesses it, even ffx source code does not use it.
-		.reset                      = 0, // #wip: reset, see ffxFrameInterpolationDispatch
+		.reset                      = passInput.bReset,
 		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #wip: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
 		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
 		.HUDLessAttachedFactor      = 0,
 		.distortionFieldSize        = { 1, 1 },
-		.opticalFlowScale           = { 1.0f, 1.0f }, // #wip: opticalFlowScale
+		.opticalFlowScale           = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
 		.opticalFlowBlockSize       = kOpticalFlowBlockSize,
 		.dispatchFlags              = passInput.dispatchFlags,
 		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
@@ -824,8 +860,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		
 		scheduleDispatchGameVectorFieldInpaintingPyramid();
 
-		// #wip: Dispatch opticalFlowVectorFieldPipeline
-#if 0
 		{
 			SCOPED_DRAW_EVENT(commandList, OpticalFlowVectorField);
 
@@ -834,7 +868,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 			TextureBarrierAuto textureBarriers[] = {
 				TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->opticalFlowVectorTexture, EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(opticalFlowConfidenceTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(opticalFlowConfidenceTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(prevInterpolationSourceTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
@@ -846,7 +880,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			ShaderParameterTable SPT{};
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 			SPT.texture("r_optical_flow", passInput.opticalFlowPassOutput->opticalFlowVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW
-			SPT.texture("r_optical_flow_confidence", opticalFlowConfidenceSRV/*uint2*/); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_CONFIDENCE
+			SPT.texture("r_optical_flow_confidence", opticalFlowConfidenceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_CONFIDENCE
 			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			SPT.texture("r_previous_interpolation_source", prevInterpolationSourceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_PREVIOUS_INTERPOLATION_SOURCE
 			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
@@ -860,7 +894,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 		}
-#endif
 
 		// #wip: Dispatch disocclusionMaskPipeline
 		{

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -598,7 +598,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			EPixelFormat::R16G16B16A16_FLOAT,
 			ETextureAccessFlags::UAV,
 			// #wip: What if inpaintingPyramid is not large enough to contain 13 mips?
-			passInput.displaySizeX, passInput.displaySizeY, _countof(inpaintingPyramidUAVs));
+			passInput.displaySizeX / 2, passInput.displaySizeY / 2, _countof(inpaintingPyramidUAVs));
 
 		inpaintingPyramidTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		inpaintingPyramidTexture->setDebugName(L"RT_FSR3_InpaintingPyramidTexture");
@@ -885,7 +885,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 	}
 
-	// #wip: Dispatch gameVectorFieldInpaintingPyramidPipeline
 	auto scheduleDispatchGameVectorFieldInpaintingPyramid = [&]()
 	{
 		SCOPED_DRAW_EVENT(commandList, GameVectorFieldInpaintingPyramid);
@@ -1129,8 +1128,52 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 	// inpainting pyramid
 	{
-		// #wip: Auto exposure via SPD
+		{
+			SCOPED_DRAW_EVENT(commandList, InpaintingPyramid);
+
+			uint32 dispatchThreadGroupCountXY[2];
+			uint32 workGroupOffset[2];
+			uint32 numWorkGroupsAndMips[2];
+			uint32 rectInfo[4] = { 0, 0, (uint32)passInput.displaySizeX, (uint32)passInput.displaySizeY };
+			ffxSpdSetup(dispatchThreadGroupCountXY, workGroupOffset, numWorkGroupsAndMips, rectInfo, -1);
+
+			auto pipeline = inpaintingPyramidPipeline.get();
+			auto& passDescriptor = inpaintingPyramidDescriptor;
+
+			BufferBarrierAuto bufferBarriers[] = {
+				{ EBarrierSync::COMPUTE_SHADING, EBarrierAccess::UNORDERED_ACCESS, counterBuffer.get() },
+			};
+			TextureBarrierAuto textureBarriers[] = {
+				TextureBarrierAuto::toShaderResource(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toUnorderedAccess(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			};
+			commandList->barrierAuto(_countof(bufferBarriers), bufferBarriers, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+			ShaderParameterTable SPT{};
+			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+			SPT.constantBuffer("cbInpaintingPyramid", inpaintingPyramidUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_INPAINTING_PYRAMID
+			SPT.texture("r_output", interpolationOutputSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OUTPUT
+			SPT.rwBuffer("rw_counters", counterUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
+			for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
+			{
+				// rw_inpainting_pyramid0 ~ rw_inpainting_pyramidN (FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_0 ~ N)
+				char msg[64];
+				std::snprintf(msg, _countof(msg), "rw_inpainting_pyramid%u", (uint32)i);
+				SPT.rwTexture(msg, inpaintingPyramidUAVs[i].get());
+			}
+
+			auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+			commandList->setComputePipelineState(pipeline);
+			commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+			commandList->dispatchCompute(dispatchThreadGroupCountXY[0], dispatchThreadGroupCountXY[1], 1);
+		}
+
 		// #wip: Dispatch inpaintingPyramidPipeline
+		{
+			//
+		}
 	}
 
 	// #wip: inpaintingPipeline

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -371,6 +371,14 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	ConstantBufferView* frameInterpUniformCBV = getCurrentFrameInterpUniformCBV();
 	ConstantBufferView* inpaintingPyramidUniformCBV = getCurrentInpaintingPyramidUniformCBV();
 
+	const bool bReset = (interpolationDispatchCount == 0) || passInput.bReset;
+
+	const bool bFrameID_decreased = passInput.frameID < prevFrameID;
+	const bool bFrameID_skipped = (passInput.frameID - prevFrameID) > 1;
+	const bool bDisjointFrameID = bFrameID_decreased || bFrameID_skipped;
+	prevFrameID = passInput.frameID;
+	interpolationDispatchCount++;
+
 	const uint32 displayDispatchSizeX = (passInput.displaySizeX + 7) / 8;
 	const uint32 displayDispatchSizeY = (passInput.displaySizeY + 7) / 8;
 
@@ -381,9 +389,37 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)kOpticalFlowBlockSize + 7) / 8;
 
 	// #wip: Dispatch setupPipeline (renderDispatchSizeX/Y)
+#if 0
+	{
+		SCOPED_DRAW_EVENT(commandList, Setup);
+
+		// #wip: barrier
+		
+		// #wip: SPT
+		ShaderParameterTable SPT{};
+		// FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_SCENE_CHANGE_DETECTION
+		// FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
+		// FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
+		// FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
+		// FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
+		// FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
+		// FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
+		// FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		
+		frameInterpDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+		auto descriptorHeap = frameInterpDescriptor.getDescriptorHeap(swapchainIndex);
+		auto pipeline = setupPipeline.get();
+
+		commandList->setComputePipelineState(pipeline);
+		commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+		
+		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
+	}
+#endif
+
 	// #wip: Dispatch gameVectorFieldInpaintingPyramidPipeline
 
-	if (passInput.bReset)
+	if (bReset)
 	{
 		// #wip: Clear estimated depth resources
 		// ...

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -292,6 +292,36 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			));
 		}
 	}
+
+	for (uint32 i = 0; i < 2; ++i)
+	{
+		if (opticalFlowMotionVectorFieldTextures[i] == nullptr
+			|| opticalFlowMotionVectorFieldTextures[i]->getCreateParams().width != passInput.displaySizeX
+			|| opticalFlowMotionVectorFieldTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		{
+			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldTextures[i].release(), true);
+			commandList->enqueueDeferredDealloc(opticalFlowMotionVectorFieldUAVs[i].release(), true);
+
+			TextureCreateParams texDesc = TextureCreateParams::texture2D(
+				EPixelFormat::R32_UINT,
+				ETextureAccessFlags::UAV,
+				passInput.displaySizeX, passInput.displaySizeY);
+			opticalFlowMotionVectorFieldTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
+
+			wchar_t debugName[128];
+			std::swprintf(debugName, _countof(debugName), L"RT_OpticalFlowMotionVectorField_%s", i == 0 ? L"X" : L"Y");
+			opticalFlowMotionVectorFieldTextures[i]->setDebugName(debugName);
+
+			opticalFlowMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
+				opticalFlowMotionVectorFieldTextures[i].get(),
+				UnorderedAccessViewDesc{
+					.format         = opticalFlowMotionVectorFieldTextures[i]->getCreateParams().format,
+					.viewDimension  = EUAVDimension::Texture2D,
+					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+				}
+			));
+		}
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -426,6 +456,10 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		// #wip: barrier
 		TextureBarrierAuto textureBarriers[] = {
 			TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->sceneChangeDetectionTexture, EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
 		};
 		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
 		
@@ -435,8 +469,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		SPT.texture("r_optical_flow_scd", passInput.opticalFlowPassOutput->sceneChangeDetectionSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_SCENE_CHANGE_DETECTION
 		SPT.rwTexture("rw_game_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
 		SPT.rwTexture("rw_game_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
-		// "rw_optical_flow_motion_vector_field_x" FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
-		// "rw_optical_flow_motion_vector_field_y" FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
+		SPT.rwTexture("rw_optical_flow_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
+		SPT.rwTexture("rw_optical_flow_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
 		// "rw_disocclusion_mask" FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
 		// "rw_counters" FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
 		

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -66,7 +66,7 @@ struct InpaintingPyramidUniform
 static void setupDeviceDepthToViewSpaceDepthParams(const Camera* camera, float viewSpaceToMetersFactor, float outDeviceToViewDepth[4])
 {
 	const bool bInverted = getReverseZPolicy() == EReverseZPolicy::Reverse;
-	// #wip: reverse-z with non-infinite depth range?
+	// #todo-fsr3: reverse-z with non-infinite depth range?
 	const bool bInfinite = bInverted; //(context->contextDescription.flags & FFX_FRAMEINTERPOLATION_ENABLE_DEPTH_INFINITE) == FFX_FRAMEINTERPOLATION_ENABLE_DEPTH_INFINITE;
 
 	// make sure it has no impact if near and far plane values are swapped in dispatch params
@@ -610,7 +610,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 	const bool bExecutePreparationPasses = (false == bResetCurrentFrame);
 
-	// #wip: distortion field texture from passInput
+	// #todo-fsr3: distortion field texture from passInput
 	auto distortionFieldTexture            = defaultDistortionFieldTexture.get();
 	auto distortionFieldSRV                = defaultDistortionFieldSRV.get();
 	auto currInterpolationSourceTexture    = passInput.sceneColorTexture;

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -151,8 +151,8 @@ void FrameGenPass::initializePipelines()
 	const uint32 swapchainCount = 2;//device->maxFramesInFlight(); // Always need 2
 
 	prepareDescriptor.initialize(device, L"FSR3_Prepare", swapchainCount, 0);
-	frameInterpDescriptor.initialize(device, L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
-	inpaintingPyramidDescriptor.initialize(device, L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
+	frameInterpDescriptor.initialize(device, L"FSR3_FrameInterp", swapchainCount, sizeof(FrameInterpUniform));
+	inpaintingPyramidDescriptor.initialize(device, L"FSR3_InpaintingPyramid", swapchainCount, sizeof(InpaintingPyramidUniform));
 
 	reconstructPrevDepthDescriptor.initialize(device, L"FSR3_ReconstructPrevDepth", swapchainCount, 0);
 	gameMotionVectorFieldDescriptor.initialize(device, L"FSR3_GameMotionVectorField", swapchainCount, 0);
@@ -160,6 +160,7 @@ void FrameGenPass::initializePipelines()
 	opticalFlowVectorFieldDescriptor.initialize(device, L"FSR3_OpticalFlowVectorField", swapchainCount, 0);
 	disocclusionMaskDescriptor.initialize(device, L"FSR3_DisocclusionMask", swapchainCount, 0);
 	interpolationDescriptor.initialize(device, L"FSR3_Interpolation", swapchainCount, 0);
+	inpaintingDescriptor.initialize(device, L"FSR3_Inpainting", swapchainCount, 0);
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -1126,57 +1127,80 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 	}
 
-	// inpainting pyramid
 	{
+		SCOPED_DRAW_EVENT(commandList, InpaintingPyramid);
+
+		uint32 dispatchThreadGroupCountXY[2];
+		uint32 workGroupOffset[2];
+		uint32 numWorkGroupsAndMips[2];
+		uint32 rectInfo[4] = { 0, 0, (uint32)passInput.displaySizeX, (uint32)passInput.displaySizeY };
+		ffxSpdSetup(dispatchThreadGroupCountXY, workGroupOffset, numWorkGroupsAndMips, rectInfo, -1);
+
+		auto pipeline = inpaintingPyramidPipeline.get();
+		auto& passDescriptor = inpaintingPyramidDescriptor;
+
+		BufferBarrierAuto bufferBarriers[] = {
+			{ EBarrierSync::COMPUTE_SHADING, EBarrierAccess::UNORDERED_ACCESS, counterBuffer.get() },
+		};
+		TextureBarrierAuto textureBarriers[] = {
+			TextureBarrierAuto::toShaderResource(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
+		};
+		commandList->barrierAuto(_countof(bufferBarriers), bufferBarriers, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+		ShaderParameterTable SPT{};
+		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		SPT.constantBuffer("cbInpaintingPyramid", inpaintingPyramidUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_INPAINTING_PYRAMID
+		SPT.texture("r_output", interpolationOutputSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OUTPUT
+		SPT.rwBuffer("rw_counters", counterUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
+		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
 		{
-			SCOPED_DRAW_EVENT(commandList, InpaintingPyramid);
-
-			uint32 dispatchThreadGroupCountXY[2];
-			uint32 workGroupOffset[2];
-			uint32 numWorkGroupsAndMips[2];
-			uint32 rectInfo[4] = { 0, 0, (uint32)passInput.displaySizeX, (uint32)passInput.displaySizeY };
-			ffxSpdSetup(dispatchThreadGroupCountXY, workGroupOffset, numWorkGroupsAndMips, rectInfo, -1);
-
-			auto pipeline = inpaintingPyramidPipeline.get();
-			auto& passDescriptor = inpaintingPyramidDescriptor;
-
-			BufferBarrierAuto bufferBarriers[] = {
-				{ EBarrierSync::COMPUTE_SHADING, EBarrierAccess::UNORDERED_ACCESS, counterBuffer.get() },
-			};
-			TextureBarrierAuto textureBarriers[] = {
-				TextureBarrierAuto::toShaderResource(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toUnorderedAccess(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
-			};
-			commandList->barrierAuto(_countof(bufferBarriers), bufferBarriers, _countof(textureBarriers), textureBarriers, 0, nullptr);
-
-			ShaderParameterTable SPT{};
-			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
-			SPT.constantBuffer("cbInpaintingPyramid", inpaintingPyramidUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_INPAINTING_PYRAMID
-			SPT.texture("r_output", interpolationOutputSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OUTPUT
-			SPT.rwBuffer("rw_counters", counterUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
-			for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
-			{
-				// rw_inpainting_pyramid0 ~ rw_inpainting_pyramidN (FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_0 ~ N)
-				char msg[64];
-				std::snprintf(msg, _countof(msg), "rw_inpainting_pyramid%u", (uint32)i);
-				SPT.rwTexture(msg, inpaintingPyramidUAVs[i].get());
-			}
-
-			auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
-
-			commandList->setComputePipelineState(pipeline);
-			commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
-
-			commandList->dispatchCompute(dispatchThreadGroupCountXY[0], dispatchThreadGroupCountXY[1], 1);
+			// rw_inpainting_pyramid0 ~ rw_inpainting_pyramidN (FFX_FRAMEINTERPOLATION_BIND_UAV_INPAINTING_PYRAMID_MIPMAP_0 ~ N)
+			char msg[64];
+			std::snprintf(msg, _countof(msg), "rw_inpainting_pyramid%u", (uint32)i);
+			SPT.rwTexture(msg, inpaintingPyramidUAVs[i].get());
 		}
 
-		// #wip: Dispatch inpaintingPyramidPipeline
-		{
-			//
-		}
+		auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+		commandList->setComputePipelineState(pipeline);
+		commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+		commandList->dispatchCompute(dispatchThreadGroupCountXY[0], dispatchThreadGroupCountXY[1], 1);
 	}
 
-	// #wip: inpaintingPipeline
+	{
+		SCOPED_DRAW_EVENT(commandList, Inpainting);
+
+		auto pipeline = inpaintingPipeline.get();
+		auto& passDescriptor = inpaintingDescriptor;
+
+		// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
+		auto presentBackbufferSRV = currInterpolationSourceSRV;
+
+		TextureBarrierAuto textureBarriers[] = {
+			TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->sceneChangeDetectionTexture, EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
+		};
+		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+		ShaderParameterTable SPT{};
+		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		SPT.texture("r_optical_flow_scd", passInput.opticalFlowPassOutput->sceneChangeDetectionSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_SCENE_CHANGE_DETECTION
+		SPT.texture("r_inpainting_pyramid", inpaintingPyramidSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPAINTING_PYRAMID
+		SPT.texture("r_present_backbuffer", presentBackbufferSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_PRESENT_BACKBUFFER
+		SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+		SPT.rwTexture("rw_output", interpolationOutputUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OUTPUT
+
+		auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+		commandList->setComputePipelineState(pipeline);
+		commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
+	}
 
 	if (false /* draw debug view */)
 	{

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -1207,7 +1207,17 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		// #wip: Dispatch debugViewPipeline
 	}
 
-	// #wip: Store current buffer
+	{
+		SCOPED_DRAW_EVENT(commandList, StoreInterpolationSource);
+
+		TextureBarrierAuto barriersBefore[] = {
+			TextureBarrierAuto::toCopySource(currInterpolationSourceTexture),
+			TextureBarrierAuto::toCopyDest(prevInterpolationSourceTexture.get()),
+		};
+		commandList->barrierAuto(0, nullptr, _countof(barriersBefore), barriersBefore, 0, nullptr);
+
+		commandList->copyTexture2D(currInterpolationSourceTexture, prevInterpolationSourceTexture.get());
+	}
 }
 
 ConstantBufferView* FrameGenPass::getCurrentFrameInterpUniformCBV()

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -69,6 +69,12 @@ void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 	reconstructedPrevDepthTextures.initialize(swapchainCount);
 	reconstructedPrevDepthSRVs.initialize(swapchainCount);
 	reconstructedPrevDepthUAVs.initialize(swapchainCount);
+	dilatedMotionVectorTextures.initialize(swapchainCount);
+	dilatedMotionVectorSRVs.initialize(swapchainCount);
+	dilatedMotionVectorUAVs.initialize(swapchainCount);
+	dilatedDepthTextures.initialize(swapchainCount);
+	dilatedDepthSRVs.initialize(swapchainCount);
+	dilatedDepthUAVs.initialize(swapchainCount);
 
 	initializePipelines();
 }
@@ -157,6 +163,96 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 				reconstructedPrevDepthTextures[i].get(),
 				UnorderedAccessViewDesc{
 					.format         = reconstructedPrevDepthTextures[i]->getCreateParams().format,
+					.viewDimension  = EUAVDimension::Texture2D,
+					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+				}
+			));
+		}
+	}
+
+	for (size_t i = 0; i < dilatedMotionVectorTextures.size(); ++i)
+	{
+		if (dilatedMotionVectorTextures[i] == nullptr
+			|| dilatedMotionVectorTextures[i]->getCreateParams().width != passInput.displaySizeX
+			|| dilatedMotionVectorTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		{
+			commandList->enqueueDeferredDealloc(dilatedMotionVectorTextures[i].release(), true);
+			commandList->enqueueDeferredDealloc(dilatedMotionVectorSRVs[i].release(), true);
+			commandList->enqueueDeferredDealloc(dilatedMotionVectorUAVs[i].release(), true);
+
+			TextureCreateParams texDesc = TextureCreateParams::texture2D(
+				EPixelFormat::R16G16_FLOAT,
+				// #wip: (FFX_RESOURCE_USAGE_RENDERTARGET | FFX_RESOURCE_USAGE_UAV | FFX_RESOURCE_USAGE_DCC_RENDERTARGET) ???
+				ETextureAccessFlags::RTV | ETextureAccessFlags::UAV,
+				passInput.displaySizeX, passInput.displaySizeY);
+			dilatedMotionVectorTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
+
+			wchar_t debugName[128];
+			std::swprintf(debugName, _countof(debugName), L"RT_DilatedMotionVector_%u", (uint32)i);
+			dilatedMotionVectorTextures[i]->setDebugName(debugName);
+			
+			dilatedMotionVectorSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
+				dilatedMotionVectorTextures[i].get(),
+				ShaderResourceViewDesc{
+					.format              = dilatedMotionVectorTextures[i]->getCreateParams().format,
+					.viewDimension       = ESRVDimension::Texture2D,
+					.texture2D           = Texture2DSRVDesc{
+						.mostDetailedMip = 0,
+						.mipLevels       = 1,
+						.planeSlice      = 0,
+						.minLODClamp     = 0.0f,
+					},
+				}
+			));
+			dilatedMotionVectorUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
+				dilatedMotionVectorTextures[i].get(),
+				UnorderedAccessViewDesc{
+					.format         = dilatedMotionVectorTextures[i]->getCreateParams().format,
+					.viewDimension  = EUAVDimension::Texture2D,
+					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+				}
+			));
+		}
+	}
+
+	for (size_t i = 0; i < dilatedDepthTextures.size(); ++i)
+	{
+		if (dilatedDepthTextures[i] == nullptr
+			|| dilatedDepthTextures[i]->getCreateParams().width != passInput.displaySizeX
+			|| dilatedDepthTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		{
+			commandList->enqueueDeferredDealloc(dilatedDepthTextures[i].release(), true);
+			commandList->enqueueDeferredDealloc(dilatedDepthSRVs[i].release(), true);
+			commandList->enqueueDeferredDealloc(dilatedDepthUAVs[i].release(), true);
+
+			TextureCreateParams texDesc = TextureCreateParams::texture2D(
+				EPixelFormat::R32_FLOAT,
+				// #wip: (FFX_RESOURCE_USAGE_RENDERTARGET | FFX_RESOURCE_USAGE_UAV | FFX_RESOURCE_USAGE_DCC_RENDERTARGET) ???
+				ETextureAccessFlags::RTV | ETextureAccessFlags::UAV,
+				passInput.displaySizeX, passInput.displaySizeY);
+			dilatedDepthTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
+
+			wchar_t debugName[128];
+			std::swprintf(debugName, _countof(debugName), L"RT_DilatedDepth_%u", (uint32)i);
+			dilatedDepthTextures[i]->setDebugName(debugName);
+			
+			dilatedDepthSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
+				dilatedDepthTextures[i].get(),
+				ShaderResourceViewDesc{
+					.format              = dilatedDepthTextures[i]->getCreateParams().format,
+					.viewDimension       = ESRVDimension::Texture2D,
+					.texture2D           = Texture2DSRVDesc{
+						.mostDetailedMip = 0,
+						.mipLevels       = 1,
+						.planeSlice      = 0,
+						.minLODClamp     = 0.0f,
+					},
+				}
+			));
+			dilatedDepthUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
+				dilatedDepthTextures[i].get(),
+				UnorderedAccessViewDesc{
+					.format         = dilatedDepthTextures[i]->getCreateParams().format,
 					.viewDimension  = EUAVDimension::Texture2D,
 					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
 				}

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -438,7 +438,6 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		TextureCreateParams texDesc = TextureCreateParams::texture2D(
 			EPixelFormat::R16G16B16A16_FLOAT,
 			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
-			// #wip: What if inpaintingPyramid is not large enough to contain 13 mips?
 			inpaintingPyramidSizeX, inpaintingPyramidSizeY, _countof(inpaintingPyramidUAVs));
 
 		inpaintingPyramidTexture = UniquePtr<Texture>(device->createTexture(texDesc));
@@ -514,12 +513,12 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.Mode                       = 0, // #todo-fsr3: FidelityFX defines but does not use it.
 		.reset                      = bResetCurrentFrame || bDisjointFrameID,
 		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // Set below
-		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
+		.deltaTime                  = 0, // #todo-fsr3: FidelityFX defines but does not use it.
 		.HUDLessAttachedFactor      = 0,
 		.distortionFieldSize        = { 1, 1 },
 		.opticalFlowScale           = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
 		.opticalFlowBlockSize       = kOpticalFlowBlockSize,
-		.dispatchFlags              = passInput.dispatchFlags,
+		.dispatchFlags              = (uint32)passInput.dispatchFlags,
 		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
 		.opticalFlowHalfResMode     = 0, // #todo-fsr3: FidelityFX defines but does not use it.
 		.NumInstances               = 0, // #todo-fsr3: FidelityFX defines but does not use it.
@@ -726,7 +725,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
 			SPT.texture("r_dilated_depth", dilatedDepthSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
-			// #wip: not used but declared in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
+			// #todo-fsr3: declared but not used in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
 			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
 			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
 			SPT.rwTexture("rw_reconstructed_depth_interpolated_frame", reconstructedDepthInterpolatedFrameUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_INTERPOLATED_FRAME

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -451,12 +451,11 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		}
 	}
 
-	// #wip: I don't know what this is. FidelityFX does not fill this texture.
-	// The way this resource is used makes no sense.
-	// It's declared as uint2, but LoadOpticalFlowConfidence() reads its y channel and return as float.
+	// #todo-fsr3: Included in FidelityFX but not used. Probably dead code but create and bind it anyway.
+	// See r_optical_flow_confidence and FFX_FRAMEINTERPOLATION_RESOURCE_IDENTIFIER_OPTICAL_FLOW_CONFIDENCE.
+	// It's declared as uint2, but LoadOpticalFlowConfidence() reads its y channel and returns it as float.
 	// Then fConfidenceFactor = ffxMax(FFX_FRAMEINTERPOLATION_EPSILON, LoadOpticalFlowConfidence(samplePos)).
-	// Finally, fConfidenceFactor is just not used at all :(
-	// Let's just assume it's dead code and bind a black texture.
+	// Finally, fConfidenceFactor is just not used at all.
 	if (nullOrWrongSize(opticalFlowConfidenceTexture, passInput.displaySizeX, passInput.displaySizeY))
 	{
 		commandList->enqueueDeferredDealloc(opticalFlowConfidenceTexture.release(), true);

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -11,7 +11,6 @@
 
 // Input: 2 back buffers + several resources shared with FSR3Upscaler and FfxOpticalFlow
 // Output: An interpolated image between the 2 back buffers
-// 
 
 // FFX_DECLARE_CB(FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION)
 struct FrameInterpUniform
@@ -27,7 +26,7 @@ struct FrameInterpUniform
 	int32           Mode;
 	int32           reset;
 
-	float           fDeviceToViewDepth[4]; // #wip: setupDeviceDepthToViewSpaceDepthParams
+	float           fDeviceToViewDepth[4]; // See setupDeviceDepthToViewSpaceDepthParams
 
 	float           deltaTime; // In milliseconds
 	int32           HUDLessAttachedFactor; // 1 or 0 (#wip: Is it for HUD upscaling?)
@@ -62,6 +61,60 @@ struct InpaintingPyramidUniform
 	uint32          numWorkGroups;
 	uint32          workGroupOffset[2];
 };
+
+// Ported from ffx_frameinterpolation.cpp
+static void setupDeviceDepthToViewSpaceDepthParams(const Camera* camera, float viewSpaceToMetersFactor, float outDeviceToViewDepth[4])
+{
+	const bool bInverted = getReverseZPolicy() == EReverseZPolicy::Reverse;
+	// #wip: reverse-z with non-infinite depth range?
+	const bool bInfinite = bInverted; //(context->contextDescription.flags & FFX_FRAMEINTERPOLATION_ENABLE_DEPTH_INFINITE) == FFX_FRAMEINTERPOLATION_ENABLE_DEPTH_INFINITE;
+
+	// make sure it has no impact if near and far plane values are swapped in dispatch params
+	// the flags "inverted" and "infinite" will decide what transform to use
+	float fMin = std::min(camera->getZNear(), camera->getZFar());
+	float fMax = std::max(camera->getZNear(), camera->getZFar());
+
+	if (bInverted)
+	{
+		float tmp = fMin;
+		fMin = fMax;
+		fMax = tmp;
+	}
+
+	// a 0 0 0   x
+	// 0 b 0 0   y
+	// 0 0 c d   z
+	// 0 0 e 0   1
+
+	const float fQ = fMax / (fMin - fMax);
+	const float d = -1.0f; // for clarity
+
+	const float matrix_elem_c[2][2] = {
+		fQ,                     // non reversed, non infinite
+		-1.0f - FLT_EPSILON,    // non reversed, infinite
+		fQ,                     // reversed, non infinite
+		0.0f + FLT_EPSILON      // reversed, infinite
+	};
+
+	const float matrix_elem_e[2][2] = {
+		fQ * fMin,              // non reversed, non infinite
+		-fMin - FLT_EPSILON,    // non reversed, infinite
+		fQ * fMin,              // reversed, non infinite
+		fMax,                   // reversed, infinite
+	};
+
+	outDeviceToViewDepth[0] = d * matrix_elem_c[bInverted][bInfinite];
+	outDeviceToViewDepth[1] = matrix_elem_e[bInverted][bInfinite] * viewSpaceToMetersFactor;
+
+	// revert x and y coords
+	const float aspect = camera->getAspectRatio();
+	const float cotHalfFovY = cosf(0.5f * camera->getFovYInRadians()) / sinf(0.5f * camera->getFovYInRadians());
+	const float a = cotHalfFovY / aspect;
+	const float b = cotHalfFovY;
+
+	outDeviceToViewDepth[2] = (1.0f / a);
+	outDeviceToViewDepth[3] = (1.0f / b);
+}
 
 void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 {
@@ -105,6 +158,7 @@ void FrameGenPass::initializePipelines()
 	gameMotionVectorFieldDescriptor.initialize(device, L"FSR3_GameMotionVectorField", swapchainCount, 0);
 	gameMotionVectorFieldInpaintingPyramidDescriptor.initialize(device, L"FSR3_GameMotionVectorFieldInpaintingPyramid", swapchainCount, 0);
 	opticalFlowVectorFieldDescriptor.initialize(device, L"FSR3_OpticalFlowVectorField", swapchainCount, 0);
+	disocclusionMaskDescriptor.initialize(device, L"FSR3_DisocclusionMask", swapchainCount, 0);
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -507,6 +561,20 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 
 		inpaintingPyramidTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		inpaintingPyramidTexture->setDebugName(L"RT_FSR3_InpaintingPyramidTexture");
+
+		inpaintingPyramidSRV = UniquePtr<ShaderResourceView>(device->createSRV(
+			inpaintingPyramidTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = inpaintingPyramidTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = inpaintingPyramidTexture->getCreateParams().mipLevels,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
 		
 		for (size_t i = 0; i < _countof(inpaintingPyramidUAVs); ++i)
 		{
@@ -571,7 +639,7 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #wip: upscale target size
 		.Mode                       = 0, // #wip: What is this? No shader accesses it, even ffx source code does not use it.
 		.reset                      = passInput.bReset,
-		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #wip: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
+		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // Set below
 		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
 		.HUDLessAttachedFactor      = 0,
 		.distortionFieldSize        = { 1, 1 },
@@ -591,6 +659,8 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.fJitter                    = { 0, 0 }, // #wip: jitter
 		.fMotionVectorScale         = { 1.0f, 1.0f },
 	};
+	setupDeviceDepthToViewSpaceDepthParams(passInput.camera, 1.0f, fiUniformData.fDeviceToViewDepth);
+
 	frameInterpUniformCBV->writeToGPU(commandList, &fiUniformData, sizeof(fiUniformData));
 
 	uint32 dispatchThreadGroupCountXY[2];
@@ -782,14 +852,17 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		Texture* distortionFieldTexture = defaultDistortionFieldTexture.get();
 		ShaderResourceView* distortionFieldSRV = defaultDistortionFieldSRV.get();
 
-		Texture* dilatedMotionVectorTexture = dilatedMotionVectorTextures[currResourceIndex].get();
-		ShaderResourceView* dilatedMotionVectorSRV = dilatedMotionVectorSRVs[currResourceIndex].get();
-
-		Texture* dilatedDepthTexture = dilatedDepthTextures[currResourceIndex].get();
-		ShaderResourceView* dilatedDepthSRV = dilatedDepthSRVs[currResourceIndex].get();
-
-		Texture* currInterpolationSourceTexture = passInput.sceneColorTexture;
-		ShaderResourceView* currInterpolationSourceSRV = passInput.sceneColorSRV;
+		auto reconstructedPrevDepthTexture = reconstructedPrevDepthTextures[currResourceIndex].get();
+		auto reconstructedPrevDepthSRV = reconstructedPrevDepthSRVs[currResourceIndex].get();
+		auto reconstructedPrevDepthUAV = reconstructedPrevDepthUAVs[currResourceIndex].get();
+		auto dilatedMotionVectorTexture = dilatedMotionVectorTextures[currResourceIndex].get();
+		auto dilatedMotionVectorSRV = dilatedMotionVectorSRVs[currResourceIndex].get();
+		auto dilatedMotionVectorUAV = dilatedMotionVectorUAVs[currResourceIndex].get();
+		auto dilatedDepthTexture = dilatedDepthTextures[currResourceIndex].get();
+		auto dilatedDepthSRV = dilatedDepthSRVs[currResourceIndex].get();
+		auto dilatedDepthUAV = dilatedDepthUAVs[currResourceIndex].get();
+		auto currInterpolationSourceTexture = passInput.sceneColorTexture;
+		auto currInterpolationSourceSRV = passInput.sceneColorSRV;
 
 		{
 			SCOPED_DRAW_EVENT(commandList, ReconstructDepthPrevFrame);
@@ -895,9 +968,41 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 		}
 
-		// #wip: Dispatch disocclusionMaskPipeline
 		{
-			//
+			SCOPED_DRAW_EVENT(commandList, DisocclusionMask);
+
+			auto pipeline = disocclusionMaskPipeline.get();
+			auto& passDescriptor = disocclusionMaskDescriptor;
+
+			TextureBarrierAuto textureBarriers[] = {
+				TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(reconstructedPrevDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(reconstructedDepthInterpolatedFrameTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toUnorderedAccess(disocclusionMaskTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			};
+			commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+			ShaderParameterTable SPT{};
+			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+			SPT.texture("r_game_motion_vector_field_x", gameMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_X
+			SPT.texture("r_game_motion_vector_field_y", gameMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_Y
+			SPT.texture("r_reconstructed_depth_previous_frame", reconstructedPrevDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME
+			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_reconstructed_depth_interpolated_frame", reconstructedDepthInterpolatedFrameSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_RECONSTRUCTED_DEPTH_INTERPOLATED_FRAME
+			SPT.texture("r_inpainting_pyramid", inpaintingPyramidSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPAINTING_PYRAMID
+			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
+			SPT.rwTexture("rw_disocclusion_mask", disocclusionMaskUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
+
+			auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+			commandList->setComputePipelineState(pipeline);
+			commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 		}
 	}
 

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -1,5 +1,8 @@
 #include "frame_gen_pass.h"
 #include "rhi/render_device.h"
+#include "world/camera.h"
+
+// See sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp
 
 // FFX_DECLARE_CB(FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION)
 struct FrameInterpUniform
@@ -15,10 +18,10 @@ struct FrameInterpUniform
 	int32           Mode;
 	int32           reset;
 
-	float           fDeviceToViewDepth[4];
+	float           fDeviceToViewDepth[4]; // #wip: setupDeviceDepthToViewSpaceDepthParams
 
 	float           deltaTime;
-	int32           HUDLessAttachedFactor;
+	int32           HUDLessAttachedFactor; // 1 or 0 (#wip: Is it for HUD upscaling?)
 	int32           distortionFieldSize[2];
 
 	float           opticalFlowScale[2];
@@ -60,7 +63,8 @@ void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 
 void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
-	//
+	preparePhase(commandList, swapchainIndex, passInput);
+	dispatchPhase(commandList, swapchainIndex, passInput);
 }
 
 void FrameGenPass::initializePipelines()
@@ -245,4 +249,90 @@ void FrameGenPass::initializePipelines()
 
 		delete shader;
 	}
+}
+
+// See ffxFrameInterpolationPrepare.
+void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
+{
+	// #wip: Dispatch reconstructAndDilatePipeline
+}
+
+// See ffxFrameInterpolationDispatch.
+void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
+{
+	FrameInterpUniform uniformData{
+		.renderSize                 = { passInput.renderSizeX, passInput.renderSizeY },
+		.displaySize                = { passInput.displaySizeX, passInput.displaySizeY },
+		.displaySizeRcp             = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
+		.cameraNear                 = passInput.camera->getZNear(),
+		.cameraFar                  = passInput.camera->getZFar(),
+		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #wip: upscale target size
+		.Mode                       = 0, // #wip: What is this? No shader accesses it, even ffx source code does not use it.
+		.reset                      = 0, // #wip: reset, see ffxFrameInterpolationDispatch
+		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // #wip: fDeviceToViewDepth, see setupDeviceDepthToViewSpaceDepthParams
+		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
+		.HUDLessAttachedFactor      = 0,
+		.distortionFieldSize        = { 1, 1 },
+		.opticalFlowScale           = { 1.0f, 1.0f }, // #wip: opticalFlowScale
+		.opticalFlowBlockSize       = passInput.opticalFlowBlockSize,
+		.dispatchFlags              = passInput.dispatchFlags,
+		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
+		.opticalFlowHalfResMode     = 0, // #wip: opticalFlowHalfResMode
+		.NumInstances               = 0, // #wip: NumInstances unused?
+		.interpolationRectBase      = { 0, 0 },
+		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
+		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
+		.backBufferTransferFunction = passInput.backBufferTransferFunction,
+		.minMaxLuminance            = { 0.0f, 65000.0f }, // #todo-fsr: minMaxLuminance
+		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
+		._pad1                      = 0,
+		.fJitter                    = { 0, 0 }, // #wip: jitter
+		.fMotionVectorScale         = { 1.0f, 1.0f },
+	};
+
+	ConstantBufferView* passUniformCBV = frameInterpDescriptor.getUniformCBV(swapchainIndex);
+	passUniformCBV->writeToGPU(commandList, &uniformData, sizeof(uniformData));
+
+	const uint32 displayDispatchSizeX = (passInput.displaySizeX + 7) / 8;
+	const uint32 displayDispatchSizeY = (passInput.displaySizeY + 7) / 8;
+
+	const uint32 renderDispatchSizeX = (passInput.renderSizeX + 7) / 8;
+	const uint32 renderDispatchSizeY = (passInput.renderSizeY + 7) / 8;
+
+	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)passInput.opticalFlowBlockSize + 7) / 8;
+	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)passInput.opticalFlowBlockSize + 7) / 8;
+
+	// #wip: Dispatch setupPipeline (renderDispatchSizeX/Y)
+	// #wip: Dispatch gameVectorFieldInpaintingPyramidPipeline
+
+	if (uniformData.reset == 0)
+	{
+		// #wip: Clear estimated depth resources
+		// ...
+
+		// #wip: Dispatch reconstructPrevDepthPipeline
+		// #wip: Dispatch gameMotionVectorFieldPipeline
+		
+		// #wip: scheduleDispatchGameVectorFieldInpaintingPyramid()
+
+		// #wip: Dispatch opticalFlowVectorFieldPipeline
+		// #wip: Dispatch disocclusionMaskPipeline
+	}
+
+	// #wip: Dispatch interpolationPipeline (pipelineFiScfi in ffx)
+
+	// inpainting pyramid
+	{
+		// #wip: Auto exposure via SPD
+		// #wip: Dispatch inpaintingPyramidPipeline
+	}
+
+	// #wip: inpaintingPipeline
+
+	if (false /* draw debug view */)
+	{
+		// #wip: Dispatch debugViewPipeline
+	}
+
+	// #wip: Store current buffer
 }

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -262,6 +262,36 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			));
 		}
 	}
+
+	for (uint32 i = 0; i < 2; ++i)
+	{
+		if (gameMotionVectorFieldTextures[i] == nullptr
+			|| gameMotionVectorFieldTextures[i]->getCreateParams().width != passInput.displaySizeX
+			|| gameMotionVectorFieldTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		{
+			commandList->enqueueDeferredDealloc(gameMotionVectorFieldTextures[i].release(), true);
+			commandList->enqueueDeferredDealloc(gameMotionVectorFieldUAVs[i].release(), true);
+
+			TextureCreateParams texDesc = TextureCreateParams::texture2D(
+				EPixelFormat::R32_UINT,
+				ETextureAccessFlags::UAV,
+				passInput.displaySizeX, passInput.displaySizeY);
+			gameMotionVectorFieldTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
+
+			wchar_t debugName[128];
+			std::swprintf(debugName, _countof(debugName), L"RT_GameMotionVectorField_%s", i == 0 ? L"X" : L"Y");
+			gameMotionVectorFieldTextures[i]->setDebugName(debugName);
+
+			gameMotionVectorFieldUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
+				gameMotionVectorFieldTextures[i].get(),
+				UnorderedAccessViewDesc{
+					.format         = gameMotionVectorFieldTextures[i]->getCreateParams().format,
+					.viewDimension  = EUAVDimension::Texture2D,
+					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+				}
+			));
+		}
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -403,8 +433,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		ShaderParameterTable SPT{};
 		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 		SPT.texture("r_optical_flow_scd", passInput.opticalFlowPassOutput->sceneChangeDetectionSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_SCENE_CHANGE_DETECTION
-		// "rw_game_motion_vector_field_x" FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
-		// "rw_game_motion_vector_field_y" FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
+		SPT.rwTexture("rw_game_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
+		SPT.rwTexture("rw_game_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
 		// "rw_optical_flow_motion_vector_field_x" FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
 		// "rw_optical_flow_motion_vector_field_y" FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
 		// "rw_disocclusion_mask" FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -121,17 +121,6 @@ void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 	device = inRenderDevice;
 	cpuFrameIndex = 0;
 
-	const uint32 swapchainCount = 2;
-	reconstructedPrevDepthTextures.initialize(swapchainCount);
-	reconstructedPrevDepthSRVs.initialize(swapchainCount);
-	reconstructedPrevDepthUAVs.initialize(swapchainCount);
-	dilatedMotionVectorTextures.initialize(swapchainCount);
-	dilatedMotionVectorSRVs.initialize(swapchainCount);
-	dilatedMotionVectorUAVs.initialize(swapchainCount);
-	dilatedDepthTextures.initialize(swapchainCount);
-	dilatedDepthSRVs.initialize(swapchainCount);
-	dilatedDepthUAVs.initialize(swapchainCount);
-
 	initializePipelines();
 }
 
@@ -235,27 +224,21 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		));
 	};
 
-	for (size_t i = 0; i < reconstructedPrevDepthTextures.size(); ++i)
+	if (nullOrWrongSize(reconstructedPrevDepthTexture, passInput.displaySizeX, passInput.displaySizeY))
 	{
-		if (nullOrWrongSize(reconstructedPrevDepthTextures[i], passInput.displaySizeX, passInput.displaySizeY))
-		{
-			commandList->enqueueDeferredDealloc(reconstructedPrevDepthTextures[i].release(), true);
-			commandList->enqueueDeferredDealloc(reconstructedPrevDepthSRVs[i].release(), true);
-			commandList->enqueueDeferredDealloc(reconstructedPrevDepthUAVs[i].release(), true);
+		commandList->enqueueDeferredDealloc(reconstructedPrevDepthTexture.release(), true);
+		commandList->enqueueDeferredDealloc(reconstructedPrevDepthSRV.release(), true);
+		commandList->enqueueDeferredDealloc(reconstructedPrevDepthUAV.release(), true);
 
-			TextureCreateParams texDesc = TextureCreateParams::texture2D(
-				EPixelFormat::R32_FLOAT,
-				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
-				passInput.displaySizeX, passInput.displaySizeY);
-			reconstructedPrevDepthTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R32_FLOAT,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		reconstructedPrevDepthTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		reconstructedPrevDepthTexture->setDebugName(L"RT_FSR3_ReconstructedPrevDepth");
 
-			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_ReconstructedPrevDepth_%u", (uint32)i);
-			reconstructedPrevDepthTextures[i]->setDebugName(debugName);
-
-			reconstructedPrevDepthSRVs[i] = createAllMipsSRV(reconstructedPrevDepthTextures[i].get());
-			reconstructedPrevDepthUAVs[i] = createSingleMipUAV(reconstructedPrevDepthTextures[i].get(), 0);
-		}
+		reconstructedPrevDepthSRV = createAllMipsSRV(reconstructedPrevDepthTexture.get());
+		reconstructedPrevDepthUAV = createSingleMipUAV(reconstructedPrevDepthTexture.get(), 0);
 	}
 
 	if (nullOrWrongSize(reconstructedDepthInterpolatedFrameTexture, passInput.displaySizeX, passInput.displaySizeY))
@@ -275,50 +258,38 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		reconstructedDepthInterpolatedFrameUAV = createSingleMipUAV(reconstructedDepthInterpolatedFrameTexture.get(), 0);
 	}
 
-	for (size_t i = 0; i < dilatedMotionVectorTextures.size(); ++i)
+	if (nullOrWrongSize(dilatedMotionVectorTexture, passInput.displaySizeX, passInput.displaySizeY))
 	{
-		if (nullOrWrongSize(dilatedMotionVectorTextures[i], passInput.displaySizeX, passInput.displaySizeY))
-		{
-			commandList->enqueueDeferredDealloc(dilatedMotionVectorTextures[i].release(), true);
-			commandList->enqueueDeferredDealloc(dilatedMotionVectorSRVs[i].release(), true);
-			commandList->enqueueDeferredDealloc(dilatedMotionVectorUAVs[i].release(), true);
+		commandList->enqueueDeferredDealloc(dilatedMotionVectorTexture.release(), true);
+		commandList->enqueueDeferredDealloc(dilatedMotionVectorSRV.release(), true);
+		commandList->enqueueDeferredDealloc(dilatedMotionVectorUAV.release(), true);
 
-			TextureCreateParams texDesc = TextureCreateParams::texture2D(
-				EPixelFormat::R16G16_FLOAT,
-				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
-				passInput.displaySizeX, passInput.displaySizeY);
-			dilatedMotionVectorTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
-
-			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_DilatedMotionVector_%u", (uint32)i);
-			dilatedMotionVectorTextures[i]->setDebugName(debugName);
-			
-			dilatedMotionVectorSRVs[i] = createAllMipsSRV(dilatedMotionVectorTextures[i].get());
-			dilatedMotionVectorUAVs[i] = createSingleMipUAV(dilatedMotionVectorTextures[i].get(), 0);
-		}
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R16G16_FLOAT,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		dilatedMotionVectorTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		dilatedMotionVectorTexture->setDebugName(L"RT_FSR3_DilatedMotionVector");
+		
+		dilatedMotionVectorSRV = createAllMipsSRV(dilatedMotionVectorTexture.get());
+		dilatedMotionVectorUAV = createSingleMipUAV(dilatedMotionVectorTexture.get(), 0);
 	}
 
-	for (size_t i = 0; i < dilatedDepthTextures.size(); ++i)
+	if (nullOrWrongSize(dilatedDepthTexture, passInput.displaySizeX, passInput.displaySizeY))
 	{
-		if (nullOrWrongSize(dilatedDepthTextures[i], passInput.displaySizeX, passInput.displaySizeY))
-		{
-			commandList->enqueueDeferredDealloc(dilatedDepthTextures[i].release(), true);
-			commandList->enqueueDeferredDealloc(dilatedDepthSRVs[i].release(), true);
-			commandList->enqueueDeferredDealloc(dilatedDepthUAVs[i].release(), true);
+		commandList->enqueueDeferredDealloc(dilatedDepthTexture.release(), true);
+		commandList->enqueueDeferredDealloc(dilatedDepthSRV.release(), true);
+		commandList->enqueueDeferredDealloc(dilatedDepthUAV.release(), true);
 
-			TextureCreateParams texDesc = TextureCreateParams::texture2D(
-				EPixelFormat::R32_FLOAT,
-				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
-				passInput.displaySizeX, passInput.displaySizeY);
-			dilatedDepthTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
-
-			wchar_t debugName[128];
-			std::swprintf(debugName, _countof(debugName), L"RT_FSR3_DilatedDepth_%u", (uint32)i);
-			dilatedDepthTextures[i]->setDebugName(debugName);
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R32_FLOAT,
+			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+			passInput.displaySizeX, passInput.displaySizeY);
+		dilatedDepthTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		dilatedDepthTexture->setDebugName(L"RT_FSR3_DilatedDepth");
 			
-			dilatedDepthSRVs[i] = createAllMipsSRV(dilatedDepthTextures[i].get());
-			dilatedDepthUAVs[i] = createSingleMipUAV(dilatedDepthTextures[i].get(), 0);
-		}
+		dilatedDepthSRV = createAllMipsSRV(dilatedDepthTexture.get());
+		dilatedDepthUAV = createSingleMipUAV(dilatedDepthTexture.get(), 0);
 	}
 
 	for (uint32 i = 0; i < 2; ++i)
@@ -579,28 +550,19 @@ void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchain
 {
 	SCOPED_DRAW_EVENT(commandList, FrameGenPrepare);
 
-	const uint32 currResourceIndex = (cpuFrameIndex & 1);
-	const uint32 prevResourceIndex = ((cpuFrameIndex + 1) & 1);
-
 	auto uniformCBV = getCurrentFrameInterpUniformCBV();
-	auto reconstructedPrevDepthTexture = reconstructedPrevDepthTextures[currResourceIndex].get();
-	auto reconstructedPrevDepthUAV = reconstructedPrevDepthUAVs[currResourceIndex].get();
-	auto dilatedMotionVectorTexture = dilatedMotionVectorTextures[currResourceIndex].get();
-	auto dilatedMotionVectorUAV = dilatedMotionVectorUAVs[currResourceIndex].get();
-	auto dilatedDepthTexture = dilatedDepthTextures[currResourceIndex].get();
-	auto dilatedDepthUAV = dilatedDepthUAVs[currResourceIndex].get();
 
 	// Clear estimated depth resources.
 	auto fClearZero = ClearResourcePass::floatClearValue(getDeviceFarDepth(), 0, 0, 0);
-	passInput.clearResourcePass->enqueueClear(reconstructedPrevDepthTexture, reconstructedPrevDepthUAV, fClearZero);
+	passInput.clearResourcePass->enqueueClear(reconstructedPrevDepthTexture.get(), reconstructedPrevDepthUAV.get(), fClearZero);
 	passInput.clearResourcePass->executeClears(commandList, swapchainIndex);
 
 	TextureBarrierAuto textureBarriers[] = {
 		TextureBarrierAuto::toShaderResource(passInput.motionVectorTexture, EBarrierSync::COMPUTE_SHADING),
 		TextureBarrierAuto::toShaderResource(passInput.sceneDepthTexture, EBarrierSync::COMPUTE_SHADING),
-		TextureBarrierAuto::toUnorderedAccess(reconstructedPrevDepthTexture, EBarrierSync::COMPUTE_SHADING),
-		TextureBarrierAuto::toUnorderedAccess(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
-		TextureBarrierAuto::toUnorderedAccess(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+		TextureBarrierAuto::toUnorderedAccess(reconstructedPrevDepthTexture.get(), EBarrierSync::COMPUTE_SHADING),
+		TextureBarrierAuto::toUnorderedAccess(dilatedMotionVectorTexture.get(), EBarrierSync::COMPUTE_SHADING),
+		TextureBarrierAuto::toUnorderedAccess(dilatedDepthTexture.get(), EBarrierSync::COMPUTE_SHADING),
 	};
 	commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
 
@@ -608,9 +570,9 @@ void FrameGenPass::preparePhase(RenderCommandList* commandList, uint32 swapchain
 	SPT.constantBuffer("cbFI", uniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 	SPT.texture("r_input_motion_vectors", passInput.motionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_MOTION_VECTORS
 	SPT.texture("r_input_depth", passInput.sceneDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPUT_DEPTH
-	SPT.rwTexture("rw_reconstructed_depth_previous_frame", reconstructedPrevDepthUAV); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME
-	SPT.rwTexture("rw_dilated_motion_vectors", dilatedMotionVectorUAV); // FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_MOTION_VECTORS
-	SPT.rwTexture("rw_dilated_depth", dilatedDepthUAV); // FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_DEPTH
+	SPT.rwTexture("rw_reconstructed_depth_previous_frame", reconstructedPrevDepthUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME
+	SPT.rwTexture("rw_dilated_motion_vectors", dilatedMotionVectorUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_MOTION_VECTORS
+	SPT.rwTexture("rw_dilated_depth", dilatedDepthUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_DILATED_DEPTH
 
 	prepareDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
 	auto descriptorHeap = prepareDescriptor.getDescriptorHeap(swapchainIndex);
@@ -629,9 +591,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 {
 	ConstantBufferView* frameInterpUniformCBV = getCurrentFrameInterpUniformCBV();
 	ConstantBufferView* inpaintingPyramidUniformCBV = getCurrentInpaintingPyramidUniformCBV();
-
-	const uint32 currResourceIndex = (cpuFrameIndex & 1);
-	const uint32 prevResourceIndex = ((cpuFrameIndex + 1) & 1);
 
 	const bool bReset = (interpolationDispatchCount == 0) || passInput.bReset;
 
@@ -655,16 +614,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	// #wip: distortion field texture from passInput
 	auto distortionFieldTexture            = defaultDistortionFieldTexture.get();
 	auto distortionFieldSRV                = defaultDistortionFieldSRV.get();
-
-	auto reconstructedPrevDepthTexture     = reconstructedPrevDepthTextures[currResourceIndex].get();
-	auto reconstructedPrevDepthSRV         = reconstructedPrevDepthSRVs[currResourceIndex].get();
-	auto reconstructedPrevDepthUAV         = reconstructedPrevDepthUAVs[currResourceIndex].get();
-	auto dilatedMotionVectorTexture        = dilatedMotionVectorTextures[currResourceIndex].get();
-	auto dilatedMotionVectorSRV            = dilatedMotionVectorSRVs[currResourceIndex].get();
-	auto dilatedMotionVectorUAV            = dilatedMotionVectorUAVs[currResourceIndex].get();
-	auto dilatedDepthTexture               = dilatedDepthTextures[currResourceIndex].get();
-	auto dilatedDepthSRV                   = dilatedDepthSRVs[currResourceIndex].get();
-	auto dilatedDepthUAV                   = dilatedDepthUAVs[currResourceIndex].get();
 	auto currInterpolationSourceTexture    = passInput.sceneColorTexture;
 	auto currInterpolationSourceSRV        = passInput.sceneColorSRV;
 
@@ -766,8 +715,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			auto& passDescriptor = reconstructPrevDepthDescriptor;
 
 			TextureBarrierAuto textureBarriers[] = {
-				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toUnorderedAccess(reconstructedDepthInterpolatedFrameTexture.get(), EBarrierSync::COMPUTE_SHADING),
@@ -776,8 +725,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 			ShaderParameterTable SPT{};
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
-			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
-			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
+			SPT.texture("r_dilated_depth", dilatedDepthSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			// #wip: not used but declared in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
 			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
 			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
@@ -798,8 +747,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			auto& passDescriptor = gameMotionVectorFieldDescriptor;
 
 			TextureBarrierAuto textureBarriers[] = {
-				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture, EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(prevInterpolationSourceTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
@@ -810,8 +759,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 
 			ShaderParameterTable SPT{};
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
-			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
-			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
+			SPT.texture("r_dilated_depth", dilatedDepthSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			SPT.texture("r_previous_interpolation_source", prevInterpolationSourceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_PREVIOUS_INTERPOLATION_SOURCE
 			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
 			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
@@ -837,7 +786,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			TextureBarrierAuto textureBarriers[] = {
 				TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->opticalFlowVectorTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(opticalFlowConfidenceTexture.get(), EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(prevInterpolationSourceTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
@@ -849,7 +798,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 			SPT.texture("r_optical_flow", passInput.opticalFlowPassOutput->opticalFlowVectorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW
 			SPT.texture("r_optical_flow_confidence", opticalFlowConfidenceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_CONFIDENCE
-			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_dilated_depth", dilatedDepthSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			SPT.texture("r_previous_interpolation_source", prevInterpolationSourceSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_PREVIOUS_INTERPOLATION_SOURCE
 			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
 			SPT.rwTexture("rw_optical_flow_motion_vector_field_x", opticalFlowMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
@@ -872,8 +821,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			TextureBarrierAuto textureBarriers[] = {
 				TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(reconstructedPrevDepthTexture, EBarrierSync::COMPUTE_SHADING),
-				TextureBarrierAuto::toShaderResource(dilatedDepthTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(reconstructedPrevDepthTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(reconstructedDepthInterpolatedFrameTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
 				TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
@@ -885,8 +834,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 			SPT.texture("r_game_motion_vector_field_x", gameMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_X
 			SPT.texture("r_game_motion_vector_field_y", gameMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_Y
-			SPT.texture("r_reconstructed_depth_previous_frame", reconstructedPrevDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME
-			SPT.texture("r_dilated_depth", dilatedDepthSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			SPT.texture("r_reconstructed_depth_previous_frame", reconstructedPrevDepthSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_RECONSTRUCTED_DEPTH_PREVIOUS_FRAME
+			SPT.texture("r_dilated_depth", dilatedDepthSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
 			SPT.texture("r_reconstructed_depth_interpolated_frame", reconstructedDepthInterpolatedFrameSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_RECONSTRUCTED_DEPTH_INTERPOLATED_FRAME
 			SPT.texture("r_inpainting_pyramid", inpaintingPyramidSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPAINTING_PYRAMID
 			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -29,7 +29,7 @@ struct FrameInterpUniform
 	float           fDeviceToViewDepth[4]; // See setupDeviceDepthToViewSpaceDepthParams
 
 	float           deltaTime; // In milliseconds
-	int32           HUDLessAttachedFactor; // 1 or 0 (#wip: Is it for HUD upscaling?)
+	int32           HUDLessAttachedFactor; // 1 or 0
 	int32           distortionFieldSize[2];
 
 	float           opticalFlowScale[2];
@@ -515,7 +515,7 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.reset                      = bResetCurrentFrame || bDisjointFrameID,
 		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // Set below
 		.deltaTime                  = 0, // #todo-fsr3: FidelityFX defines but does not use it.
-		.HUDLessAttachedFactor      = 0,
+		.HUDLessAttachedFactor      = 0, // #todo-fsr3: HUDLessAttachedFactor
 		.distortionFieldSize        = { 1, 1 },
 		.opticalFlowScale           = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
 		.opticalFlowBlockSize       = kOpticalFlowBlockSize,
@@ -530,7 +530,7 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.minMaxLuminance            = { passInput.minLuminance, passInput.maxLuminance },
 		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
 		._pad1                      = 0,
-		.fJitter                    = { 0, 0 }, // #wip: jitter
+		.fJitter                    = { 0, 0 }, // #todo-fsr3: Probably needed when doing super resolution AND interpolation.
 		.fMotionVectorScale         = { 1.0f, 1.0f },
 	};
 	setupDeviceDepthToViewSpaceDepthParams(passInput.camera, 1.0f, fiUniformData.fDeviceToViewDepth);
@@ -935,7 +935,8 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		commandList->dispatchCompute(dispatchThreadGroupCountXY[0], dispatchThreadGroupCountXY[1], 1);
 	}
 
-	// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
+	// #todo-fsr3-presentbackbuffer: Revisit when dealing with swapchain interaction.
+	// Currently just assume that PRESENT_BACKBUFFER == currInterpolationSourceTexture.
 	auto presentBackbufferSRV = currInterpolationSourceSRV;
 
 	{
@@ -947,7 +948,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		TextureBarrierAuto textureBarriers[] = {
 			TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->sceneChangeDetectionTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
-			// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
+			// #todo-fsr3-presentbackbuffer
 			//TextureBarrierAuto::toShaderResource(presentBackbufferTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toUnorderedAccess(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
@@ -983,7 +984,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(disocclusionMaskTexture.get(), EBarrierSync::COMPUTE_SHADING),
-			// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
+			// #todo-fsr3-presentbackbuffer
 			//TextureBarrierAuto::toShaderResource(presentBackbufferTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -100,12 +100,21 @@ void FrameGenPass::initializePipelines()
 	frameInterpDescriptor.initialize(device, L"FSR3_FrameInterpUniform", swapchainCount, sizeof(FrameInterpUniform));
 	inpaintingPyramidDescriptor.initialize(device, L"FSR3_InpaintingPyramidUniform", swapchainCount, sizeof(InpaintingPyramidUniform));
 
+	reconstructPrevDepthDescriptor.initialize(device, L"FSR3_ReconstructPrevDepth", swapchainCount, 0);
+
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
 	{
+		std::vector<std::wstring> defines = { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" };
+		if (getReverseZPolicy() == EReverseZPolicy::Reverse)
+		{
+			// Not all FSR3 shaders require it, but no harm also.
+			defines.push_back(L"FFX_FRAMEINTERPOLATION_OPTION_INVERTED_DEPTH");
+		}
+
 		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, debugName);
 		shader->declarePushConstants();
-		shader->loadFromFile(filepath, "CS", { L"FFX_GPU", L"FFX_HLSL", L"FFX_HALF" });
+		shader->loadFromFile(filepath, "CS", defines);
 
 		pipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
 			ComputePipelineDesc{ .cs = shader, .nodeMask = 0 }
@@ -184,7 +193,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		commandList->enqueueDeferredDealloc(reconstructedDepthInterpolatedFrameUAV.release(), true);
 
 		TextureCreateParams texDesc = TextureCreateParams::texture2D(
-			EPixelFormat::R32_FLOAT,
+			EPixelFormat::R32_UINT,
 			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 			passInput.displaySizeX, passInput.displaySizeY);
 		reconstructedDepthInterpolatedFrameTexture = UniquePtr<Texture>(device->createTexture(texDesc));
@@ -417,6 +426,29 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			}
 		));
 	}
+
+	if (defaultDistortionFieldTexture == nullptr)
+	{
+		TextureCreateParams texDesc = TextureCreateParams::texture2D(
+			EPixelFormat::R8G8_UNORM, ETextureAccessFlags::SRV, 1, 1);
+		texDesc.setOptimalClearColor(0, 0, 0, 0);
+		defaultDistortionFieldTexture = UniquePtr<Texture>(device->createTexture(texDesc));
+		defaultDistortionFieldTexture->setDebugName(L"RT_FSR3_DefaultDistortionField");
+		
+		defaultDistortionFieldSRV = UniquePtr<ShaderResourceView>(device->createSRV(
+			defaultDistortionFieldTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = defaultDistortionFieldTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = 1,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -526,6 +558,9 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	ConstantBufferView* frameInterpUniformCBV = getCurrentFrameInterpUniformCBV();
 	ConstantBufferView* inpaintingPyramidUniformCBV = getCurrentInpaintingPyramidUniformCBV();
 
+	const uint32 currResourceIndex = (cpuFrameIndex & 1);
+	const uint32 prevResourceIndex = ((cpuFrameIndex + 1) & 1);
+
 	const bool bReset = (interpolationDispatchCount == 0) || passInput.bReset;
 
 	const bool bFrameID_decreased = passInput.frameID < prevFrameID;
@@ -629,7 +664,38 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			ClearResourcePass::floatClearValue(zFar, zFar, zFar, zFar));
 		passInput.clearResourcePass->executeClears(commandList, swapchainIndex);
 
-		// #wip: Dispatch reconstructPrevDepthPipeline
+		{
+			SCOPED_DRAW_EVENT(commandList, ReconstructDepthPrevFrame);
+
+			auto pipeline = reconstructPrevDepthPipeline.get();
+			auto& passDescriptor = reconstructPrevDepthDescriptor;
+
+			TextureBarrierAuto textureBarriers[] = {
+				TextureBarrierAuto::toShaderResource(dilatedMotionVectorTextures[currResourceIndex].get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(dilatedDepthTextures[currResourceIndex].get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(passInput.sceneColorTexture, EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toShaderResource(defaultDistortionFieldTexture.get(), EBarrierSync::COMPUTE_SHADING),
+				TextureBarrierAuto::toUnorderedAccess(reconstructedDepthInterpolatedFrameTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			};
+			commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+			ShaderParameterTable SPT{};
+			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRVs[currResourceIndex].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
+			SPT.texture("r_dilated_depth", dilatedDepthSRVs[currResourceIndex].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
+			// #wip: not used but declared in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
+			SPT.texture("r_current_interpolation_source", passInput.sceneColorSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+			SPT.texture("r_input_distortion_field", defaultDistortionFieldSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
+			SPT.rwTexture("rw_reconstructed_depth_interpolated_frame", reconstructedDepthInterpolatedFrameUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_INTERPOLATED_FRAME
+
+			auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+			commandList->setComputePipelineState(pipeline);
+			commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+			commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
+		}
+
 		// #wip: Dispatch gameMotionVectorFieldPipeline
 		
 		//scheduleDispatchGameVectorFieldInpaintingPyramid();

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -1,5 +1,6 @@
 #include "frame_gen_pass.h"
 #include "rhi/render_device.h"
+#include "rhi/render_command.h"
 #include "world/camera.h"
 
 // doc: docs/techniques/frame-interpolation.md
@@ -64,11 +65,18 @@ void FrameGenPass::initialize(RenderDevice* inRenderDevice)
 	device = inRenderDevice;
 	cpuFrameIndex = 0;
 
+	const uint32 swapchainCount = 2;
+	reconstructedPrevDepthTextures.initialize(swapchainCount);
+	reconstructedPrevDepthSRVs.initialize(swapchainCount);
+	reconstructedPrevDepthUAVs.initialize(swapchainCount);
+
 	initializePipelines();
 }
 
 void FrameGenPass::runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput)
 {
+	recreateResources(commandList, passInput);
+
 	updateUniforms(commandList, passInput);
 	//preparePhase(commandList, swapchainIndex, passInput);
 	//dispatchPhase(commandList, swapchainIndex, passInput);
@@ -108,6 +116,53 @@ void FrameGenPass::initializePipelines()
 	createPipeline("FSR3InpaintingPipelineCS", L"amd/ffx_frameinterpolation_inpainting_pass.hlsl", inpaintingPipeline);
 	createPipeline("FSR3GameVectorFieldInpaintingPyramidPipelineCS", L"amd/ffx_frameinterpolation_compute_game_vector_field_inpainting_pyramid_pass.hlsl", gameVectorFieldInpaintingPyramidPipeline);
 	createPipeline("FSR3DebugViewPipelineCS", L"amd/ffx_frameinterpolation_debug_view_pass.hlsl", debugViewPipeline);
+}
+
+void FrameGenPass::recreateResources(RenderCommandList* commandList, const FrameGenPassInput& passInput)
+{
+	for (size_t i = 0; i < reconstructedPrevDepthTextures.size(); ++i)
+	{
+		if (reconstructedPrevDepthTextures[i] == nullptr
+			|| reconstructedPrevDepthTextures[i]->getCreateParams().width != passInput.displaySizeX
+			|| reconstructedPrevDepthTextures[i]->getCreateParams().height != passInput.displaySizeY)
+		{
+			commandList->enqueueDeferredDealloc(reconstructedPrevDepthTextures[i].release(), true);
+			commandList->enqueueDeferredDealloc(reconstructedPrevDepthSRVs[i].release(), true);
+			commandList->enqueueDeferredDealloc(reconstructedPrevDepthUAVs[i].release(), true);
+
+			TextureCreateParams texDesc = TextureCreateParams::texture2D(
+				EPixelFormat::R32_FLOAT,
+				ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
+				passInput.displaySizeX, passInput.displaySizeY);
+			reconstructedPrevDepthTextures[i] = UniquePtr<Texture>(device->createTexture(texDesc));
+
+			wchar_t debugName[128];
+			std::swprintf(debugName, _countof(debugName), L"RT_ReconstructedPrevDepth_%u", (uint32)i);
+			reconstructedPrevDepthTextures[i]->setDebugName(debugName);
+
+			reconstructedPrevDepthSRVs[i] = UniquePtr<ShaderResourceView>(device->createSRV(
+				reconstructedPrevDepthTextures[i].get(),
+				ShaderResourceViewDesc{
+					.format              = reconstructedPrevDepthTextures[i]->getCreateParams().format,
+					.viewDimension       = ESRVDimension::Texture2D,
+					.texture2D           = Texture2DSRVDesc{
+						.mostDetailedMip = 0,
+						.mipLevels       = 1,
+						.planeSlice      = 0,
+						.minLODClamp     = 0.0f,
+					},
+				}
+			));
+			reconstructedPrevDepthUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(
+				reconstructedPrevDepthTextures[i].get(),
+				UnorderedAccessViewDesc{
+					.format         = reconstructedPrevDepthTextures[i]->getCreateParams().format,
+					.viewDimension  = EUAVDimension::Texture2D,
+					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+				}
+			));
+		}
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -510,8 +510,8 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.displaySizeRcp             = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
 		.cameraNear                 = passInput.camera->getZNear(),
 		.cameraFar                  = passInput.camera->getZFar(),
-		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY }, // #wip: upscale target size
-		.Mode                       = 0, // #wip: What is this? No shader accesses it, even ffx source code does not use it.
+		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY },
+		.Mode                       = 0, // #todo-fsr3: FidelityFX defines but does not use it.
 		.reset                      = bResetCurrentFrame || bDisjointFrameID,
 		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // Set below
 		.deltaTime                  = passInput.deltaTime, // #wip: Unit of deltaTime?
@@ -521,13 +521,13 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.opticalFlowBlockSize       = kOpticalFlowBlockSize,
 		.dispatchFlags              = passInput.dispatchFlags,
 		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
-		.opticalFlowHalfResMode     = 0, // #wip: opticalFlowHalfResMode
-		.NumInstances               = 0, // #wip: NumInstances unused?
+		.opticalFlowHalfResMode     = 0, // #todo-fsr3: FidelityFX defines but does not use it.
+		.NumInstances               = 0, // #todo-fsr3: FidelityFX defines but does not use it.
 		.interpolationRectBase      = { 0, 0 },
 		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
 		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
 		.backBufferTransferFunction = (uint32)passInput.backBufferTransferFunction,
-		.minMaxLuminance            = { 0.0f, 65000.0f }, // #wip: minMaxLuminance
+		.minMaxLuminance            = { passInput.minLuminance, passInput.maxLuminance },
 		.fTanHalfFOV                = 0.5f * std::tan(2.0f * std::atan(std::tan(passInput.camera->getFovYInRadians() * 0.5f) * passInput.camera->getAspectRatio())),
 		._pad1                      = 0,
 		.fJitter                    = { 0, 0 }, // #wip: jitter

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -340,6 +340,33 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 			}
 		));
 	}
+
+	// 2 uints. See COUNTER_SPD and COUNTER_FRAME_INDEX_SINCE_LAST_RESET.
+	if (counterBuffer == nullptr)
+	{
+		counterBuffer = UniquePtr<Buffer>(device->createBuffer(
+			BufferCreateParams{
+				.sizeInBytes = 2 * sizeof(uint32),
+				.alignment   = 0,
+				.accessFlags = EBufferAccessFlags::UAV,
+			}
+		));
+		counterBuffer->setDebugName(L"Buffer_FSR3_Counter");
+
+		counterUAV = UniquePtr<UnorderedAccessView>(device->createUAV(counterBuffer.get(),
+			UnorderedAccessViewDesc{
+				.format        = EPixelFormat::UNKNOWN,
+				.viewDimension = EUAVDimension::Buffer,
+				.buffer        = BufferUAVDesc{
+					.firstElement         = 0,
+					.numElements          = 2,
+					.structureByteStride  = sizeof(uint32),
+					.counterOffsetInBytes = 0,
+					.flags                = EBufferUAVFlags::None,
+				}
+			}
+		));
+	}
 }
 
 void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput)
@@ -466,12 +493,12 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)kOpticalFlowBlockSize + 7) / 8;
 	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)kOpticalFlowBlockSize + 7) / 8;
 
-	// #wip: Dispatch setupPipeline
-#if 0
 	{
 		SCOPED_DRAW_EVENT(commandList, Setup);
 
-		// #wip: barrier
+		BufferBarrierAuto bufferBarriers[] = {
+			{ EBarrierSync::COMPUTE_SHADING, EBarrierAccess::UNORDERED_ACCESS, counterBuffer.get() },
+		};
 		TextureBarrierAuto textureBarriers[] = {
 			TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->sceneChangeDetectionTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toUnorderedAccess(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
@@ -480,18 +507,17 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			TextureBarrierAuto::toUnorderedAccess(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toUnorderedAccess(disocclusionMaskTexture.get(), EBarrierSync::COMPUTE_SHADING),
 		};
-		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+		commandList->barrierAuto(_countof(bufferBarriers), bufferBarriers, _countof(textureBarriers), textureBarriers, 0, nullptr);
 		
-		// #wip: SPT
 		ShaderParameterTable SPT{};
 		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 		SPT.texture("r_optical_flow_scd", passInput.opticalFlowPassOutput->sceneChangeDetectionSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_SCENE_CHANGE_DETECTION
+		SPT.rwBuffer("rw_counters", counterUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
 		SPT.rwTexture("rw_game_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
 		SPT.rwTexture("rw_game_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
 		SPT.rwTexture("rw_optical_flow_motion_vector_field_x", gameMotionVectorFieldUAVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
 		SPT.rwTexture("rw_optical_flow_motion_vector_field_y", gameMotionVectorFieldUAVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
 		SPT.rwTexture("rw_disocclusion_mask", disocclusionMaskUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
-		// "rw_counters" FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
 		
 		frameInterpDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
 		auto descriptorHeap = frameInterpDescriptor.getDescriptorHeap(swapchainIndex);
@@ -502,7 +528,6 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		
 		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 	}
-#endif
 
 	// #wip: Dispatch gameVectorFieldInpaintingPyramidPipeline
 

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -388,23 +388,27 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 	const uint32 opticalFlowDispatchSizeX = (uint32)(passInput.displaySizeX / (float)kOpticalFlowBlockSize + 7) / 8;
 	const uint32 opticalFlowDispatchSizeY = (uint32)(passInput.displaySizeY / (float)kOpticalFlowBlockSize + 7) / 8;
 
-	// #wip: Dispatch setupPipeline (renderDispatchSizeX/Y)
+	// #wip: Dispatch setupPipeline
 #if 0
 	{
 		SCOPED_DRAW_EVENT(commandList, Setup);
 
 		// #wip: barrier
+		TextureBarrierAuto textureBarriers[] = {
+			TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->sceneChangeDetectionTexture, EBarrierSync::COMPUTE_SHADING),
+		};
+		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
 		
 		// #wip: SPT
 		ShaderParameterTable SPT{};
-		// FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_SCENE_CHANGE_DETECTION
-		// FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
-		// FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
-		// FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
-		// FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
-		// FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
-		// FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
-		// FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		SPT.texture("r_optical_flow_scd", passInput.opticalFlowPassOutput->sceneChangeDetectionSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_SCENE_CHANGE_DETECTION
+		// "rw_game_motion_vector_field_x" FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_X
+		// "rw_game_motion_vector_field_y" FFX_FRAMEINTERPOLATION_BIND_UAV_GAME_MOTION_VECTOR_FIELD_Y
+		// "rw_optical_flow_motion_vector_field_x" FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
+		// "rw_optical_flow_motion_vector_field_y" FFX_FRAMEINTERPOLATION_BIND_UAV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
+		// "rw_disocclusion_mask" FFX_FRAMEINTERPOLATION_BIND_UAV_DISOCCLUSION_MASK
+		// "rw_counters" FFX_FRAMEINTERPOLATION_BIND_UAV_COUNTERS
 		
 		frameInterpDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
 		auto descriptorHeap = frameInterpDescriptor.getDescriptorHeap(swapchainIndex);

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -157,6 +157,7 @@ void FrameGenPass::initializePipelines()
 	disocclusionMaskDescriptor.initialize(device, L"FSR3_DisocclusionMask", swapchainCount, 0);
 	interpolationDescriptor.initialize(device, L"FSR3_Interpolation", swapchainCount, 0);
 	inpaintingDescriptor.initialize(device, L"FSR3_Inpainting", swapchainCount, 0);
+	debugViewDescriptor.initialize(device, L"FSR3_DebugView", swapchainCount, 0);
 
 	auto createPipeline = [device = this->device]
 		(const char* debugName, const wchar_t* filepath, UniquePtr<ComputePipelineState>& pipeline)
@@ -934,18 +935,20 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		commandList->dispatchCompute(dispatchThreadGroupCountXY[0], dispatchThreadGroupCountXY[1], 1);
 	}
 
+	// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
+	auto presentBackbufferSRV = currInterpolationSourceSRV;
+
 	{
 		SCOPED_DRAW_EVENT(commandList, Inpainting);
 
 		auto pipeline = inpaintingPipeline.get();
 		auto& passDescriptor = inpaintingDescriptor;
 
-		// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
-		auto presentBackbufferSRV = currInterpolationSourceSRV;
-
 		TextureBarrierAuto textureBarriers[] = {
 			TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->sceneChangeDetectionTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
+			//TextureBarrierAuto::toShaderResource(presentBackbufferTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toUnorderedAccess(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
 		};
@@ -967,9 +970,47 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 	}
 
-	if (false /* draw debug view */)
+	if (ENUM_HAS_FLAG(passInput.dispatchFlags, EFrameGenDispatchFlags::DRAW_DEBUG_VIEW))
 	{
-		// #wip: Dispatch debugViewPipeline
+		SCOPED_DRAW_EVENT(commandList, DebugView);
+		
+		auto pipeline = debugViewPipeline.get();
+		auto& passDescriptor = debugViewDescriptor;
+
+		TextureBarrierAuto textureBarriers[] = {
+			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(gameMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(disocclusionMaskTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			// #wip: Assumes PRESENT_BACKBUFFER == currInterpolationSourceTexture
+			//TextureBarrierAuto::toShaderResource(presentBackbufferTexture, EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toShaderResource(distortionFieldTexture, EBarrierSync::COMPUTE_SHADING),
+			TextureBarrierAuto::toUnorderedAccess(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
+		};
+		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+		ShaderParameterTable SPT{};
+		SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
+		SPT.texture("r_game_motion_vector_field_x", gameMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_X
+		SPT.texture("r_game_motion_vector_field_y", gameMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_GAME_MOTION_VECTOR_FIELD_Y
+		SPT.texture("r_optical_flow_motion_vector_field_x", opticalFlowMotionVectorFieldSRVs[0].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
+		SPT.texture("r_optical_flow_motion_vector_field_y", opticalFlowMotionVectorFieldSRVs[1].get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
+		SPT.texture("r_disocclusion_mask", disocclusionMaskSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISOCCLUSION_MASK
+		SPT.texture("r_inpainting_pyramid", inpaintingPyramidSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_INPAINTING_PYRAMID
+		SPT.texture("r_present_backbuffer", presentBackbufferSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_PRESENT_BACKBUFFER
+		SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
+		SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
+		SPT.rwTexture("rw_output", interpolationOutputUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_OUTPUT
+
+		auto descriptorHeap = passDescriptor.resizeDescriptorHeap(swapchainIndex, SPT.totalDescriptors());
+
+		commandList->setComputePipelineState(pipeline);
+		commandList->bindComputeShaderParameters(pipeline, &SPT, descriptorHeap);
+
+		commandList->dispatchCompute(renderDispatchSizeX, renderDispatchSizeY, 1);
 	}
 
 	{

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -100,6 +100,7 @@ private:
 	VolatileDescriptorHelper               disocclusionMaskDescriptor;
 	VolatileDescriptorHelper               interpolationDescriptor;
 	VolatileDescriptorHelper               inpaintingDescriptor;
+	VolatileDescriptorHelper               debugViewDescriptor;
 
 	UniquePtr<Texture>                     reconstructedPrevDepthTexture;
 	UniquePtr<ShaderResourceView>          reconstructedPrevDepthSRV;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -20,6 +20,10 @@ struct FrameGenPassInput
 	uint32                                dispatchFlags;
 	OpticalFlowBackbufferTransferFunction backBufferTransferFunction;
 	bool                                  bReset;
+	Texture*                              sceneDepthTexture;
+	ShaderResourceView*                   sceneDepthSRV;
+	Texture*                              motionVectorTexture;
+	ShaderResourceView*                   motionVectorSRV;
 };
 
 class FrameGenPass final : public SceneRenderPass
@@ -31,6 +35,8 @@ public:
 
 private:
 	void initializePipelines();
+
+	void recreateResources(RenderCommandList* commandList, const FrameGenPassInput& passInput);
 
 	void updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput);
 	void preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
@@ -45,18 +51,22 @@ private:
 
 	// #todo-fsr3: See FfxFrameInterpolationPass enum in
 	// <FidelityFX_SDK>\sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp
-	UniquePtr<ComputePipelineState> reconstructAndDilatePipeline;
-	UniquePtr<ComputePipelineState> setupPipeline;
-	UniquePtr<ComputePipelineState> reconstructPrevDepthPipeline;
-	UniquePtr<ComputePipelineState> gameMotionVectorFieldPipeline;
-	UniquePtr<ComputePipelineState> opticalFlowVectorFieldPipeline;
-	UniquePtr<ComputePipelineState> disocclusionMaskPipeline;
-	UniquePtr<ComputePipelineState> interpolationPipeline;
-	UniquePtr<ComputePipelineState> inpaintingPyramidPipeline;
-	UniquePtr<ComputePipelineState> inpaintingPipeline;
-	UniquePtr<ComputePipelineState> gameVectorFieldInpaintingPyramidPipeline;
-	UniquePtr<ComputePipelineState> debugViewPipeline;
+	UniquePtr<ComputePipelineState>        reconstructAndDilatePipeline;
+	UniquePtr<ComputePipelineState>        setupPipeline;
+	UniquePtr<ComputePipelineState>        reconstructPrevDepthPipeline;
+	UniquePtr<ComputePipelineState>        gameMotionVectorFieldPipeline;
+	UniquePtr<ComputePipelineState>        opticalFlowVectorFieldPipeline;
+	UniquePtr<ComputePipelineState>        disocclusionMaskPipeline;
+	UniquePtr<ComputePipelineState>        interpolationPipeline;
+	UniquePtr<ComputePipelineState>        inpaintingPyramidPipeline;
+	UniquePtr<ComputePipelineState>        inpaintingPipeline;
+	UniquePtr<ComputePipelineState>        gameVectorFieldInpaintingPyramidPipeline;
+	UniquePtr<ComputePipelineState>        debugViewPipeline;
 
-	VolatileDescriptorHelper        frameInterpDescriptor;
-	VolatileDescriptorHelper        inpaintingPyramidDescriptor;
+	VolatileDescriptorHelper               frameInterpDescriptor;
+	VolatileDescriptorHelper               inpaintingPyramidDescriptor;
+
+	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
+	BufferedUniquePtr<ShaderResourceView>  reconstructedPrevDepthSRVs;
+	BufferedUniquePtr<UnorderedAccessView> reconstructedPrevDepthUAVs;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -72,6 +72,7 @@ private:
 	VolatileDescriptorHelper               frameInterpDescriptor;
 	VolatileDescriptorHelper               inpaintingPyramidDescriptor;
 
+	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
 	BufferedUniquePtr<ShaderResourceView>  reconstructedPrevDepthSRVs;
 	BufferedUniquePtr<UnorderedAccessView> reconstructedPrevDepthUAVs;
@@ -81,4 +82,6 @@ private:
 	BufferedUniquePtr<Texture>             dilatedDepthTextures;
 	BufferedUniquePtr<ShaderResourceView>  dilatedDepthSRVs;
 	BufferedUniquePtr<UnorderedAccessView> dilatedDepthUAVs;
+	UniquePtr<Texture>                     gameMotionVectorFieldTextures[2]; // x, y
+	UniquePtr<UnorderedAccessView>         gameMotionVectorFieldUAVs[2]; // x, y
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -33,8 +33,10 @@ struct FrameGenPassInput
 
 struct FrameGenPassOutput
 {
-	Texture*                              interpolatedFrameTexture = nullptr;
-	ShaderResourceView*                   interpolatedFrameSRV     = nullptr;
+	Texture*               interpolatedFrameTexture                = nullptr;
+	ShaderResourceView*    interpolatedFrameSRV                    = nullptr;
+	Texture*               opticalFlowMotionVectorFieldTextures[2] = { nullptr, nullptr };
+	ShaderResourceView*    opticalFlowMotionVectorFieldSRVs[2]     = { nullptr, nullptr };
 };
 
 class FrameGenPass final : public SceneRenderPass

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -23,6 +23,8 @@ struct FrameGenPassInput
 	uint32                                dispatchFlags;
 	OpticalFlowBackbufferTransferFunction backBufferTransferFunction;
 	bool                                  bReset;
+	float                                 minLuminance;
+	float                                 maxLuminance;
 	Texture*                              sceneColorTexture;
 	ShaderResourceView*                   sceneColorSRV;
 	Texture*                              sceneDepthTexture;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -84,4 +84,6 @@ private:
 	BufferedUniquePtr<UnorderedAccessView> dilatedDepthUAVs;
 	UniquePtr<Texture>                     gameMotionVectorFieldTextures[2]; // x, y
 	UniquePtr<UnorderedAccessView>         gameMotionVectorFieldUAVs[2]; // x, y
+	UniquePtr<Texture>                     opticalFlowMotionVectorFieldTextures[2]; // x, y
+	UniquePtr<UnorderedAccessView>         opticalFlowMotionVectorFieldUAVs[2]; // x, y
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -78,6 +78,7 @@ private:
 	VolatileDescriptorHelper               gameMotionVectorFieldDescriptor;
 	VolatileDescriptorHelper               gameMotionVectorFieldInpaintingPyramidDescriptor;
 	VolatileDescriptorHelper               opticalFlowVectorFieldDescriptor;
+	VolatileDescriptorHelper               disocclusionMaskDescriptor;
 
 	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
@@ -107,6 +108,7 @@ private:
 	UniquePtr<ShaderResourceView>          prevInterpolationSourceSRV;
 	UniquePtr<UnorderedAccessView>         prevInterpolationSourceUAV;
 	UniquePtr<Texture>                     inpaintingPyramidTexture;
+	UniquePtr<ShaderResourceView>          inpaintingPyramidSRV;
 	UniquePtr<UnorderedAccessView>         inpaintingPyramidUAVs[13];
 	UniquePtr<Texture>                     opticalFlowConfidenceTexture; // #wip: This is not used at all in FidelityFX. Possibly dead code.
 	UniquePtr<ShaderResourceView>          opticalFlowConfidenceSRV;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -76,6 +76,7 @@ private:
 
 	VolatileDescriptorHelper               reconstructPrevDepthDescriptor;
 	VolatileDescriptorHelper               gameMotionVectorFieldDescriptor;
+	VolatileDescriptorHelper               gameMotionVectorFieldInpaintingPyramidDescriptor;
 
 	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
@@ -104,4 +105,6 @@ private:
 	UniquePtr<Texture>                     prevInterpolationSourceTexture;
 	UniquePtr<ShaderResourceView>          prevInterpolationSourceSRV;
 	UniquePtr<UnorderedAccessView>         prevInterpolationSourceUAV;
+	UniquePtr<Texture>                     inpaintingPyramidTexture;
+	UniquePtr<UnorderedAccessView>         inpaintingPyramidUAVs[13];
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -88,4 +88,6 @@ private:
 	UniquePtr<UnorderedAccessView>         opticalFlowMotionVectorFieldUAVs[2]; // x, y
 	UniquePtr<Texture>                     disocclusionMaskTexture;
 	UniquePtr<UnorderedAccessView>         disocclusionMaskUAV;
+	UniquePtr<Buffer>                      counterBuffer;
+	UniquePtr<UnorderedAccessView>         counterUAV;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -11,6 +11,7 @@ class Camera;
 
 struct FrameGenPassInput
 {
+	class ClearResourcePass*              clearResourcePass;
 	const Camera*                         camera;
 	int32                                 renderSizeX;
 	int32                                 renderSizeY;
@@ -63,6 +64,7 @@ private:
 	UniquePtr<ComputePipelineState>        gameVectorFieldInpaintingPyramidPipeline;
 	UniquePtr<ComputePipelineState>        debugViewPipeline;
 
+	VolatileDescriptorHelper               prepareDescriptor;
 	VolatileDescriptorHelper               frameInterpDescriptor;
 	VolatileDescriptorHelper               inpaintingPyramidDescriptor;
 

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -37,4 +37,7 @@ private:
 	UniquePtr<ComputePipelineState> inpaintingPipeline;
 	UniquePtr<ComputePipelineState> gameVectorFieldInpaintingPyramidPipeline;
 	UniquePtr<ComputePipelineState> debugViewPipeline;
+
+	VolatileDescriptorHelper        frameInterpDescriptor;
+	VolatileDescriptorHelper        inpaintingPyramidDescriptor;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -108,4 +108,6 @@ private:
 	UniquePtr<UnorderedAccessView>         prevInterpolationSourceUAV;
 	UniquePtr<Texture>                     inpaintingPyramidTexture;
 	UniquePtr<UnorderedAccessView>         inpaintingPyramidUAVs[13];
+	UniquePtr<Texture>                     opticalFlowConfidenceTexture; // #wip: This is not used at all in FidelityFX. Possibly dead code.
+	UniquePtr<ShaderResourceView>          opticalFlowConfidenceSRV;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -69,4 +69,10 @@ private:
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
 	BufferedUniquePtr<ShaderResourceView>  reconstructedPrevDepthSRVs;
 	BufferedUniquePtr<UnorderedAccessView> reconstructedPrevDepthUAVs;
+	BufferedUniquePtr<Texture>             dilatedMotionVectorTextures;
+	BufferedUniquePtr<ShaderResourceView>  dilatedMotionVectorSRVs;
+	BufferedUniquePtr<UnorderedAccessView> dilatedMotionVectorUAVs;
+	BufferedUniquePtr<Texture>             dilatedDepthTextures;
+	BufferedUniquePtr<ShaderResourceView>  dilatedDepthSRVs;
+	BufferedUniquePtr<UnorderedAccessView> dilatedDepthUAVs;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -80,6 +80,7 @@ private:
 	VolatileDescriptorHelper               opticalFlowVectorFieldDescriptor;
 	VolatileDescriptorHelper               disocclusionMaskDescriptor;
 	VolatileDescriptorHelper               interpolationDescriptor;
+	VolatileDescriptorHelper               inpaintingDescriptor;
 
 	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -63,6 +63,7 @@ private:
 	uint32 cpuFrameIndex = 0;
 	uint32 prevFrameID = 0; // from FrameGenPassInput
 	uint32 interpolationDispatchCount = 0;
+	bool bResetCurrentFrame = false;
 
 	// #todo-fsr3: See FfxFrameInterpolationPass enum in
 	// <FidelityFX_SDK>\sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -31,12 +31,18 @@ struct FrameGenPassInput
 	ShaderResourceView*                   motionVectorSRV;
 };
 
+struct FrameGenPassOutput
+{
+	Texture*                              interpolatedFrameTexture = nullptr;
+	ShaderResourceView*                   interpolatedFrameSRV     = nullptr;
+};
+
 class FrameGenPass final : public SceneRenderPass
 {
 public:
 	void initialize(RenderDevice* inRenderDevice);
 
-	void runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
+	FrameGenPassOutput runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
 
 private:
 	void initializePipelines();

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -75,6 +75,7 @@ private:
 	VolatileDescriptorHelper               inpaintingPyramidDescriptor;
 
 	VolatileDescriptorHelper               reconstructPrevDepthDescriptor;
+	VolatileDescriptorHelper               gameMotionVectorFieldDescriptor;
 
 	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
@@ -100,4 +101,7 @@ private:
 	UniquePtr<UnorderedAccessView>         counterUAV;
 	UniquePtr<Texture>                     defaultDistortionFieldTexture;
 	UniquePtr<ShaderResourceView>          defaultDistortionFieldSRV;
+	UniquePtr<Texture>                     prevInterpolationSourceTexture;
+	UniquePtr<ShaderResourceView>          prevInterpolationSourceSRV;
+	UniquePtr<UnorderedAccessView>         prevInterpolationSourceUAV;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -17,6 +17,7 @@ struct FrameGenPassInput
 	int32                                 renderSizeY;
 	int32                                 displaySizeX;
 	int32                                 displaySizeY;
+	uint32                                frameID;
 	float                                 deltaTime;
 	uint32                                dispatchFlags;
 	OpticalFlowBackbufferTransferFunction backBufferTransferFunction;
@@ -49,6 +50,8 @@ private:
 private:
 	RenderDevice* device = nullptr;
 	uint32 cpuFrameIndex = 0;
+	uint32 prevFrameID = 0; // from FrameGenPassInput
+	uint32 interpolationDispatchCount = 0;
 
 	// #todo-fsr3: See FfxFrameInterpolationPass enum in
 	// <FidelityFX_SDK>\sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -17,7 +17,6 @@ struct FrameGenPassInput
 	int32                                 displaySizeX;
 	int32                                 displaySizeY;
 	float                                 deltaTime;
-	int32                                 opticalFlowBlockSize;
 	uint32                                dispatchFlags;
 	OpticalFlowBackbufferTransferFunction backBufferTransferFunction;
 	bool                                  bReset;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -9,6 +9,15 @@
 
 class Camera;
 
+enum class EFrameGenDispatchFlags : uint32
+{
+	NONE                        = 0,
+	DRAW_DEBUG_TEAR_LINES       = (1 << 0),
+	DRAW_DEBUG_RESET_INDICATORS = (1 << 1),
+	DRAW_DEBUG_VIEW             = (1 << 2),
+};
+ENUM_CLASS_FLAGS(EFrameGenDispatchFlags);
+
 struct FrameGenPassInput
 {
 	class ClearResourcePass*              clearResourcePass;
@@ -19,8 +28,7 @@ struct FrameGenPassInput
 	int32                                 displaySizeX;
 	int32                                 displaySizeY;
 	uint32                                frameID;
-	float                                 deltaTime;
-	uint32                                dispatchFlags;
+	EFrameGenDispatchFlags                dispatchFlags;
 	OpticalFlowBackbufferTransferFunction backBufferTransferFunction;
 	bool                                  bReset;
 	float                                 minLuminance;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -90,19 +90,19 @@ private:
 	VolatileDescriptorHelper               interpolationDescriptor;
 	VolatileDescriptorHelper               inpaintingDescriptor;
 
-	// #wip: Remove unnecessary buffering.
-	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
-	BufferedUniquePtr<ShaderResourceView>  reconstructedPrevDepthSRVs;
-	BufferedUniquePtr<UnorderedAccessView> reconstructedPrevDepthUAVs;
+	
+	UniquePtr<Texture>                     reconstructedPrevDepthTexture;
+	UniquePtr<ShaderResourceView>          reconstructedPrevDepthSRV;
+	UniquePtr<UnorderedAccessView>         reconstructedPrevDepthUAV;
 	UniquePtr<Texture>                     reconstructedDepthInterpolatedFrameTexture;
 	UniquePtr<ShaderResourceView>          reconstructedDepthInterpolatedFrameSRV;
 	UniquePtr<UnorderedAccessView>         reconstructedDepthInterpolatedFrameUAV;
-	BufferedUniquePtr<Texture>             dilatedMotionVectorTextures;
-	BufferedUniquePtr<ShaderResourceView>  dilatedMotionVectorSRVs;
-	BufferedUniquePtr<UnorderedAccessView> dilatedMotionVectorUAVs;
-	BufferedUniquePtr<Texture>             dilatedDepthTextures;
-	BufferedUniquePtr<ShaderResourceView>  dilatedDepthSRVs;
-	BufferedUniquePtr<UnorderedAccessView> dilatedDepthUAVs;
+	UniquePtr<Texture>                     dilatedMotionVectorTexture;
+	UniquePtr<ShaderResourceView>          dilatedMotionVectorSRV;
+	UniquePtr<UnorderedAccessView>         dilatedMotionVectorUAV;
+	UniquePtr<Texture>                     dilatedDepthTexture;
+	UniquePtr<ShaderResourceView>          dilatedDepthSRV;
+	UniquePtr<UnorderedAccessView>         dilatedDepthUAV;
 	UniquePtr<Texture>                     gameMotionVectorFieldTextures[2]; // x, y
 	UniquePtr<ShaderResourceView>          gameMotionVectorFieldSRVs[2]; // x, y
 	UniquePtr<UnorderedAccessView>         gameMotionVectorFieldUAVs[2]; // x, y

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -23,6 +23,8 @@ struct FrameGenPassInput
 	uint32                                dispatchFlags;
 	OpticalFlowBackbufferTransferFunction backBufferTransferFunction;
 	bool                                  bReset;
+	Texture*                              sceneColorTexture;
+	ShaderResourceView*                   sceneColorSRV;
 	Texture*                              sceneDepthTexture;
 	ShaderResourceView*                   sceneDepthSRV;
 	Texture*                              motionVectorTexture;
@@ -72,6 +74,8 @@ private:
 	VolatileDescriptorHelper               frameInterpDescriptor;
 	VolatileDescriptorHelper               inpaintingPyramidDescriptor;
 
+	VolatileDescriptorHelper               reconstructPrevDepthDescriptor;
+
 	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
 	BufferedUniquePtr<ShaderResourceView>  reconstructedPrevDepthSRVs;
@@ -94,4 +98,6 @@ private:
 	UniquePtr<UnorderedAccessView>         disocclusionMaskUAV;
 	UniquePtr<Buffer>                      counterBuffer;
 	UniquePtr<UnorderedAccessView>         counterUAV;
+	UniquePtr<Texture>                     defaultDistortionFieldTexture;
+	UniquePtr<ShaderResourceView>          defaultDistortionFieldSRV;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -77,6 +77,7 @@ private:
 	VolatileDescriptorHelper               reconstructPrevDepthDescriptor;
 	VolatileDescriptorHelper               gameMotionVectorFieldDescriptor;
 	VolatileDescriptorHelper               gameMotionVectorFieldInpaintingPyramidDescriptor;
+	VolatileDescriptorHelper               opticalFlowVectorFieldDescriptor;
 
 	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -6,9 +6,20 @@
 #include "rhi/pipeline_state.h"
 #include "util/volatile_descriptor.h"
 
+class Camera;
+
 struct FrameGenPassInput
 {
-	//
+	const Camera* camera;
+
+	int32  renderSizeX;
+	int32  renderSizeY;
+	int32  displaySizeX;
+	int32  displaySizeY;
+	float  deltaTime;
+	int32  opticalFlowBlockSize;
+	uint32 dispatchFlags;
+	uint32 backBufferTransferFunction;
 };
 
 class FrameGenPass final : public SceneRenderPass
@@ -20,6 +31,9 @@ public:
 
 private:
 	void initializePipelines();
+
+	void preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
+	void dispatchPhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
 
 private:
 	RenderDevice* device = nullptr;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -12,6 +12,7 @@ class Camera;
 struct FrameGenPassInput
 {
 	class ClearResourcePass*              clearResourcePass;
+	const OpticalFlowPassOutput*          opticalFlowPassOutput;
 	const Camera*                         camera;
 	int32                                 renderSizeX;
 	int32                                 renderSizeY;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -90,7 +90,6 @@ private:
 	VolatileDescriptorHelper               interpolationDescriptor;
 	VolatileDescriptorHelper               inpaintingDescriptor;
 
-	
 	UniquePtr<Texture>                     reconstructedPrevDepthTexture;
 	UniquePtr<ShaderResourceView>          reconstructedPrevDepthSRV;
 	UniquePtr<UnorderedAccessView>         reconstructedPrevDepthUAV;
@@ -123,7 +122,7 @@ private:
 	UniquePtr<Texture>                     inpaintingPyramidTexture;
 	UniquePtr<ShaderResourceView>          inpaintingPyramidSRV;
 	UniquePtr<UnorderedAccessView>         inpaintingPyramidUAVs[13];
-	UniquePtr<Texture>                     opticalFlowConfidenceTexture; // #wip: This is not used at all in FidelityFX. Possibly dead code.
+	UniquePtr<Texture>                     opticalFlowConfidenceTexture; // #todo-fsr3: Probably dead code.
 	UniquePtr<ShaderResourceView>          opticalFlowConfidenceSRV;
 	UniquePtr<Texture>                     interpolationOutputTexture;
 	UniquePtr<ShaderResourceView>          interpolationOutputSRV;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -86,4 +86,6 @@ private:
 	UniquePtr<UnorderedAccessView>         gameMotionVectorFieldUAVs[2]; // x, y
 	UniquePtr<Texture>                     opticalFlowMotionVectorFieldTextures[2]; // x, y
 	UniquePtr<UnorderedAccessView>         opticalFlowMotionVectorFieldUAVs[2]; // x, y
+	UniquePtr<Texture>                     disocclusionMaskTexture;
+	UniquePtr<UnorderedAccessView>         disocclusionMaskUAV;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -76,6 +76,9 @@ private:
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
 	BufferedUniquePtr<ShaderResourceView>  reconstructedPrevDepthSRVs;
 	BufferedUniquePtr<UnorderedAccessView> reconstructedPrevDepthUAVs;
+	UniquePtr<Texture>                     reconstructedDepthInterpolatedFrameTexture;
+	UniquePtr<ShaderResourceView>          reconstructedDepthInterpolatedFrameSRV;
+	UniquePtr<UnorderedAccessView>         reconstructedDepthInterpolatedFrameUAV;
 	BufferedUniquePtr<Texture>             dilatedMotionVectorTextures;
 	BufferedUniquePtr<ShaderResourceView>  dilatedMotionVectorSRVs;
 	BufferedUniquePtr<UnorderedAccessView> dilatedMotionVectorUAVs;
@@ -83,6 +86,7 @@ private:
 	BufferedUniquePtr<ShaderResourceView>  dilatedDepthSRVs;
 	BufferedUniquePtr<UnorderedAccessView> dilatedDepthUAVs;
 	UniquePtr<Texture>                     gameMotionVectorFieldTextures[2]; // x, y
+	UniquePtr<ShaderResourceView>          gameMotionVectorFieldSRVs[2]; // x, y
 	UniquePtr<UnorderedAccessView>         gameMotionVectorFieldUAVs[2]; // x, y
 	UniquePtr<Texture>                     opticalFlowMotionVectorFieldTextures[2]; // x, y
 	UniquePtr<UnorderedAccessView>         opticalFlowMotionVectorFieldUAVs[2]; // x, y

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "scene_render_pass.h"
+#include "optical_flow_common.h"
 #include "core/smart_pointer.h"
 #include "rhi/rhi_forward.h"
 #include "rhi/pipeline_state.h"
@@ -10,16 +11,16 @@ class Camera;
 
 struct FrameGenPassInput
 {
-	const Camera* camera;
-
-	int32  renderSizeX;
-	int32  renderSizeY;
-	int32  displaySizeX;
-	int32  displaySizeY;
-	float  deltaTime;
-	int32  opticalFlowBlockSize;
-	uint32 dispatchFlags;
-	uint32 backBufferTransferFunction;
+	const Camera*                         camera;
+	int32                                 renderSizeX;
+	int32                                 renderSizeY;
+	int32                                 displaySizeX;
+	int32                                 displaySizeY;
+	float                                 deltaTime;
+	int32                                 opticalFlowBlockSize;
+	uint32                                dispatchFlags;
+	OpticalFlowBackbufferTransferFunction backBufferTransferFunction;
+	bool                                  bReset;
 };
 
 class FrameGenPass final : public SceneRenderPass
@@ -32,11 +33,16 @@ public:
 private:
 	void initializePipelines();
 
+	void updateUniforms(RenderCommandList* commandList, const FrameGenPassInput& passInput);
 	void preparePhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
 	void dispatchPhase(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
 
+	ConstantBufferView* getCurrentFrameInterpUniformCBV();
+	ConstantBufferView* getCurrentInpaintingPyramidUniformCBV();
+
 private:
 	RenderDevice* device = nullptr;
+	uint32 cpuFrameIndex = 0;
 
 	// #todo-fsr3: See FfxFrameInterpolationPass enum in
 	// <FidelityFX_SDK>\sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -75,8 +75,7 @@ private:
 	uint32 interpolationDispatchCount = 0;
 	bool bResetCurrentFrame = false;
 
-	// #todo-fsr3: See FfxFrameInterpolationPass enum in
-	// <FidelityFX_SDK>\sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp
+	// See FfxFrameInterpolationPass enum in <FidelityFX_SDK>\sdk\src\components\frameinterpolation\ffx_frameinterpolation.cpp
 	UniquePtr<ComputePipelineState>        reconstructAndDilatePipeline;
 	UniquePtr<ComputePipelineState>        setupPipeline;
 	UniquePtr<ComputePipelineState>        reconstructPrevDepthPipeline;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -79,6 +79,7 @@ private:
 	VolatileDescriptorHelper               gameMotionVectorFieldInpaintingPyramidDescriptor;
 	VolatileDescriptorHelper               opticalFlowVectorFieldDescriptor;
 	VolatileDescriptorHelper               disocclusionMaskDescriptor;
+	VolatileDescriptorHelper               interpolationDescriptor;
 
 	// #wip: Remove unnecessary buffering.
 	BufferedUniquePtr<Texture>             reconstructedPrevDepthTextures;
@@ -97,10 +98,13 @@ private:
 	UniquePtr<ShaderResourceView>          gameMotionVectorFieldSRVs[2]; // x, y
 	UniquePtr<UnorderedAccessView>         gameMotionVectorFieldUAVs[2]; // x, y
 	UniquePtr<Texture>                     opticalFlowMotionVectorFieldTextures[2]; // x, y
+	UniquePtr<ShaderResourceView>          opticalFlowMotionVectorFieldSRVs[2]; // x, y
 	UniquePtr<UnorderedAccessView>         opticalFlowMotionVectorFieldUAVs[2]; // x, y
 	UniquePtr<Texture>                     disocclusionMaskTexture;
+	UniquePtr<ShaderResourceView>          disocclusionMaskSRV;
 	UniquePtr<UnorderedAccessView>         disocclusionMaskUAV;
 	UniquePtr<Buffer>                      counterBuffer;
+	UniquePtr<ShaderResourceView>          counterSRV;
 	UniquePtr<UnorderedAccessView>         counterUAV;
 	UniquePtr<Texture>                     defaultDistortionFieldTexture;
 	UniquePtr<ShaderResourceView>          defaultDistortionFieldSRV;
@@ -112,4 +116,7 @@ private:
 	UniquePtr<UnorderedAccessView>         inpaintingPyramidUAVs[13];
 	UniquePtr<Texture>                     opticalFlowConfidenceTexture; // #wip: This is not used at all in FidelityFX. Possibly dead code.
 	UniquePtr<ShaderResourceView>          opticalFlowConfidenceSRV;
+	UniquePtr<Texture>                     interpolationOutputTexture;
+	UniquePtr<ShaderResourceView>          interpolationOutputSRV;
+	UniquePtr<UnorderedAccessView>         interpolationOutputUAV;
 };

--- a/projects/Cyseal/src/render/optical_flow_common.cpp
+++ b/projects/Cyseal/src/render/optical_flow_common.cpp
@@ -1,0 +1,36 @@
+#include "optical_flow_common.h"
+
+void ffxSpdSetup(
+	uint32 dispatchThreadGroupCountXY[2],
+	uint32 workGroupOffset[2],
+	uint32 numWorkGroupsAndMips[2],
+	const uint32 rectInfo[4],
+	const int32 mips)
+{
+	// determines the offset of the first tile to downsample based on
+	// left (rectInfo[0]) and top (rectInfo[1]) of the subregion.
+	workGroupOffset[0] = rectInfo[0] / 64;
+	workGroupOffset[1] = rectInfo[1] / 64;
+
+	uint32 endIndexX = (rectInfo[0] + rectInfo[2] - 1) / 64;  // rectInfo[0] = left, rectInfo[2] = width
+	uint32 endIndexY = (rectInfo[1] + rectInfo[3] - 1) / 64;  // rectInfo[1] = top, rectInfo[3] = height
+
+	// we only need to dispatch as many thread groups as tiles we need to downsample
+	// number of tiles per slice depends on the subregion to downsample
+	dispatchThreadGroupCountXY[0] = endIndexX + 1 - workGroupOffset[0];
+	dispatchThreadGroupCountXY[1] = endIndexY + 1 - workGroupOffset[1];
+
+	// number of thread groups per slice
+	numWorkGroupsAndMips[0] = (dispatchThreadGroupCountXY[0]) * (dispatchThreadGroupCountXY[1]);
+
+	if (mips >= 0)
+	{
+		numWorkGroupsAndMips[1] = uint32(mips);
+	}
+	else
+	{
+		// calculate based on rect width and height
+		uint32 resolution = (std::max)(rectInfo[2], rectInfo[3]);
+		numWorkGroupsAndMips[1] = (uint32)((std::min(std::floor(std::log2(float(resolution))), float(12))));
+	}
+}

--- a/projects/Cyseal/src/render/optical_flow_common.h
+++ b/projects/Cyseal/src/render/optical_flow_common.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "core/int_types.h"
+
+// See ffx_opticalflow_prepare_luma.h
+enum class OpticalFlowBackbufferTransferFunction : uint32
+{
+	LinearLdrToLuminance                  = 0,
+	PQCorrectedHdrToPerceivedLuminance    = 1,
+	SCRGBCorrectedHdrToPerceivedLuminance = 2,
+
+	Count,
+};
+
+// Ported from <FidelityFX_SDK>/sdk/include/FidelityFX/gpu/spd/ffx_spd.h
+void ffxSpdSetup(
+	uint32 dispatchThreadGroupCountXY[2],
+	uint32 workGroupOffset[2],
+	uint32 numWorkGroupsAndMips[2],
+	const uint32 rectInfo[4],
+	const int32 mips);

--- a/projects/Cyseal/src/render/optical_flow_common.h
+++ b/projects/Cyseal/src/render/optical_flow_common.h
@@ -2,6 +2,8 @@
 
 #include "core/int_types.h"
 
+const uint32 kOpticalFlowBlockSize = 8;
+
 // See ffx_opticalflow_prepare_luma.h
 enum class OpticalFlowBackbufferTransferFunction : uint32
 {

--- a/projects/Cyseal/src/render/optical_flow_common.h
+++ b/projects/Cyseal/src/render/optical_flow_common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/int_types.h"
+#include "rhi/rhi_forward.h"
 
 const uint32 kOpticalFlowBlockSize = 8;
 
@@ -12,6 +13,16 @@ enum class OpticalFlowBackbufferTransferFunction : uint32
 	SCRGBCorrectedHdrToPerceivedLuminance = 2,
 
 	Count,
+};
+
+struct OpticalFlowPassOutput
+{
+	uint32              opticalFlowVectorSizeX          = 0;
+	uint32              opticalFlowVectorSizeY          = 0;
+	Texture*            opticalFlowVectorTexture        = nullptr;
+	ShaderResourceView* opticalFlowVectorSRV            = nullptr;
+	Texture*            sceneChangeDetectionTexture     = nullptr;
+	ShaderResourceView* sceneChangeDetectionSRV         = nullptr;
 };
 
 // Ported from <FidelityFX_SDK>/sdk/include/FidelityFX/gpu/spd/ffx_spd.h

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -74,12 +74,6 @@ OpticalFlowPassOutput OpticalFlowPass::runOpticalFlow(RenderCommandList* command
 	auto currScdHistogramTexture = scdHistogramTextures[1].get();
 	auto currScdHistogramUAV     = scdHistogramUAVs[1].get();
 
-	// #todo-fsr3-fg: How to calculate min/max luminance? Just downsample the sceneColor to 1x1?
-	// But how to read it? GPU stall and readback is def not an option :(
-	// If these are not scene luminance min/max but the range in HDR calibration then I should pass them from application logic side.
-	const float fMinLuminance = 0.0f;
-	const float fMaxLuminance = 3000.0f;
-
 	if (passInput.bResetAccumulation || bFirstExecution)
 	{
 		gpuFrameIndex = 0;
@@ -115,7 +109,7 @@ OpticalFlowPassOutput OpticalFlowPass::runOpticalFlow(RenderCommandList* command
 		.uOpticalFlowPyramidLevelCount = 7,
 		.iFrameIndex                   = gpuFrameIndex,
 		.backbufferTransferFunction    = (uint32)passInput.transferFunction,
-		.minMaxLuminance               = { fMinLuminance, fMaxLuminance },
+		.minMaxLuminance               = { passInput.minLuminance, passInput.maxLuminance },
 	};
 	ConstantBufferView* passUniformCBV = prepareLumaDescriptor.getUniformCBV(swapchainIndex);
 	passUniformCBV->writeToGPU(commandList, &passUniformData, sizeof(passUniformData));
@@ -339,7 +333,7 @@ OpticalFlowPassOutput OpticalFlowPass::runOpticalFlow(RenderCommandList* command
 			.uOpticalFlowPyramidLevelCount = 7,
 			.iFrameIndex                   = gpuFrameIndex,
 			.backbufferTransferFunction    = (uint32)passInput.transferFunction,
-			.minMaxLuminance               = { fMinLuminance, fMaxLuminance },
+			.minMaxLuminance               = { passInput.minLuminance, passInput.maxLuminance },
 		};
 		ConstantBufferView* v5PassUniformCBV = computeOpticalFlowAdvancedV5Descriptor.getUniformChunkCBV(swapchainIndex, level);
 		v5PassUniformCBV->writeToGPU(commandList, &v5PassUniformData, sizeof(v5PassUniformData));

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -530,26 +530,6 @@ OpticalFlowPassOutput OpticalFlowPass::runOpticalFlow(RenderCommandList* command
 	};
 }
 
-Texture* OpticalFlowPass::getOpticalFlowVectorTexture() const
-{
-	return opticalFlowVectorTexture.get();
-}
-
-ShaderResourceView* OpticalFlowPass::getOpticalFlowVectorSRV() const
-{
-	return opticalFlowVectorSRV.get();
-}
-
-uint32 OpticalFlowPass::getOpticalFlowVectorSizeX() const
-{
-	return opticalFlowVectorSizeX;
-}
-
-uint32 OpticalFlowPass::getOpticalFlowVectorSizeY() const
-{
-	return opticalFlowVectorSizeY;
-}
-
 void OpticalFlowPass::initializePipelines()
 {
 	const uint32 swapchainCount = 2; // Always need two frames.

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -84,18 +84,21 @@ void OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swap
 	{
 		gpuFrameIndex = 0;
 
+
 		ClearResourcePass* clearPass = passInput.clearResourcePass;
-		clearPass->enqueueClear(scdTempTexture.get(), scdTempUAV.get());
-		clearPass->enqueueClear(scdOutputTexture.get(), scdOutputUAV.get());
+		auto uintClear = ClearResourcePass::uintClearValue(0, 0, 0, 0);
+
+		clearPass->enqueueClear(scdTempTexture.get(), scdTempUAV.get(), uintClear);
+		clearPass->enqueueClear(scdOutputTexture.get(), scdOutputUAV.get(), uintClear);
 		for (size_t i = 0; i < scdHistogramTextures.size(); ++i)
 		{
-			clearPass->enqueueClear(scdHistogramTextures[i].get(), scdHistogramUAVs[i].get());
+			clearPass->enqueueClear(scdHistogramTextures[i].get(), scdHistogramUAVs[i].get(), uintClear);
 		}
 		for (size_t i = 0; i < _countof(opticalFlowInputTextures); ++i)
 		{
 			for (size_t j = 0; j < _countof(opticalFlowInputTextures[0]); ++j)
 			{
-				clearPass->enqueueClear(opticalFlowInputTextures[i][j].get(), opticalFlowInputUAVs[i][j].get());
+				clearPass->enqueueClear(opticalFlowInputTextures[i][j].get(), opticalFlowInputUAVs[i][j].get(), uintClear);
 			}
 		}
 		clearPass->executeClears(commandList, swapchainIndex);

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -68,7 +68,6 @@ void OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swap
 	const uint32 prevFrame = isOddFrame ? 0 : 1;
 
 	const int advancedAlgorithmIterations = 7;
-	const uint32 opticalFlowBlockSize = 8;
 
 	auto prevScdHistogramTexture = scdHistogramTextures[0].get();
 	auto prevScdHistogramUAV     = scdHistogramUAVs[0].get();
@@ -305,7 +304,7 @@ void OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swap
 	const int32 pyramidMaxIterations = advancedAlgorithmIterations;
 	CHECK(pyramidMaxIterations <= OpticalFlowMaxPyramidLevels);
 
-	opticalFlowTextureSizes[0] = GetOpticalFlowTextureSize({ passInput.containerSizeX,passInput.containerSizeY }, opticalFlowBlockSize);
+	opticalFlowTextureSizes[0] = GetOpticalFlowTextureSize({ passInput.containerSizeX,passInput.containerSizeY }, kOpticalFlowBlockSize);
 	for (int32 i = 1; i < pyramidMaxIterations; i++)
 	{
 		opticalFlowTextureSizes[i] = {
@@ -384,7 +383,7 @@ void OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swap
 			const uint32 inputLumaWidth = std::max(passInput.lumaResolutionX >> level, 1);
 			const uint32 inputLumaHeight = std::max(passInput.lumaResolutionY >> level, 1);
 			const uint32 threadPixels = 4;
-			CHECK(opticalFlowBlockSize >= threadPixels);
+			CHECK(kOpticalFlowBlockSize >= threadPixels);
 			const uint32 threadGroupSizeY = 16;
 			const uint32 threadGroupSize = 64;
 			const uint32 dispatchX = ((inputLumaWidth + threadPixels - 1) / threadPixels * threadGroupSizeY + (threadGroupSize - 1)) / threadGroupSize;
@@ -500,11 +499,11 @@ void OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swap
 			commandList->setComputePipelineState(pipelineState);
 			commandList->bindComputeShaderParameters(pipelineState, &SPT, descriptorHeap, &scaleV5Tracker);
 
-			CHECK(opticalFlowBlockSize >= 2);
+			CHECK(kOpticalFlowBlockSize >= 2);
 			const uint32 nextLevelWidth = opticalFlowTextureSizes[level - 1].width;
 			const uint32 nextLevelHeight = opticalFlowTextureSizes[level - 1].height;
-			const uint32 threadGroupSizeX = opticalFlowBlockSize / 2;
-			const uint32 threadGroupSizeY = opticalFlowBlockSize / 2;
+			const uint32 threadGroupSizeX = kOpticalFlowBlockSize / 2;
+			const uint32 threadGroupSizeY = kOpticalFlowBlockSize / 2;
 			const uint32 threadGroupSizeZ = 4;
 			const uint32 dispatchX = (nextLevelWidth + 3) / 4;
 			const uint32 dispatchY = (nextLevelHeight + 3) / 4;
@@ -587,9 +586,8 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 	const bool bContainerResolutionChanged = containerResolutionXs[swapchainIndex] != passInput.containerSizeX || containerResolutionYs[swapchainIndex] != passInput.containerSizeY;
 	const bool bLumaResolutionChanged = lumaResolutionXs[swapchainIndex] != passInput.lumaResolutionX || lumaResolutionYs[swapchainIndex] != passInput.lumaResolutionY;
 	
-	const uint32 opticalFlowBlockSize = 8;
 	FfxDimensions2D opticalFlowTextureSizes[OpticalFlowMaxPyramidLevels];
-	opticalFlowTextureSizes[0] = GetOpticalFlowTextureSize({ passInput.containerSizeX,passInput.containerSizeY }, opticalFlowBlockSize);
+	opticalFlowTextureSizes[0] = GetOpticalFlowTextureSize({ passInput.containerSizeX,passInput.containerSizeY }, kOpticalFlowBlockSize);
 	for (int32 i = 1; i < OpticalFlowMaxPyramidLevels; i++)
 	{
 		opticalFlowTextureSizes[i] = {

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -590,6 +590,30 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 	opticalFlowVectorSizeX = opticalFlowTextureSizes[0].width;
 	opticalFlowVectorSizeY = opticalFlowTextureSizes[0].height;
 
+	auto createAllMipsSRV = [device = device](Texture* texture) -> UniquePtr<ShaderResourceView> {
+		return UniquePtr<ShaderResourceView>(device->createSRV(texture,
+			ShaderResourceViewDesc{
+				.format        = texture->getCreateParams().format,
+				.viewDimension = ESRVDimension::Texture2D,
+				.texture2D     = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = texture->getCreateParams().mipLevels,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
+			}
+		));
+	};
+	auto createSingleMipUAV = [device = device](Texture* texture, uint32 mip) -> UniquePtr<UnorderedAccessView> {
+		return UniquePtr<UnorderedAccessView>(device->createUAV(texture,
+			UnorderedAccessViewDesc{
+				.format         = texture->getCreateParams().format,
+				.viewDimension  = EUAVDimension::Texture2D,
+				.texture2D      = Texture2DUAVDesc{ .mipSlice = mip, .planeSlice = 0 },
+			}
+		));
+	};
+
 	// #todo-fsr3-fg: Use bContainerResolutionChanged?
 	if (bLumaResolutionChanged)
 	{
@@ -604,6 +628,7 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 
 			for (uint32 mip = 0; mip < _countof(opticalFlowInputTextures[frameIx]); ++mip)
 			{
+				// Not a case where a texture contains 7 mips; each mip is an individual texture.
 				TextureCreateParams texDesc = TextureCreateParams::texture2D(
 					EPixelFormat::R32_UINT, ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 					passInput.lumaResolutionX >> mip, passInput.lumaResolutionY >> mip, 1);
@@ -615,25 +640,8 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 				std::swprintf(msg, _countof(msg), L"RT_OpticalFlow_OpticalFlowInput_%s_%u", frameIx == 0 ? L"A" : L"B", mip);
 				currTexture->setDebugName(msg);
 
-				opticalFlowInputUAVs[frameIx][mip] = UniquePtr<UnorderedAccessView>(device->createUAV(currTexture,
-					UnorderedAccessViewDesc{
-						.format         = currTexture->getCreateParams().format,
-						.viewDimension  = EUAVDimension::Texture2D,
-						.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-					}
-				));
-				opticalFlowInputSRVs[frameIx][mip] = UniquePtr<ShaderResourceView>(device->createSRV(currTexture,
-					ShaderResourceViewDesc{
-						.format              = currTexture->getCreateParams().format,
-						.viewDimension       = ESRVDimension::Texture2D,
-						.texture2D           = Texture2DSRVDesc{
-							.mostDetailedMip = 0,
-							.mipLevels       = 1,
-							.planeSlice      = 0,
-							.minLODClamp     = 0.0f,
-						},
-					}
-				));
+				opticalFlowInputUAVs[frameIx][mip] = createSingleMipUAV(currTexture, 0);
+				opticalFlowInputSRVs[frameIx][mip] = createAllMipsSRV(currTexture);
 			}
 		}
 	}
@@ -663,25 +671,8 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 				std::swprintf(msg, _countof(msg), L"RT_OpticalFlow_OpticalFlow_%s_%u", frameIx == 0 ? L"A" : L"B", mip);
 				currTexture->setDebugName(msg);
 
-				opticalFlowUAVs[frameIx][mip] = UniquePtr<UnorderedAccessView>(device->createUAV(currTexture,
-					UnorderedAccessViewDesc{
-						.format         = currTexture->getCreateParams().format,
-						.viewDimension  = EUAVDimension::Texture2D,
-						.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-					}
-				));
-				opticalFlowSRVs[frameIx][mip] = UniquePtr<ShaderResourceView>(device->createSRV(currTexture,
-					ShaderResourceViewDesc{
-						.format              = currTexture->getCreateParams().format,
-						.viewDimension       = ESRVDimension::Texture2D,
-						.texture2D           = Texture2DSRVDesc{
-							.mostDetailedMip = 0,
-							.mipLevels       = 1,
-							.planeSlice      = 0,
-							.minLODClamp     = 0.0f,
-						},
-					}
-				));
+				opticalFlowUAVs[frameIx][mip] = createSingleMipUAV(currTexture, 0);
+				opticalFlowSRVs[frameIx][mip] = createAllMipsSRV(currTexture);
 			}
 		}
 	}
@@ -699,13 +690,7 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 			std::swprintf(debugName, _countof(debugName), L"OpticalFlow_SCDHistogram_%u", i);
 			scdHistogramTextures[i]->setDebugName(debugName);
 
-			scdHistogramUAVs[i] = UniquePtr<UnorderedAccessView>(device->createUAV(scdHistogramTextures[i].get(),
-				UnorderedAccessViewDesc{
-					.format         = scdHistogramTextures[i]->getCreateParams().format,
-					.viewDimension  = EUAVDimension::Texture2D,
-					.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-				}
-			));
+			scdHistogramUAVs[i] = createSingleMipUAV(scdHistogramTextures[i].get(), 0);
 		}
 	}
 	if (scdTempTexture == nullptr)
@@ -714,13 +699,7 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 			EPixelFormat::R32_UINT, ETextureAccessFlags::UAV, 3, 1)));
 		scdTempTexture->setDebugName(L"OpticalFlow_SCDTemp");
 
-		scdTempUAV = UniquePtr<UnorderedAccessView>(device->createUAV(scdTempTexture.get(),
-			UnorderedAccessViewDesc{
-				.format         = scdTempTexture->getCreateParams().format,
-				.viewDimension  = EUAVDimension::Texture2D,
-				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-			}
-		));
+		scdTempUAV = createSingleMipUAV(scdTempTexture.get(), 0);
 	}
 	if (scdOutputTexture == nullptr)
 	{
@@ -728,25 +707,8 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 			EPixelFormat::R32_UINT, ETextureAccessFlags::UAV, 3, 1)));
 		scdOutputTexture->setDebugName(L"OpticalFlow_SCDOutput");
 
-		scdOutputUAV = UniquePtr<UnorderedAccessView>(device->createUAV(scdOutputTexture.get(),
-			UnorderedAccessViewDesc{
-				.format         = scdOutputTexture->getCreateParams().format,
-				.viewDimension  = EUAVDimension::Texture2D,
-				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-			}
-		));
-		scdOutputSRV = UniquePtr<ShaderResourceView>(device->createSRV(scdOutputTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = scdOutputTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = 1,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
+		scdOutputUAV = createSingleMipUAV(scdOutputTexture.get(), 0);
+		scdOutputSRV = createAllMipsSRV(scdOutputTexture.get());
 	}
 
 	if (bLumaResolutionChanged)
@@ -761,24 +723,7 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 		opticalFlowVectorTexture = UniquePtr<Texture>(device->createTexture(texDesc));
 		opticalFlowVectorTexture->setDebugName(L"RT_OpticalFlow_opticalFlowVector");
 
-		opticalFlowVectorUAV = UniquePtr<UnorderedAccessView>(device->createUAV(opticalFlowVectorTexture.get(),
-			UnorderedAccessViewDesc{
-				.format         = opticalFlowVectorTexture->getCreateParams().format,
-				.viewDimension  = EUAVDimension::Texture2D,
-				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
-			}
-		));
-		opticalFlowVectorSRV = UniquePtr<ShaderResourceView>(device->createSRV(opticalFlowVectorTexture.get(),
-			ShaderResourceViewDesc{
-				.format              = opticalFlowVectorTexture->getCreateParams().format,
-				.viewDimension       = ESRVDimension::Texture2D,
-				.texture2D           = Texture2DSRVDesc{
-					.mostDetailedMip = 0,
-					.mipLevels       = opticalFlowVectorTexture->getCreateParams().mipLevels,
-					.planeSlice      = 0,
-					.minLODClamp     = 0.0f,
-				},
-			}
-		));
+		opticalFlowVectorUAV = createSingleMipUAV(opticalFlowVectorTexture.get(), 0);
+		opticalFlowVectorSRV = createAllMipsSRV(opticalFlowVectorTexture.get());
 	}
 }

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -48,42 +48,6 @@ struct SpdUniform
 	uint32 pad2_;
 };
 
-// Ported from <FidelityFX_SDK>/sdk/include/FidelityFX/gpu/spd/ffx_spd.h
-static void ffxSpdSetup(
-	uint32 dispatchThreadGroupCountXY[2],
-	uint32 workGroupOffset[2],
-	uint32 numWorkGroupsAndMips[2],
-	const uint32 rectInfo[4],
-	const int32 mips)
-{
-	// determines the offset of the first tile to downsample based on
-	// left (rectInfo[0]) and top (rectInfo[1]) of the subregion.
-	workGroupOffset[0] = rectInfo[0] / 64;
-	workGroupOffset[1] = rectInfo[1] / 64;
-
-	uint32 endIndexX = (rectInfo[0] + rectInfo[2] - 1) / 64;  // rectInfo[0] = left, rectInfo[2] = width
-	uint32 endIndexY = (rectInfo[1] + rectInfo[3] - 1) / 64;  // rectInfo[1] = top, rectInfo[3] = height
-
-	// we only need to dispatch as many thread groups as tiles we need to downsample
-	// number of tiles per slice depends on the subregion to downsample
-	dispatchThreadGroupCountXY[0] = endIndexX + 1 - workGroupOffset[0];
-	dispatchThreadGroupCountXY[1] = endIndexY + 1 - workGroupOffset[1];
-
-	// number of thread groups per slice
-	numWorkGroupsAndMips[0] = (dispatchThreadGroupCountXY[0]) * (dispatchThreadGroupCountXY[1]);
-
-	if (mips >= 0)
-	{
-		numWorkGroupsAndMips[1] = uint32(mips);
-	}
-	else
-	{
-		// calculate based on rect width and height
-		uint32 resolution = (std::max)(rectInfo[2], rectInfo[3]);
-		numWorkGroupsAndMips[1] = (uint32)((std::min(std::floor(std::log2(float(resolution))), float(12))));
-	}
-}
-
 void OpticalFlowPass::initialize(RenderDevice* inRenderDevice)
 {
 	device = inRenderDevice;

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -59,7 +59,7 @@ void OpticalFlowPass::initialize(RenderDevice* inRenderDevice)
 }
 
 // See dispatch() in sdk/src/components/opticalflow/ffx_opticalflow.cpp for dispatch order.
-void OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swapchainIndex, const OpticalFlowPassInput& passInput)
+OpticalFlowPassOutput OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swapchainIndex, const OpticalFlowPassInput& passInput)
 {
 	recreateResources(commandList, swapchainIndex, passInput);
 
@@ -519,6 +519,15 @@ void OpticalFlowPass::runOpticalFlow(RenderCommandList* commandList, uint32 swap
 	}
 
 	resourceFrameIndex = (resourceFrameIndex + 1) % FFX_OPTICALFLOW_MAX_QUEUED_FRAMES;
+
+	return OpticalFlowPassOutput{
+		.opticalFlowVectorSizeX      = opticalFlowVectorSizeX,
+		.opticalFlowVectorSizeY      = opticalFlowVectorSizeY,
+		.opticalFlowVectorTexture    = opticalFlowVectorTexture.get(),
+		.opticalFlowVectorSRV        = opticalFlowVectorSRV.get(),
+		.sceneChangeDetectionTexture = scdOutputTexture.get(),
+		.sceneChangeDetectionSRV     = scdOutputSRV.get(),
+	};
 }
 
 Texture* OpticalFlowPass::getOpticalFlowVectorTexture() const
@@ -750,6 +759,18 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 				.format         = scdOutputTexture->getCreateParams().format,
 				.viewDimension  = EUAVDimension::Texture2D,
 				.texture2D      = Texture2DUAVDesc{ .mipSlice = 0, .planeSlice = 0 },
+			}
+		));
+		scdOutputSRV = UniquePtr<ShaderResourceView>(device->createSRV(scdOutputTexture.get(),
+			ShaderResourceViewDesc{
+				.format              = scdOutputTexture->getCreateParams().format,
+				.viewDimension       = ESRVDimension::Texture2D,
+				.texture2D           = Texture2DSRVDesc{
+					.mostDetailedMip = 0,
+					.mipLevels       = 1,
+					.planeSlice      = 0,
+					.minLODClamp     = 0.0f,
+				},
 			}
 		));
 	}

--- a/projects/Cyseal/src/render/optical_flow_pass.h
+++ b/projects/Cyseal/src/render/optical_flow_pass.h
@@ -24,7 +24,7 @@ class OpticalFlowPass final : public SceneRenderPass
 public:
 	void initialize(RenderDevice* inRenderDevice);
 
-	void runOpticalFlow(RenderCommandList* commandList, uint32 swapchainIndex, const OpticalFlowPassInput& passInput);
+	OpticalFlowPassOutput runOpticalFlow(RenderCommandList* commandList, uint32 swapchainIndex, const OpticalFlowPassInput& passInput);
 
 	Texture* getOpticalFlowVectorTexture() const;
 	ShaderResourceView* getOpticalFlowVectorSRV() const;
@@ -77,6 +77,7 @@ private:
 	UniquePtr<UnorderedAccessView>         scdTempUAV;
 	UniquePtr<Texture>                     scdOutputTexture;
 	UniquePtr<UnorderedAccessView>         scdOutputUAV;
+	UniquePtr<ShaderResourceView>          scdOutputSRV;
 
 	uint32                                 opticalFlowVectorSizeX = 0;
 	uint32                                 opticalFlowVectorSizeY = 0;

--- a/projects/Cyseal/src/render/optical_flow_pass.h
+++ b/projects/Cyseal/src/render/optical_flow_pass.h
@@ -26,11 +26,6 @@ public:
 
 	OpticalFlowPassOutput runOpticalFlow(RenderCommandList* commandList, uint32 swapchainIndex, const OpticalFlowPassInput& passInput);
 
-	Texture* getOpticalFlowVectorTexture() const;
-	ShaderResourceView* getOpticalFlowVectorSRV() const;
-	uint32 getOpticalFlowVectorSizeX() const;
-	uint32 getOpticalFlowVectorSizeY() const;
-
 private:
 	void initializePipelines();
 	void recreateResources(RenderCommandList* commandList, uint32 swapchainIndex, const OpticalFlowPassInput& passInput);

--- a/projects/Cyseal/src/render/optical_flow_pass.h
+++ b/projects/Cyseal/src/render/optical_flow_pass.h
@@ -15,6 +15,8 @@ struct OpticalFlowPassInput
 	uint32                                containerSizeY;
 	int32                                 lumaResolutionX;
 	int32                                 lumaResolutionY;
+	float                                 minLuminance;
+	float                                 maxLuminance;
 	Texture*                              sceneColorTexture;
 	ShaderResourceView*                   sceneColorSRV;
 };

--- a/projects/Cyseal/src/render/optical_flow_pass.h
+++ b/projects/Cyseal/src/render/optical_flow_pass.h
@@ -1,19 +1,10 @@
 #pragma once
 
 #include "scene_render_pass.h"
+#include "optical_flow_common.h"
 #include "core/smart_pointer.h"
 #include "rhi/rhi_forward.h"
 #include "util/volatile_descriptor.h"
-
-// See ffx_opticalflow_prepare_luma.h
-enum class OpticalFlowBackbufferTransferFunction : uint32
-{
-	LinearLdrToLuminance                  = 0,
-	PQCorrectedHdrToPerceivedLuminance    = 1,
-	SCRGBCorrectedHdrToPerceivedLuminance = 2,
-
-	Count,
-};
 
 struct OpticalFlowPassInput
 {

--- a/projects/Cyseal/src/render/renderer_options.h
+++ b/projects/Cyseal/src/render/renderer_options.h
@@ -206,6 +206,9 @@ struct RendererOptions
 	bool                      bEnableDepthPrepass = true;
 	bool                      bEnableVisibilityBuffer = true;
 
+	// Frame generation
+	bool                      bGenerateFrame = true;
+
 	// Debug visualization
 	EBufferVisualizationMode  bufferVisualization = EBufferVisualizationMode::None;
 

--- a/projects/Cyseal/src/render/renderer_options.h
+++ b/projects/Cyseal/src/render/renderer_options.h
@@ -33,6 +33,7 @@ enum class EBufferVisualizationMode : uint32
 	VisibilityBufferMetalMask     = 16,
 	OpticalFlowVector             = 17,
 	InterpolatedFrame             = 18,
+	FrameGenerationDebugView      = 19,
 
 	Count,
 };
@@ -120,6 +121,7 @@ inline const char** getBufferVisualizationModeNames()
 		"VisibilityBufferMetalMask",
 		"OpticalFlowVector",
 		"InterpolatedFrame",
+		"FrameGenerationDebugView",
 	};
 	static_assert(_countof(strings) == (int)EBufferVisualizationMode::Count);
 	return strings;

--- a/projects/Cyseal/src/render/renderer_options.h
+++ b/projects/Cyseal/src/render/renderer_options.h
@@ -32,6 +32,7 @@ enum class EBufferVisualizationMode : uint32
 	VisibilityBufferRoughness     = 15,
 	VisibilityBufferMetalMask     = 16,
 	OpticalFlowVector             = 17,
+	InterpolatedFrame             = 18,
 
 	Count,
 };
@@ -118,6 +119,7 @@ inline const char** getBufferVisualizationModeNames()
 		"VisibilityBufferRoughness",
 		"VisibilityBufferMetalMask",
 		"OpticalFlowVector",
+		"InterpolatedFrame",
 	};
 	static_assert(_countof(strings) == (int)EBufferVisualizationMode::Count);
 	return strings;

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -831,6 +831,12 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		{
 			SCOPED_DRAW_EVENT(commandList, FrameGeneration);
 
+			// #wip: dispatchFlags
+			//DRAW_DEBUG_TEAR_LINES       = (1 << 0),
+			//DRAW_DEBUG_RESET_INDICATORS = (1 << 1),
+			//DRAW_DEBUG_VIEW             = (1 << 2),
+			const EFrameGenDispatchFlags dispatchFlags = EFrameGenDispatchFlags::NONE;
+
 			FrameGenPassInput passInput{
 				.clearResourcePass          = clearResourcePass,
 				.opticalFlowPassOutput      = &opticalFlowPassOutput,
@@ -840,8 +846,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.displaySizeX               = (int32)unscaledRenderWidth,
 				.displaySizeY               = (int32)unscaledRenderHeight,
 				.frameID                    = frameID,
-				.deltaTime                  = 0.0f, // #wip: deltaTime
-				.dispatchFlags              = 0, // #wip: dispatchFlags
+				.dispatchFlags              = dispatchFlags,
 				.backBufferTransferFunction = backbufferTransferFunction,
 				.bReset                     = bResetOpticalFlowAccumulation,
 				.minLuminance               = fMinLuminance,

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -889,50 +889,17 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		SCOPED_DRAW_EVENT(commandList, BufferVisualization);
 
 		TextureBarrierAuto textureBarriers[] = {
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_gbuffers[0].get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_gbuffers[1].get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_sceneColor.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_shadowMask.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_indirectDiffuse.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_indirectSpecular.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_velocityMap.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_visibilityBuffer.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_barycentricCoord.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_visGbuffers[0].get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_visGbuffers[1].get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
+			TextureBarrierAuto::toShaderResource(RT_gbuffers[0].get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_gbuffers[1].get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_sceneColor.get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_shadowMask.get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_indirectDiffuse.get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_indirectSpecular.get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_velocityMap.get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_visibilityBuffer.get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_barycentricCoord.get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_visGbuffers[0].get(), EBarrierSync::PIXEL_SHADING),
+			TextureBarrierAuto::toShaderResource(RT_visGbuffers[1].get(), EBarrierSync::PIXEL_SHADING),
 			// #wip: Null if the pass does not run. (enable buffer vis + enable path tracing -> crashes)
 			TextureBarrierAuto::toShaderResource(opticalFlowPassOutput.opticalFlowVectorTexture, EBarrierSync::PIXEL_SHADING),
 		};

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -794,17 +794,16 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		combineLightingPass->combineLighting(commandList, swapchainIndex, passInput);
 	}
 
+	const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
+	const bool bResetOpticalFlowAccumulation = false;
 	if (!bRenderPathTracing)
 	{
 		SCOPED_DRAW_EVENT(commandList, OpticalFlow);
 
-		const auto transferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
-		const bool bResetAccumulation = false;
-
 		OpticalFlowPassInput passInput{
 			.clearResourcePass  = clearResourcePass,
-			.transferFunction   = transferFunction,
-			.bResetAccumulation = bResetAccumulation,
+			.transferFunction   = backbufferTransferFunction,
+			.bResetAccumulation = bResetOpticalFlowAccumulation,
 			.containerSizeX     = unscaledRenderWidth,
 			.containerSizeY     = unscaledRenderHeight,
 			.lumaResolutionX    = (int32)sceneWidth,
@@ -813,8 +812,29 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.sceneColorSRV      = sceneColorSRV.get(),
 		};
 		opticalFlowPass->runOpticalFlow(commandList, swapchainIndex, passInput);
+	}
 
-		// #wip: frameGenPass here
+	if (!bRenderPathTracing)
+	{
+		SCOPED_DRAW_EVENT(commandList, FrameGeneration);
+
+		FrameGenPassInput passInput{
+			.clearResourcePass          = clearResourcePass,
+			.camera                     = camera,
+			.renderSizeX                = (int32)sceneWidth,
+			.renderSizeY                = (int32)sceneHeight,
+			.displaySizeX               = (int32)unscaledRenderWidth,
+			.displaySizeY               = (int32)unscaledRenderHeight,
+			.deltaTime                  = 0.0f, // #wip: deltaTime
+			.dispatchFlags              = 0, // #wip: dispatchFlags
+			.backBufferTransferFunction = backbufferTransferFunction,
+			.bReset                     = bResetOpticalFlowAccumulation,
+			.sceneDepthTexture          = RT_sceneDepth.get(),
+			.sceneDepthSRV              = sceneDepthSRV.get(),
+			.motionVectorTexture        = RT_velocityMap.get(),
+			.motionVectorSRV            = velocityMapSRV.get(),
+		};
+		frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
 	}
 
 	// Set final color as render target.

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -831,11 +831,11 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		{
 			SCOPED_DRAW_EVENT(commandList, FrameGeneration);
 
-			// #wip: dispatchFlags
-			//DRAW_DEBUG_TEAR_LINES       = (1 << 0),
-			//DRAW_DEBUG_RESET_INDICATORS = (1 << 1),
-			//DRAW_DEBUG_VIEW             = (1 << 2),
-			const EFrameGenDispatchFlags dispatchFlags = EFrameGenDispatchFlags::NONE;
+			EFrameGenDispatchFlags dispatchFlags = EFrameGenDispatchFlags::NONE;
+			if (renderOptions.bufferVisualization == EBufferVisualizationMode::FrameGenerationDebugView)
+			{
+				dispatchFlags |= EFrameGenDispatchFlags::DRAW_DEBUG_VIEW;
+			}
 
 			FrameGenPassInput passInput{
 				.clearResourcePass          = clearResourcePass,

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -239,7 +239,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 	const bool bRenderAnyRaytracingPass = renderOptions.anyRayTracingEnabled();
 
-	const bool bRenderOpticalFlow = !bRenderPathTracing;
+	const bool bRenderFrameGeneration = renderOptions.bGenerateFrame && !bRenderPathTracing;
 
 	clearResourcePass->prepareForFrame(swapchainIndex);
 
@@ -799,7 +799,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 	OpticalFlowPassOutput opticalFlowPassOutput{};
 	FrameGenPassOutput frameGenPassOutput{};
-	if (bRenderOpticalFlow)
+	if (bRenderFrameGeneration)
 	{
 		const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
 		const bool bResetOpticalFlowAccumulation = false;
@@ -921,7 +921,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			TextureBarrierAuto::toShaderResource(RT_visGbuffers[0].get(), EBarrierSync::PIXEL_SHADING),
 			TextureBarrierAuto::toShaderResource(RT_visGbuffers[1].get(), EBarrierSync::PIXEL_SHADING),
 		};
-		if (bRenderOpticalFlow)
+		if (bRenderFrameGeneration)
 		{
 			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(frameGenPassOutput.opticalFlowMotionVectorFieldTextures[0], EBarrierSync::PIXEL_SHADING));
 			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(frameGenPassOutput.opticalFlowMotionVectorFieldTextures[1], EBarrierSync::PIXEL_SHADING));
@@ -946,11 +946,11 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.barycentricCoordSRV    = barycentricCoordSRV.get(),
 			.visGbuffer0SRV         = visGbufferSRVs[0].get(),
 			.visGbuffer1SRV         = visGbufferSRVs[1].get(),
-			.opticalFlowVectorXSRV  = bRenderOpticalFlow ? frameGenPassOutput.opticalFlowMotionVectorFieldSRVs[0] : grey2DSRV.get(),
-			.opticalFlowVectorYSRV  = bRenderOpticalFlow ? frameGenPassOutput.opticalFlowMotionVectorFieldSRVs[1] : grey2DSRV.get(),
-			.opticalFlowVectorSizeX = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSizeX : 1,
-			.opticalFlowVectorSizeY = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSizeY : 1,
-			.interpolatedFrameSRV   = bRenderOpticalFlow ? frameGenPassOutput.interpolatedFrameSRV : grey2DSRV.get(),
+			.opticalFlowVectorXSRV  = bRenderFrameGeneration ? frameGenPassOutput.opticalFlowMotionVectorFieldSRVs[0] : grey2DSRV.get(),
+			.opticalFlowVectorYSRV  = bRenderFrameGeneration ? frameGenPassOutput.opticalFlowMotionVectorFieldSRVs[1] : grey2DSRV.get(),
+			.opticalFlowVectorSizeX = bRenderFrameGeneration ? opticalFlowPassOutput.opticalFlowVectorSizeX : 1,
+			.opticalFlowVectorSizeY = bRenderFrameGeneration ? opticalFlowPassOutput.opticalFlowVectorSizeY : 1,
+			.interpolatedFrameSRV   = bRenderFrameGeneration ? frameGenPassOutput.interpolatedFrameSRV : grey2DSRV.get(),
 		};
 
 		bufferVisualization->renderVisualization(commandList, swapchainIndex, sources);

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -795,48 +795,51 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		combineLightingPass->combineLighting(commandList, swapchainIndex, passInput);
 	}
 
-	const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
-	const bool bResetOpticalFlowAccumulation = false;
 	if (!bRenderPathTracing)
 	{
-		SCOPED_DRAW_EVENT(commandList, OpticalFlow);
+		const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
+		const bool bResetOpticalFlowAccumulation = false;
+		OpticalFlowPassOutput opticalFlowPassOutput{};
 
-		OpticalFlowPassInput passInput{
-			.clearResourcePass  = clearResourcePass,
-			.transferFunction   = backbufferTransferFunction,
-			.bResetAccumulation = bResetOpticalFlowAccumulation,
-			.containerSizeX     = unscaledRenderWidth,
-			.containerSizeY     = unscaledRenderHeight,
-			.lumaResolutionX    = (int32)sceneWidth,
-			.lumaResolutionY    = (int32)sceneHeight,
-			.sceneColorTexture  = RT_sceneColor.get(),
-			.sceneColorSRV      = sceneColorSRV.get(),
-		};
-		opticalFlowPass->runOpticalFlow(commandList, swapchainIndex, passInput);
-	}
+		{
+			SCOPED_DRAW_EVENT(commandList, OpticalFlow);
 
-	if (!bRenderPathTracing)
-	{
-		SCOPED_DRAW_EVENT(commandList, FrameGeneration);
+			OpticalFlowPassInput passInput{
+				.clearResourcePass  = clearResourcePass,
+				.transferFunction   = backbufferTransferFunction,
+				.bResetAccumulation = bResetOpticalFlowAccumulation,
+				.containerSizeX     = unscaledRenderWidth,
+				.containerSizeY     = unscaledRenderHeight,
+				.lumaResolutionX    = (int32)sceneWidth,
+				.lumaResolutionY    = (int32)sceneHeight,
+				.sceneColorTexture  = RT_sceneColor.get(),
+				.sceneColorSRV      = sceneColorSRV.get(),
+			};
+			opticalFlowPassOutput = opticalFlowPass->runOpticalFlow(commandList, swapchainIndex, passInput);
+		}
+		{
+			SCOPED_DRAW_EVENT(commandList, FrameGeneration);
 
-		FrameGenPassInput passInput{
-			.clearResourcePass          = clearResourcePass,
-			.camera                     = camera,
-			.renderSizeX                = (int32)sceneWidth,
-			.renderSizeY                = (int32)sceneHeight,
-			.displaySizeX               = (int32)unscaledRenderWidth,
-			.displaySizeY               = (int32)unscaledRenderHeight,
-			.frameID                    = frameID,
-			.deltaTime                  = 0.0f, // #wip: deltaTime
-			.dispatchFlags              = 0, // #wip: dispatchFlags
-			.backBufferTransferFunction = backbufferTransferFunction,
-			.bReset                     = bResetOpticalFlowAccumulation,
-			.sceneDepthTexture          = RT_sceneDepth.get(),
-			.sceneDepthSRV              = sceneDepthSRV.get(),
-			.motionVectorTexture        = RT_velocityMap.get(),
-			.motionVectorSRV            = velocityMapSRV.get(),
-		};
-		frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
+			FrameGenPassInput passInput{
+				.clearResourcePass          = clearResourcePass,
+				.opticalFlowPassOutput      = &opticalFlowPassOutput,
+				.camera                     = camera,
+				.renderSizeX                = (int32)sceneWidth,
+				.renderSizeY                = (int32)sceneHeight,
+				.displaySizeX               = (int32)unscaledRenderWidth,
+				.displaySizeY               = (int32)unscaledRenderHeight,
+				.frameID                    = frameID,
+				.deltaTime                  = 0.0f, // #wip: deltaTime
+				.dispatchFlags              = 0, // #wip: dispatchFlags
+				.backBufferTransferFunction = backbufferTransferFunction,
+				.bReset                     = bResetOpticalFlowAccumulation,
+				.sceneDepthTexture          = RT_sceneDepth.get(),
+				.sceneDepthSRV              = sceneDepthSRV.get(),
+				.motionVectorTexture        = RT_velocityMap.get(),
+				.motionVectorSRV            = velocityMapSRV.get(),
+			};
+			frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
+		}
 	}
 
 	// Set final color as render target.

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -795,11 +795,11 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		combineLightingPass->combineLighting(commandList, swapchainIndex, passInput);
 	}
 
+	OpticalFlowPassOutput opticalFlowPassOutput{};
 	if (!bRenderPathTracing)
 	{
 		const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
 		const bool bResetOpticalFlowAccumulation = false;
-		OpticalFlowPassOutput opticalFlowPassOutput{};
 
 		{
 			SCOPED_DRAW_EVENT(commandList, OpticalFlow);
@@ -933,10 +933,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
 				RT_visGbuffers[1].get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
 			},
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				opticalFlowPass->getOpticalFlowVectorTexture(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
+			// #wip: Null if the pass does not run. (enable buffer vis + enable path tracing -> crashes)
+			TextureBarrierAuto::toShaderResource(opticalFlowPassOutput.opticalFlowVectorTexture, EBarrierSync::PIXEL_SHADING),
 		};
 		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
 
@@ -957,9 +955,9 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.barycentricCoordSRV    = barycentricCoordSRV.get(),
 			.visGbuffer0SRV         = visGbufferSRVs[0].get(),
 			.visGbuffer1SRV         = visGbufferSRVs[1].get(),
-			.opticalFlowVectorSRV   = opticalFlowPass->getOpticalFlowVectorSRV(),
-			.opticalFlowVectorSizeX = opticalFlowPass->getOpticalFlowVectorSizeX(),
-			.opticalFlowVectorSizeY = opticalFlowPass->getOpticalFlowVectorSizeY(),
+			.opticalFlowVectorSRV   = opticalFlowPassOutput.opticalFlowVectorSRV,
+			.opticalFlowVectorSizeX = opticalFlowPassOutput.opticalFlowVectorSizeX,
+			.opticalFlowVectorSizeY = opticalFlowPassOutput.opticalFlowVectorSizeY,
 		};
 
 		bufferVisualization->renderVisualization(commandList, swapchainIndex, sources);

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -239,6 +239,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 	const bool bRenderAnyRaytracingPass = renderOptions.anyRayTracingEnabled();
 
+	const bool bRenderOpticalFlow = !bRenderPathTracing;
+
 	clearResourcePass->prepareForFrame(swapchainIndex);
 
 	rebuildFrameResources(commandList, scene);
@@ -796,7 +798,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	}
 
 	OpticalFlowPassOutput opticalFlowPassOutput{};
-	if (!bRenderPathTracing)
+	FrameGenPassOutput frameGenPassOutput{};
+	if (bRenderOpticalFlow)
 	{
 		const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
 		const bool bResetOpticalFlowAccumulation = false;
@@ -840,7 +843,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.motionVectorTexture        = RT_velocityMap.get(),
 				.motionVectorSRV            = velocityMapSRV.get(),
 			};
-			frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
+			frameGenPassOutput = frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
 		}
 	}
 
@@ -890,7 +893,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		SCOPED_DRAW_EVENT(commandList, BufferVisualization);
 
-		TextureBarrierAuto textureBarriers[] = {
+		std::vector<TextureBarrierAuto> textureBarriers = {
 			TextureBarrierAuto::toShaderResource(RT_gbuffers[0].get(), EBarrierSync::PIXEL_SHADING),
 			TextureBarrierAuto::toShaderResource(RT_gbuffers[1].get(), EBarrierSync::PIXEL_SHADING),
 			TextureBarrierAuto::toShaderResource(RT_sceneColor.get(), EBarrierSync::PIXEL_SHADING),
@@ -902,10 +905,13 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			TextureBarrierAuto::toShaderResource(RT_barycentricCoord.get(), EBarrierSync::PIXEL_SHADING),
 			TextureBarrierAuto::toShaderResource(RT_visGbuffers[0].get(), EBarrierSync::PIXEL_SHADING),
 			TextureBarrierAuto::toShaderResource(RT_visGbuffers[1].get(), EBarrierSync::PIXEL_SHADING),
-			// #wip: Null if the pass does not run. (enable buffer vis + enable path tracing -> crashes)
-			TextureBarrierAuto::toShaderResource(opticalFlowPassOutput.opticalFlowVectorTexture, EBarrierSync::PIXEL_SHADING),
 		};
-		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+		if (bRenderOpticalFlow)
+		{
+			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(opticalFlowPassOutput.opticalFlowVectorTexture, EBarrierSync::PIXEL_SHADING));
+			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(frameGenPassOutput.interpolatedFrameTexture, EBarrierSync::PIXEL_SHADING));
+		}
+		commandList->barrierAuto(0, nullptr, (uint32)textureBarriers.size(), textureBarriers.data(), 0, nullptr);
 
 		BufferVisualizationInput sources{
 			.renderTarget           = RT_finalSceneColor.get(),
@@ -924,9 +930,10 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.barycentricCoordSRV    = barycentricCoordSRV.get(),
 			.visGbuffer0SRV         = visGbufferSRVs[0].get(),
 			.visGbuffer1SRV         = visGbufferSRVs[1].get(),
-			.opticalFlowVectorSRV   = opticalFlowPassOutput.opticalFlowVectorSRV,
-			.opticalFlowVectorSizeX = opticalFlowPassOutput.opticalFlowVectorSizeX,
-			.opticalFlowVectorSizeY = opticalFlowPassOutput.opticalFlowVectorSizeY,
+			.opticalFlowVectorSRV   = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSRV : grey2DSRV.get(),
+			.opticalFlowVectorSizeX = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSizeX : 1,
+			.opticalFlowVectorSizeY = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSizeY : 1,
+			.interpolatedFrameSRV   = bRenderOpticalFlow ? frameGenPassOutput.interpolatedFrameSRV : grey2DSRV.get(),
 		};
 
 		bufferVisualization->renderVisualization(commandList, swapchainIndex, sources);

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -51,6 +51,7 @@ static uint32 fullMipCount(uint32 width, uint32 height)
 void SceneRenderer::initialize(RenderDevice* renderDevice)
 {
 	device = renderDevice;
+	frameID = 0;
 
 	// Scene textures: Don't create yet. You invoke recreateSceneTextures() before using scene renderer.
 	// recreateSceneTextures(width, height);
@@ -825,6 +826,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.renderSizeY                = (int32)sceneHeight,
 			.displaySizeX               = (int32)unscaledRenderWidth,
 			.displaySizeY               = (int32)unscaledRenderHeight,
+			.frameID                    = frameID,
 			.deltaTime                  = 0.0f, // #wip: deltaTime
 			.dispatchFlags              = 0, // #wip: dispatchFlags
 			.backBufferTransferFunction = backbufferTransferFunction,
@@ -1073,6 +1075,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		device->flushCommandQueue();
 	}
+
+	frameID += 1;
 
 	// Deallocate memory, a bit messy
 	commandList->executeDeferredDealloc();

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -804,6 +804,12 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
 		const bool bResetOpticalFlowAccumulation = false;
 
+		// #todo-fsr3: How to calculate min/max luminance? Just downsample the sceneColor to 1x1?
+		// But how to read it? GPU stall and readback is def not an option :(
+		// If these are not scene luminance min/max but the range in HDR calibration then I should pass them from application logic side.
+		const float fMinLuminance = 0.0f;
+		const float fMaxLuminance = 3000.0f;
+
 		{
 			SCOPED_DRAW_EVENT(commandList, OpticalFlow);
 
@@ -815,6 +821,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.containerSizeY     = unscaledRenderHeight,
 				.lumaResolutionX    = (int32)sceneWidth,
 				.lumaResolutionY    = (int32)sceneHeight,
+				.minLuminance       = fMinLuminance,
+				.maxLuminance       = fMaxLuminance,
 				.sceneColorTexture  = RT_sceneColor.get(),
 				.sceneColorSRV      = sceneColorSRV.get(),
 			};
@@ -836,6 +844,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.dispatchFlags              = 0, // #wip: dispatchFlags
 				.backBufferTransferFunction = backbufferTransferFunction,
 				.bReset                     = bResetOpticalFlowAccumulation,
+				.minLuminance               = fMinLuminance,
+				.maxLuminance               = fMaxLuminance,
 				.sceneColorTexture          = RT_sceneColor.get(),
 				.sceneColorSRV              = sceneColorSRV.get(),
 				.sceneDepthTexture          = RT_sceneDepth.get(),

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -833,8 +833,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.dispatchFlags              = 0, // #wip: dispatchFlags
 				.backBufferTransferFunction = backbufferTransferFunction,
 				.bReset                     = bResetOpticalFlowAccumulation,
-				.sceneColorTexture          = RT_finalSceneColor.get(),
-				.sceneColorSRV              = finalSceneColorSRV.get(),
+				.sceneColorTexture          = RT_sceneColor.get(),
+				.sceneColorSRV              = sceneColorSRV.get(),
 				.sceneDepthTexture          = RT_sceneDepth.get(),
 				.sceneDepthSRV              = sceneDepthSRV.get(),
 				.motionVectorTexture        = RT_velocityMap.get(),

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -908,7 +908,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		};
 		if (bRenderOpticalFlow)
 		{
-			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(opticalFlowPassOutput.opticalFlowVectorTexture, EBarrierSync::PIXEL_SHADING));
+			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(frameGenPassOutput.opticalFlowMotionVectorFieldTextures[0], EBarrierSync::PIXEL_SHADING));
+			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(frameGenPassOutput.opticalFlowMotionVectorFieldTextures[1], EBarrierSync::PIXEL_SHADING));
 			textureBarriers.push_back(TextureBarrierAuto::toShaderResource(frameGenPassOutput.interpolatedFrameTexture, EBarrierSync::PIXEL_SHADING));
 		}
 		commandList->barrierAuto(0, nullptr, (uint32)textureBarriers.size(), textureBarriers.data(), 0, nullptr);
@@ -930,7 +931,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.barycentricCoordSRV    = barycentricCoordSRV.get(),
 			.visGbuffer0SRV         = visGbufferSRVs[0].get(),
 			.visGbuffer1SRV         = visGbufferSRVs[1].get(),
-			.opticalFlowVectorSRV   = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSRV : grey2DSRV.get(),
+			.opticalFlowVectorXSRV  = bRenderOpticalFlow ? frameGenPassOutput.opticalFlowMotionVectorFieldSRVs[0] : grey2DSRV.get(),
+			.opticalFlowVectorYSRV  = bRenderOpticalFlow ? frameGenPassOutput.opticalFlowMotionVectorFieldSRVs[1] : grey2DSRV.get(),
 			.opticalFlowVectorSizeX = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSizeX : 1,
 			.opticalFlowVectorSizeY = bRenderOpticalFlow ? opticalFlowPassOutput.opticalFlowVectorSizeY : 1,
 			.interpolatedFrameSRV   = bRenderOpticalFlow ? frameGenPassOutput.interpolatedFrameSRV : grey2DSRV.get(),

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -833,6 +833,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.dispatchFlags              = 0, // #wip: dispatchFlags
 				.backBufferTransferFunction = backbufferTransferFunction,
 				.bReset                     = bResetOpticalFlowAccumulation,
+				.sceneColorTexture          = RT_finalSceneColor.get(),
+				.sceneColorSRV              = finalSceneColorSRV.get(),
 				.sceneDepthTexture          = RT_sceneDepth.get(),
 				.sceneDepthSRV              = sceneDepthSRV.get(),
 				.motionVectorTexture        = RT_velocityMap.get(),

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -798,10 +798,13 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		SCOPED_DRAW_EVENT(commandList, OpticalFlow);
 
+		const auto transferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
+		const bool bResetAccumulation = false;
+
 		OpticalFlowPassInput passInput{
 			.clearResourcePass  = clearResourcePass,
-			.transferFunction   = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance,
-			.bResetAccumulation = false,
+			.transferFunction   = transferFunction,
+			.bResetAccumulation = bResetAccumulation,
 			.containerSizeX     = unscaledRenderWidth,
 			.containerSizeY     = unscaledRenderHeight,
 			.lumaResolutionX    = (int32)sceneWidth,
@@ -810,6 +813,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.sceneColorSRV      = sceneColorSRV.get(),
 		};
 		opticalFlowPass->runOpticalFlow(commandList, swapchainIndex, passInput);
+
+		// #wip: frameGenPass here
 	}
 
 	// Set final color as render target.

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -70,6 +70,8 @@ private:
 	SceneUniform sceneUniformData;
 	SceneUniform prevSceneUniformData;
 
+	uint32 frameID = 0;
+
 	// ------------------------------------------------------------------------
 	// #todo-renderer: Temporarily manage render targets in the renderer.
 

--- a/projects/Cyseal/src/render/util/clear_resource_pass.cpp
+++ b/projects/Cyseal/src/render/util/clear_resource_pass.cpp
@@ -5,6 +5,15 @@
 // #todo-renderer: Support arbitrary number of requests.
 static const uint32 maxTextureClearDescriptorsPerFrame = 1024;
 
+struct ClearResourcePushConstants
+{
+	uint32 width;
+	uint32 height;
+	uint32 depth;
+	uint32 _pad0;
+	uint32 clearValue[4];
+};
+
 static EClearTextureDimension getClearTextureDim(const TextureCreateParams& desc)
 {
 	switch (desc.dimension)
@@ -53,7 +62,7 @@ void ClearResourcePass::initialize(RenderDevice* inRenderDevice)
 		std::wstring wFormat = L"TEXTURE_FORMAT_ENUM=" + std::to_wstring(format);
 
 		ShaderStage* shader = device->createShader(EShaderStage::COMPUTE_SHADER, debugName);
-		shader->declarePushConstants({ { "pushConstants", 4 } });
+		shader->declarePushConstants({ { "pushConstants", (int32)(sizeof(ClearResourcePushConstants) / 4) } });
 		shader->loadFromFile(filepath, entryName, { wDimension, wFormat });
 
 		pipeline = UniquePtr<ComputePipelineState>(device->createComputePipelineState(
@@ -83,10 +92,11 @@ void ClearResourcePass::prepareForFrame(uint32 swapchainIndex)
 	tracker = DescriptorIndexTracker{};
 }
 
-void ClearResourcePass::enqueueClear(Texture* texture, UnorderedAccessView* uav)
+void ClearResourcePass::enqueueClear(Texture* texture, UnorderedAccessView* uav, ClearValue clearValue)
 {
 	texturesToClear.push_back(texture);
 	UAVsToClear.push_back(uav);
+	clearValues.push_back(clearValue);
 }
 
 void ClearResourcePass::executeClears(RenderCommandList* commandList, uint32 swapchainIndex)
@@ -110,9 +120,27 @@ void ClearResourcePass::executeClears(RenderCommandList* commandList, uint32 swa
 		const auto& desc = texturesToClear[i]->getCreateParams();
 		const EClearTextureDimension dim = getClearTextureDim(desc);
 		const EClearTextureFormat format = getClearTextureFormat(desc);
+		const auto& clearValue = clearValues[i];
+
+		ClearResourcePushConstants pushConstants{};
+		pushConstants.width = desc.width;
+		pushConstants.height = desc.height;
+		pushConstants.depth = desc.depth;
+		if (clearValue.valueType == EClearValueType::Float)
+		{
+			std::memcpy(pushConstants.clearValue, clearValue.asFloat, sizeof(clearValue.asFloat));
+		}
+		else if (clearValue.valueType == EClearValueType::UInt)
+		{
+			std::memcpy(pushConstants.clearValue, clearValue.asUInt, sizeof(clearValue.asUInt));
+		}
+		else if (clearValue.valueType == EClearValueType::Int)
+		{
+			std::memcpy(pushConstants.clearValue, clearValue.asInt, sizeof(clearValue.asInt));
+		}
 
 		ShaderParameterTable SPT{};
-		SPT.pushConstants("pushConstants", { desc.width, desc.height, desc.depth, 0 });
+		SPT.pushConstants("pushConstants", &pushConstants, sizeof(pushConstants));
 		SPT.rwTexture("rwTexture", UAVsToClear[i]);
 
 		// #todo-renderer: Sort requests by dimension and format to minimize pipeline changes?
@@ -139,4 +167,8 @@ void ClearResourcePass::executeClears(RenderCommandList* commandList, uint32 swa
 			commandList->dispatchCompute(dispatchX, dispatchY, dispatchZ);
 		}
 	}
+
+	texturesToClear.clear();
+	UAVsToClear.clear();
+	clearValues.clear();
 }

--- a/projects/Cyseal/src/render/util/clear_resource_pass.h
+++ b/projects/Cyseal/src/render/util/clear_resource_pass.h
@@ -33,11 +33,44 @@ enum class EClearTextureFormat : uint32
 class ClearResourcePass final : public SceneRenderPass
 {
 public:
+	enum class EClearValueType { Float, UInt, Int };
+	struct ClearValue
+	{
+		EClearValueType valueType;
+		union
+		{
+			float asFloat[4];
+			uint32 asUInt[4];
+			int asInt[4];
+		};
+	};
+	static ClearValue floatClearValue(float x, float y, float z, float w)
+	{
+		return ClearValue{
+			.valueType = EClearValueType::Float,
+			.asFloat = { x, y, z, w },
+		};
+	}
+	static ClearValue uintClearValue(uint32 x, uint32 y, uint32 z, uint32 w)
+	{
+		return ClearValue{
+			.valueType = EClearValueType::UInt,
+			.asUInt = { x, y, z, w },
+		};
+	}
+	static ClearValue intClearValue(int32 x, int32 y, int32 z, int32 w)
+	{
+		return ClearValue{
+			.valueType = EClearValueType::Int,
+			.asInt = { x, y, z, w },
+		};
+	}
+
 	void initialize(RenderDevice* inRenderDevice);
 
 	void prepareForFrame(uint32 swapchainIndex);
 
-	void enqueueClear(Texture* texture, UnorderedAccessView* uav);
+	void enqueueClear(Texture* texture, UnorderedAccessView* uav, ClearValue clearValue);
 
 	/// CAUTION: No barrier after clear.
 	void executeClears(RenderCommandList* commandList, uint32 swapchainIndex);
@@ -51,4 +84,5 @@ private:
 
 	std::vector<Texture*> texturesToClear;
 	std::vector<UnorderedAccessView*> UAVsToClear;
+	std::vector<ClearValue> clearValues;
 };

--- a/projects/Cyseal/src/render/util/volatile_descriptor.cpp
+++ b/projects/Cyseal/src/render/util/volatile_descriptor.cpp
@@ -74,11 +74,11 @@ void VolatileDescriptorHelper::destroy()
 	uniformCBVs.clear();
 }
 
-void VolatileDescriptorHelper::resizeDescriptorHeap(uint32 swapchainIndex, uint32 maxDescriptors)
+DescriptorHeap* VolatileDescriptorHelper::resizeDescriptorHeap(uint32 swapchainIndex, uint32 maxDescriptors)
 {
 	if (maxDescriptors <= totalDescriptor[swapchainIndex])
 	{
-		return;
+		return descriptorHeap[swapchainIndex].get();
 	}
 	totalDescriptor[swapchainIndex] = maxDescriptors;
 
@@ -97,4 +97,6 @@ void VolatileDescriptorHelper::resizeDescriptorHeap(uint32 swapchainIndex, uint3
 	descriptorHeap[swapchainIndex]->setDebugName(debugName);
 
 	CYLOG(LogRHI, Log, L"Resize [%s]: %u descriptors", debugName, maxDescriptors);
+
+	return descriptorHeap[swapchainIndex].get();
 }

--- a/projects/Cyseal/src/render/util/volatile_descriptor.h
+++ b/projects/Cyseal/src/render/util/volatile_descriptor.h
@@ -24,7 +24,13 @@ public:
 	// It uses gRenderDevice and does not take RenderDevice parameter.
 	void initialize(const wchar_t* inPassName, uint32 swapchainCount, uint32 uniformTotalSize, uint32 uniformChunkCount = 1);
 	
-	void resizeDescriptorHeap(uint32 swapchainIndex, uint32 maxDescriptors);
+	/// <summary>
+	/// Recreate descriptor heap if current one is smaller than required.
+	/// </summary>
+	/// <param name="swapchainIndex"></param>
+	/// <param name="maxDescriptors"></param>
+	/// <returns>Current descriptor heap or recreated one.</returns>
+	DescriptorHeap* resizeDescriptorHeap(uint32 swapchainIndex, uint32 maxDescriptors);
 	
 	inline DescriptorHeap* getDescriptorHeap(uint32 swapchainIndex) const { return descriptorHeap.at(swapchainIndex); }
 	

--- a/projects/Cyseal/src/rhi/barrier_tracker.h
+++ b/projects/Cyseal/src/rhi/barrier_tracker.h
@@ -57,6 +57,28 @@ struct TextureBarrierAuto
 			texture, subresources, flags
 		};
 	}
+	static TextureBarrierAuto toShaderResource(
+		TextureKind* texture,
+		EBarrierSync syncAfter, // Usually EBarrierSync::COMPUTE_SHADING or EBarrierSync::PIXEL_SHADING
+		BarrierSubresourceRange subresources = BarrierSubresourceRange::allMips(),
+		ETextureBarrierFlags flags = ETextureBarrierFlags::None)
+	{
+		return TextureBarrierAuto{
+			syncAfter, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
+			texture, subresources, flags
+		};
+	}
+	static TextureBarrierAuto toUnorderedAccess(
+		TextureKind* texture,
+		EBarrierSync syncAfter = EBarrierSync::COMPUTE_SHADING, // Usually EBarrierSync::COMPUTE_SHADING
+		BarrierSubresourceRange subresources = BarrierSubresourceRange::allMips(),
+		ETextureBarrierFlags flags = ETextureBarrierFlags::None)
+	{
+		return TextureBarrierAuto{
+			syncAfter, EBarrierAccess::UNORDERED_ACCESS, EBarrierLayout::UnorderedAccess,
+			texture, subresources, flags
+		};
+	}
 };
 
 // Tracks resource states for issueing barriers in a render command list.

--- a/projects/Cyseal/src/rhi/dx12/d3d_into.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_into.h
@@ -250,6 +250,8 @@ namespace into_d3d
 			case EPixelFormat::R32_FLOAT_X8X24_TYPELESS : return DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
 			case EPixelFormat::R8G8B8A8_UNORM           : return DXGI_FORMAT_R8G8B8A8_UNORM;
 			case EPixelFormat::B8G8R8A8_UNORM           : return DXGI_FORMAT_B8G8R8A8_UNORM;
+			case EPixelFormat::R8G8_UNORM               : return DXGI_FORMAT_R8G8_UNORM;
+			case EPixelFormat::R8_UNORM                 : return DXGI_FORMAT_R8_UNORM;
 			case EPixelFormat::R32_FLOAT                : return DXGI_FORMAT_R32_FLOAT;
 			case EPixelFormat::R32G32_FLOAT             : return DXGI_FORMAT_R32G32_FLOAT;
 			case EPixelFormat::R32G32B32_FLOAT          : return DXGI_FORMAT_R32G32B32_FLOAT;

--- a/projects/Cyseal/src/rhi/dx12/d3d_into.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_into.h
@@ -262,6 +262,7 @@ namespace into_d3d
 			case EPixelFormat::R32_UINT                 : return DXGI_FORMAT_R32_UINT;
 			case EPixelFormat::R16_UINT                 : return DXGI_FORMAT_R16_UINT;
 			case EPixelFormat::R8_UINT                  : return DXGI_FORMAT_R8_UINT;
+			case EPixelFormat::R16G16_UINT              : return DXGI_FORMAT_R16G16_UINT;
 			case EPixelFormat::R32G32B32A32_UINT        : return DXGI_FORMAT_R32G32B32A32_UINT;
 			case EPixelFormat::R16G16_SINT              : return DXGI_FORMAT_R16G16_SINT;
 			case EPixelFormat::D24_UNORM_S8_UINT        : return DXGI_FORMAT_D24_UNORM_S8_UINT;

--- a/projects/Cyseal/src/rhi/dx12/d3d_shader.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_shader.cpp
@@ -70,7 +70,7 @@ static std::wstring getPDBDirectory()
 }
 #endif
 
-void D3DShaderStage::loadFromFile(const wchar_t* inFilename, const char* inEntryPoint, std::initializer_list<std::wstring> defines)
+void D3DShaderStage::loadFromFile(const wchar_t* inFilename, const char* inEntryPoint, const std::vector<std::wstring>& defines)
 {
 	IDxcUtils* utils = device->getDxcUtils();
 	IDxcCompiler3* compiler = device->getDxcCompiler();

--- a/projects/Cyseal/src/rhi/dx12/d3d_shader.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_shader.h
@@ -61,7 +61,7 @@ public:
 		, device(inDevice)
 	{}
 
-	virtual void loadFromFile(const wchar_t* inFilename, const char* entryPoint, std::initializer_list<std::wstring> defines) override;
+	virtual void loadFromFile(const wchar_t* inFilename, const char* entryPoint, const std::vector<std::wstring>& defines) override;
 
 	virtual const wchar_t* getEntryPointW() override { return wEntryPoint.c_str(); }
 	virtual const char* getEntryPointA() override { return aEntryPoint.c_str(); }

--- a/projects/Cyseal/src/rhi/pixel_format.h
+++ b/projects/Cyseal/src/rhi/pixel_format.h
@@ -38,6 +38,7 @@ enum class EPixelFormat : uint8
 	R32_UINT,
 	R16_UINT,
 	R8_UINT,
+	R16G16_UINT,
 	R32G32B32A32_UINT,
 
 	// SINT
@@ -53,15 +54,18 @@ inline uint32 getPixelFormatBytes(EPixelFormat format)
 	// #todo-rhi: Ignore depth formats?
 	switch (format)
 	{
+		// TYPELESS
 		case EPixelFormat::R32_TYPELESS             : return 4;
 		case EPixelFormat::R24G8_TYPELESS           : return 4;
 		case EPixelFormat::R24_UNORM_X8_TYPELESS    : return 4;
 		case EPixelFormat::R32G8X24_TYPELESS        : return 8;
 		case EPixelFormat::R32_FLOAT_X8X24_TYPELESS : return 8;
+		// UNORM
 		case EPixelFormat::R8G8B8A8_UNORM           : return 4;
 		case EPixelFormat::B8G8R8A8_UNORM           : return 4;
 		case EPixelFormat::R8G8_UNORM               : return 2;
 		case EPixelFormat::R8_UNORM                 : return 1;
+		// FLOAT
 		case EPixelFormat::R32_FLOAT                : return 4;
 		case EPixelFormat::R32G32_FLOAT             : return 8;
 		case EPixelFormat::R32G32B32_FLOAT          : return 12;
@@ -69,10 +73,13 @@ inline uint32 getPixelFormatBytes(EPixelFormat format)
 		case EPixelFormat::R16G16B16A16_FLOAT       : return 8;
 		case EPixelFormat::R16G16_FLOAT             : return 4;
 		case EPixelFormat::R16_FLOAT                : return 2;
+		// UINT
 		case EPixelFormat::R32_UINT                 : return 4;
 		case EPixelFormat::R16_UINT                 : return 2;
 		case EPixelFormat::R8_UINT                  : return 1;
+		case EPixelFormat::R16G16_UINT              : return 4;
 		case EPixelFormat::R32G32B32A32_UINT        : return 16;
+		// SINT
 		case EPixelFormat::R16G16_SINT              : return 4;
 		default: CHECK_NO_ENTRY();
 	}

--- a/projects/Cyseal/src/rhi/pixel_format.h
+++ b/projects/Cyseal/src/rhi/pixel_format.h
@@ -22,6 +22,8 @@ enum class EPixelFormat : uint8
 	// UNORM
 	R8G8B8A8_UNORM,
 	B8G8R8A8_UNORM,
+	R8G8_UNORM,
+	R8_UNORM,
 	
 	// FLOAT
 	R32_FLOAT,
@@ -58,6 +60,8 @@ inline uint32 getPixelFormatBytes(EPixelFormat format)
 		case EPixelFormat::R32_FLOAT_X8X24_TYPELESS : return 8;
 		case EPixelFormat::R8G8B8A8_UNORM           : return 4;
 		case EPixelFormat::B8G8R8A8_UNORM           : return 4;
+		case EPixelFormat::R8G8_UNORM               : return 2;
+		case EPixelFormat::R8_UNORM                 : return 1;
 		case EPixelFormat::R32_FLOAT                : return 4;
 		case EPixelFormat::R32G32_FLOAT             : return 8;
 		case EPixelFormat::R32G32B32_FLOAT          : return 12;

--- a/projects/Cyseal/src/rhi/shader.h
+++ b/projects/Cyseal/src/rhi/shader.h
@@ -46,7 +46,7 @@ public:
 
 	inline bool isPushConstantsDeclared() const { return bPushConstantsDeclared; }
 
-	virtual void loadFromFile(const wchar_t* inFilename, const char* entryPoint, std::initializer_list<std::wstring> defines = {}) = 0;
+	virtual void loadFromFile(const wchar_t* inFilename, const char* entryPoint, const std::vector<std::wstring>& defines = {}) = 0;
 
 	virtual const wchar_t* getEntryPointW() = 0;
 	virtual const char* getEntryPointA() = 0;

--- a/projects/Cyseal/src/rhi/shader_codegen.cpp
+++ b/projects/Cyseal/src/rhi/shader_codegen.cpp
@@ -30,7 +30,7 @@ std::string ShaderCodegen::hlslToSpirv(
 	const char* inFilename,
 	const char* inEntryPoint,
 	EShaderStage stageFlag,
-	std::initializer_list<std::wstring> defines)
+	const std::vector<std::wstring>& defines)
 {
 	std::wstring targetProfileW = getD3DShaderProfile(D3D_SHADER_MODEL_FOR_SPIRV, stageFlag);
 	std::string targetProfile;

--- a/projects/Cyseal/src/rhi/shader_codegen.h
+++ b/projects/Cyseal/src/rhi/shader_codegen.h
@@ -29,7 +29,7 @@ public:
 		const char* inFilename,
 		const char* inEntryPoint,
 		EShaderStage stageFlag,
-		std::initializer_list<std::wstring> defines);
+		const std::vector<std::wstring>& defines);
 
 private:
 	ShaderCodegen();

--- a/projects/Cyseal/src/rhi/vulkan/vk_into.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_into.h
@@ -514,6 +514,8 @@ namespace into_vk
 			case EPixelFormat::R32_FLOAT_X8X24_TYPELESS : CHECK_NO_ENTRY(); return VkFormat::VK_FORMAT_R64_SFLOAT;
 			case EPixelFormat::R8G8B8A8_UNORM           : return VkFormat::VK_FORMAT_R8G8B8A8_UNORM;
 			case EPixelFormat::B8G8R8A8_UNORM           : return VkFormat::VK_FORMAT_B8G8R8A8_UNORM;
+			case EPixelFormat::R8G8_UNORM               : return VkFormat::VK_FORMAT_R8G8_UNORM;
+			case EPixelFormat::R8_UNORM                 : return VkFormat::VK_FORMAT_R8_UNORM;
 			case EPixelFormat::R32_FLOAT                : return VkFormat::VK_FORMAT_R32_SFLOAT;
 			case EPixelFormat::R32G32_FLOAT             : return VkFormat::VK_FORMAT_R32G32_SFLOAT;
 			case EPixelFormat::R32G32B32_FLOAT          : return VkFormat::VK_FORMAT_R32G32B32_SFLOAT;

--- a/projects/Cyseal/src/rhi/vulkan/vk_into.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_into.h
@@ -526,6 +526,7 @@ namespace into_vk
 			case EPixelFormat::R32_UINT                 : return VkFormat::VK_FORMAT_R32_UINT;
 			case EPixelFormat::R16_UINT                 : return VkFormat::VK_FORMAT_R16_UINT;
 			case EPixelFormat::R8_UINT                  : return VkFormat::VK_FORMAT_R8_UINT;
+			case EPixelFormat::R16G16_UINT              : return VkFormat::VK_FORMAT_R16G16_UINT;
 			case EPixelFormat::R32G32B32A32_UINT        : return VkFormat::VK_FORMAT_R32G32B32A32_UINT;
 			case EPixelFormat::R16G16_SINT              : return VkFormat::VK_FORMAT_R16G16_SINT;
 			case EPixelFormat::D24_UNORM_S8_UINT        : return VkFormat::VK_FORMAT_D24_UNORM_S8_UINT;

--- a/projects/Cyseal/src/rhi/vulkan/vk_shader.cpp
+++ b/projects/Cyseal/src/rhi/vulkan/vk_shader.cpp
@@ -62,7 +62,7 @@ VulkanShaderStage::~VulkanShaderStage()
 	}
 }
 
-void VulkanShaderStage::loadFromFile(const wchar_t* inFilename, const char* inEntryPoint, std::initializer_list<std::wstring> defines)
+void VulkanShaderStage::loadFromFile(const wchar_t* inFilename, const char* inEntryPoint, const std::vector<std::wstring>& defines)
 {
 #if USE_DXC
 	loadFromFileByDxc(inFilename, inEntryPoint, defines);
@@ -79,7 +79,7 @@ void VulkanShaderStage::moveVkDescriptorSetLayouts(std::vector<VkDescriptorSetLa
 	vkDescriptorSetLayouts.clear();
 }
 
-void VulkanShaderStage::loadFromFileByGlslangValidator(const wchar_t* inFilename, const char* inEntryPoint, std::initializer_list<std::wstring> defines)
+void VulkanShaderStage::loadFromFileByGlslangValidator(const wchar_t* inFilename, const char* inEntryPoint, const std::vector<std::wstring>& defines)
 {
 	aEntryPoint = inEntryPoint;
 	str_to_wstr(inEntryPoint, wEntryPoint);
@@ -143,7 +143,7 @@ void VulkanShaderStage::loadFromFileByGlslangValidator(const wchar_t* inFilename
 	CHECK(ret == VK_SUCCESS);
 }
 
-void VulkanShaderStage::loadFromFileByDxc(const wchar_t* inFilename, const char* inEntryPoint, std::initializer_list<std::wstring> defines)
+void VulkanShaderStage::loadFromFileByDxc(const wchar_t* inFilename, const char* inEntryPoint, const std::vector<std::wstring>& defines)
 {
 	aEntryPoint = inEntryPoint;
 	str_to_wstr(inEntryPoint, wEntryPoint);

--- a/projects/Cyseal/src/rhi/vulkan/vk_shader.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_shader.h
@@ -39,7 +39,7 @@ public:
 	VulkanShaderStage(VulkanDevice* inDevice, EShaderStage inStageFlag, const char* inDebugName);
 	~VulkanShaderStage();
 
-	virtual void loadFromFile(const wchar_t* inFilename, const char* inEntryPoint, std::initializer_list<std::wstring> defines) override;
+	virtual void loadFromFile(const wchar_t* inFilename, const char* inEntryPoint, const std::vector<std::wstring>& defines) override;
 
 	virtual const wchar_t* getEntryPointW() override { return wEntryPoint.c_str(); }
 	virtual const char* getEntryPointA() override { return aEntryPoint.c_str(); }
@@ -52,8 +52,8 @@ public:
 	void moveVkDescriptorSetLayouts(std::vector<VkDescriptorSetLayout>& target);
 
 private:
-	void loadFromFileByGlslangValidator(const wchar_t* inFilename, const char* inEntryPoint, std::initializer_list<std::wstring> defines);
-	void loadFromFileByDxc(const wchar_t* inFilename, const char* inEntryPoint, std::initializer_list<std::wstring> defines);
+	void loadFromFileByGlslangValidator(const wchar_t* inFilename, const char* inEntryPoint, const std::vector<std::wstring>& defines);
+	void loadFromFileByDxc(const wchar_t* inFilename, const char* inEntryPoint, const std::vector<std::wstring>& defines);
 
 	void readShaderReflection(const void* spirv_code, size_t spirv_nbytes);
 	void addToShaderParameterTable(const VulkanShaderParameter& inParam);

--- a/projects/Cyseal/src/world/camera.h
+++ b/projects/Cyseal/src/world/camera.h
@@ -47,7 +47,10 @@ public:
 	void setZNear(float zNear);
 	void setZFar(float zFar);
 
+	inline float getFovYInRadians() const { return fovY_radians; }
 	inline float getAspectRatio() const { return aspectRatioWH; }
+	inline float getZNear() const { return zNear; }
+	inline float getZFar() const { return zFar; }
 
 	// Set properties of view matrix at once.
 	void lookAt(const vec3& origin, const vec3& target, const vec3& up);

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -289,7 +289,6 @@ void TestApplication::onTick(float deltaSeconds)
 			}
 
 			ImGui::SeparatorText("Depth and Visibility");
-
 			ImGui::Checkbox("Depth Prepass", &appState.rendererOptions.bEnableDepthPrepass);
 			if (!appState.rendererOptions.bEnableDepthPrepass)
 			{
@@ -297,6 +296,17 @@ void TestApplication::onTick(float deltaSeconds)
 			}
 			ImGui::Checkbox("Depth Prepass - Visibility Buffer", &appState.rendererOptions.bEnableVisibilityBuffer);
 			if (!appState.rendererOptions.bEnableDepthPrepass)
+			{
+				ImGui::EndDisabled();
+			}
+
+			ImGui::SeparatorText("Frame Generation");
+			if (appState.rendererOptions.pathTracing != EPathTracingMode::Disabled)
+			{
+				ImGui::BeginDisabled();
+			}
+			ImGui::Checkbox("Generate frames", &appState.rendererOptions.bGenerateFrame);
+			if (appState.rendererOptions.pathTracing != EPathTracingMode::Disabled)
 			{
 				ImGui::EndDisabled();
 			}

--- a/shaders/buffer_visualization.hlsl
+++ b/shaders/buffer_visualization.hlsl
@@ -181,6 +181,8 @@ uint2 LoadOpticalFlowFieldMv(int2 iPxSample)
 	// Also I can't find how these resources are actually bound. I searched for the macros in the entire SDK folder but nothing pops up?
 	//
 #if 0
+    // #wip: ffx_frameinterpolation generates its own OPTICAL_FLOW_MOTION_VECTOR_FIELD_X/Y.
+    // Then do I not need the optical flow vector texture from the optical flow module???
 	uint packedX = r_optical_flow_motion_vector_field_x[iPxSample];
 	uint packedY = r_optical_flow_motion_vector_field_y[iPxSample];
 	return uint2(packedX, packedY);

--- a/shaders/buffer_visualization.hlsl
+++ b/shaders/buffer_visualization.hlsl
@@ -19,6 +19,7 @@
 #define MODE_VIS_ROUGHNESS       15
 #define MODE_VIS_METAL_MASK      16
 #define MODE_OPTICAL_FLOW_VECTOR 17
+#define MODE_INTERPOLATED_FRAME  18
 
 // ------------------------------------------------------------------------
 // Resource bindings
@@ -48,6 +49,7 @@ Texture2D                     barycentricCoord  : register(t8, space0);
 Texture2D<GBUFFER0_DATATYPE>  visGBuffer0       : register(t9, space0);
 Texture2D<GBUFFER1_DATATYPE>  visGBuffer1       : register(t10, space0);
 Texture2D<int2>               opticalFlowVector : register(t11, space0);
+Texture2D                     interpolatedFrame : register(t12, space0);
 
 SamplerState                  textureSampler    : register(s0, space0);
 
@@ -181,8 +183,8 @@ uint2 LoadOpticalFlowFieldMv(int2 iPxSample)
 	// Also I can't find how these resources are actually bound. I searched for the macros in the entire SDK folder but nothing pops up?
 	//
 #if 0
-    // #wip: ffx_frameinterpolation generates its own OPTICAL_FLOW_MOTION_VECTOR_FIELD_X/Y.
-    // Then do I not need the optical flow vector texture from the optical flow module???
+	// #wip: ffx_frameinterpolation generates its own OPTICAL_FLOW_MOTION_VECTOR_FIELD_X/Y.
+	// Then do I not need the optical flow vector texture from the optical flow module???
 	uint packedX = r_optical_flow_motion_vector_field_x[iPxSample];
 	uint packedY = r_optical_flow_motion_vector_field_y[iPxSample];
 	return uint2(packedX, packedY);
@@ -408,6 +410,10 @@ float4 mainPS(Interpolants interpolants) : SV_TARGET
 		
 		color.rgb = getMotionVectorColor(ofMv.fMotionVector);
 #endif
+	}
+	else if (modeEnum == MODE_INTERPOLATED_FRAME)
+	{
+		color.rgb = interpolatedFrame.SampleLevel(textureSampler, scaledUV, 0.0).rgb;
 	}
 
 	// Gamma correction

--- a/shaders/buffer_visualization.hlsl
+++ b/shaders/buffer_visualization.hlsl
@@ -64,202 +64,199 @@ uint2 unpackOpticalFlowVectorTextureSize()
 // ------------------------------------------------------------------------
 // From ffx_frameinterpolation_common.h
 
-// #wip: Cleanup.
-
-const uint MOTION_VECTOR_FIELD_ENTRY_BIT_COUNT = 32;
-
-// Make sure all bit counts add up to MOTION_VECTOR_FIELD_ENTRY_BIT_COUNT
-const uint MOTION_VECTOR_FIELD_VECTOR_COEFFICIENT_BIT_COUNT = 16;
-const uint MOTION_VECTOR_FIELD_PRIORITY_LOW_BIT_COUNT = 5;
-const uint MOTION_VECTOR_FIELD_PRIORITY_HIGH_BIT_COUNT = 10;
-const uint MOTION_VECTOR_PRIMARY_VECTOR_INDICATION_BIT_COUNT = 1;
-
-const uint MOTION_VECTOR_FIELD_PRIMARY_VECTOR_INDICATION_BIT = (1U << (MOTION_VECTOR_FIELD_ENTRY_BIT_COUNT - 1));
-
-const uint PRIORITY_LOW_MAX = (1U << MOTION_VECTOR_FIELD_PRIORITY_LOW_BIT_COUNT) - 1;
-const uint PRIORITY_HIGH_MAX = (1U << MOTION_VECTOR_FIELD_PRIORITY_HIGH_BIT_COUNT) - 1;
-
-const uint PRIORITY_LOW_OFFSET = MOTION_VECTOR_FIELD_VECTOR_COEFFICIENT_BIT_COUNT;
-const uint PRIORITY_HIGH_OFFSET = PRIORITY_LOW_OFFSET + MOTION_VECTOR_FIELD_PRIORITY_LOW_BIT_COUNT;
-const uint PRIMARY_VECTOR_INDICATION_OFFSET = PRIORITY_HIGH_OFFSET + MOTION_VECTOR_FIELD_PRIORITY_HIGH_BIT_COUNT;
-
-struct VectorFieldEntry
+namespace opticalFlow
 {
-	float2 fMotionVector;
-	float  uHighPriorityFactor;
-	float  uLowPriorityFactor;
-	bool   bValid;
-	bool   bPrimary;
-	bool   bSecondary;
-	bool   bInPainted;
-	float  fVelocity;
-	bool   bNegOutside;
-	bool   bPosOutside;
-};
+	const uint MOTION_VECTOR_FIELD_ENTRY_BIT_COUNT               = 32;
+	// Make sure all bit counts add up to MOTION_VECTOR_FIELD_ENTRY_BIT_COUNT
+	const uint MOTION_VECTOR_FIELD_VECTOR_COEFFICIENT_BIT_COUNT  = 16;
+	const uint MOTION_VECTOR_FIELD_PRIORITY_LOW_BIT_COUNT        = 5;
+	const uint MOTION_VECTOR_FIELD_PRIORITY_HIGH_BIT_COUNT       = 10;
+	const uint MOTION_VECTOR_PRIMARY_VECTOR_INDICATION_BIT_COUNT = 1;
+	const uint MOTION_VECTOR_FIELD_PRIMARY_VECTOR_INDICATION_BIT = (1U << (MOTION_VECTOR_FIELD_ENTRY_BIT_COUNT - 1));
+	const uint PRIORITY_LOW_MAX                                  = (1U << MOTION_VECTOR_FIELD_PRIORITY_LOW_BIT_COUNT) - 1;
+	const uint PRIORITY_HIGH_MAX                                 = (1U << MOTION_VECTOR_FIELD_PRIORITY_HIGH_BIT_COUNT) - 1;
+	const uint PRIORITY_LOW_OFFSET                               = MOTION_VECTOR_FIELD_VECTOR_COEFFICIENT_BIT_COUNT;
+	const uint PRIORITY_HIGH_OFFSET                              = PRIORITY_LOW_OFFSET + MOTION_VECTOR_FIELD_PRIORITY_LOW_BIT_COUNT;
+	const uint PRIMARY_VECTOR_INDICATION_OFFSET                  = PRIORITY_HIGH_OFFSET + MOTION_VECTOR_FIELD_PRIORITY_HIGH_BIT_COUNT;
 
-struct BilinearSamplingData
-{
-	int2 iOffsets[4];
-	float fWeights[4];
-	int2 iBasePos;
-};
+	struct VectorFieldEntry
+	{
+		float2 fMotionVector;
+		float  uHighPriorityFactor;
+		float  uLowPriorityFactor;
+		bool   bValid;
+		bool   bPrimary;
+		bool   bSecondary;
+		bool   bInPainted;
+		float  fVelocity;
+		bool   bNegOutside;
+		bool   bPosOutside;
+	};
 
-VectorFieldEntry NewVectorFieldEntry()
-{
-	VectorFieldEntry vfe;
-	vfe.fMotionVector = float2(0.0, 0.0);
-	vfe.uHighPriorityFactor = 0.0;
-	vfe.uLowPriorityFactor = 0.0;
-	vfe.bValid = false;
-	vfe.bPrimary = false;
-	vfe.bSecondary = false;
-	vfe.bInPainted = false;
-	vfe.fVelocity = 0.0;
-	vfe.bNegOutside = false;
-	vfe.bPosOutside = false;
-	return vfe;
-}
+	struct BilinearSamplingData
+	{
+		int2  iOffsets[4];
+		float fWeights[4];
+		int2  iBasePos;
+	};
 
-BilinearSamplingData GetBilinearSamplingData(float2 fUv, int2 iSize)
-{
-	BilinearSamplingData data;
+	VectorFieldEntry NewVectorFieldEntry()
+	{
+		VectorFieldEntry vfe;
+		vfe.fMotionVector = float2(0.0, 0.0);
+		vfe.uHighPriorityFactor = 0.0;
+		vfe.uLowPriorityFactor = 0.0;
+		vfe.bValid = false;
+		vfe.bPrimary = false;
+		vfe.bSecondary = false;
+		vfe.bInPainted = false;
+		vfe.fVelocity = 0.0;
+		vfe.bNegOutside = false;
+		vfe.bPosOutside = false;
+		return vfe;
+	}
 
-	float2 fPxSample = (fUv * iSize) - float2(0.5f, 0.5f);
-	data.iBasePos = int2(floor(fPxSample));
-	float2 fPxFrac = frac(fPxSample);
+	BilinearSamplingData GetBilinearSamplingData(float2 fUv, int2 iSize)
+	{
+		BilinearSamplingData data;
 
-	data.iOffsets[0] = int2(0, 0);
-	data.iOffsets[1] = int2(1, 0);
-	data.iOffsets[2] = int2(0, 1);
-	data.iOffsets[3] = int2(1, 1);
+		float2 fPxSample = (fUv * iSize) - float2(0.5f, 0.5f);
+		data.iBasePos = int2(floor(fPxSample));
+		float2 fPxFrac = frac(fPxSample);
 
-	data.fWeights[0] = (1 - fPxFrac.x) * (1 - fPxFrac.y);
-	data.fWeights[1] = (fPxFrac.x) * (1 - fPxFrac.y);
-	data.fWeights[2] = (1 - fPxFrac.x) * (fPxFrac.y);
-	data.fWeights[3] = (fPxFrac.x) * (fPxFrac.y);
+		data.iOffsets[0] = int2(0, 0);
+		data.iOffsets[1] = int2(1, 0);
+		data.iOffsets[2] = int2(0, 1);
+		data.iOffsets[3] = int2(1, 1);
 
-	return data;
-}
+		data.fWeights[0] = (1 - fPxFrac.x) * (1 - fPxFrac.y);
+		data.fWeights[1] = (fPxFrac.x) * (1 - fPxFrac.y);
+		data.fWeights[2] = (1 - fPxFrac.x) * (fPxFrac.y);
+		data.fWeights[3] = (fPxFrac.x) * (fPxFrac.y);
 
-int2 DisplaySize()
-{
-	return int2(pushConstants.width, pushConstants.height);
-}
+		return data;
+	}
 
-float4 getMotionVectorColor(float2 fMotionVector)
-{
-	return float4(0.5f + fMotionVector * DisplaySize() * 0.1f, 0.5f, 1.0f);
-}
+	int2 DisplaySize()
+	{
+		return int2(pushConstants.width, pushConstants.height);
+	}
 
-int2 GetOpticalFlowSize()
-{
-	const float2 opticalFlowScale = 1.0 / float2(DisplaySize());
-	const int opticalFlowBlockSize = 8;
+	float4 getMotionVectorColor(float2 fMotionVector)
+	{
+		return float4(0.5f + fMotionVector * DisplaySize() * 0.1f, 0.5f, 1.0f);
+	}
+
+	int2 GetOpticalFlowSize()
+	{
+		const float2 opticalFlowScale = 1.0 / float2(DisplaySize());
+		const int opticalFlowBlockSize = 8;
 	
-	int2 iOpticalFlowSize = (1.0f / opticalFlowScale) / float2(opticalFlowBlockSize.xx);
+		int2 iOpticalFlowSize = (1.0f / opticalFlowScale) / float2(opticalFlowBlockSize.xx);
 
-	return iOpticalFlowSize;
-}
+		return iOpticalFlowSize;
+	}
 
-int2 GetOpticalFlowSize2()
-{
-	return GetOpticalFlowSize() * 1;
-}
+	int2 GetOpticalFlowSize2()
+	{
+		return GetOpticalFlowSize() * 1;
+	}
 
-bool IsOnScreen(int2 pos, int2 size)
-{
-	return all((uint2(pos) < uint2(size)));
-}
+	bool IsOnScreen(int2 pos, int2 size)
+	{
+		return all((uint2(pos) < uint2(size)));
+	}
 
-bool IsUvInside(float2 fUv)
-{
-	return (fUv.x > 0.0f && fUv.x < 1.0f) && (fUv.y > 0.0f && fUv.y < 1.0f);
-}
+	bool IsUvInside(float2 fUv)
+	{
+		return (fUv.x > 0.0f && fUv.x < 1.0f) && (fUv.y > 0.0f && fUv.y < 1.0f);
+	}
 
-uint2 LoadOpticalFlowFieldMv(int2 iPxSample)
-{
+	uint2 LoadOpticalFlowFieldMv(int2 iPxSample)
+	{
 	// optical flow pass generates a single int2 texture.
 	// frame gen pass takes it and generates two uint textures, each for x and y.
 #if 1
-	uint packedX = opticalFlowVectorX[iPxSample];
-	uint packedY = opticalFlowVectorY[iPxSample];
-	return uint2(packedX, packedY);
+		uint packedX = opticalFlowVectorX[iPxSample];
+		uint packedY = opticalFlowVectorY[iPxSample];
+		return uint2(packedX, packedY);
 #else
 	uint2 packedXY = opticalFlowVector.Load(int3(iPxSample, 0)).xy;
 	return packedXY;
 #endif
-}
+	}
 
-float2 ffxUnpackF32(uint a)
-{
-	return f16tof32(uint2(a & 0xFFFF, a >> 16));
-}
+	float2 ffxUnpackF32(uint a)
+	{
+		return f16tof32(uint2(a & 0xFFFF, a >> 16));
+	}
 
-bool PackedVectorFieldEntryIsPrimary(uint packedEntry)
-{
-	return ((packedEntry & MOTION_VECTOR_FIELD_PRIMARY_VECTOR_INDICATION_BIT) != 0);
-}
+	bool PackedVectorFieldEntryIsPrimary(uint packedEntry)
+	{
+		return ((packedEntry & MOTION_VECTOR_FIELD_PRIMARY_VECTOR_INDICATION_BIT) != 0);
+	}
 
-void UnpackVectorFieldEntries(uint2 packed, out VectorFieldEntry vfElement)
-{
-	vfElement.uHighPriorityFactor = float((packed.x >> PRIORITY_HIGH_OFFSET) & PRIORITY_HIGH_MAX) / PRIORITY_HIGH_MAX;
-	vfElement.uLowPriorityFactor = float((packed.x >> PRIORITY_LOW_OFFSET) & PRIORITY_LOW_MAX) / PRIORITY_LOW_MAX;
+	void UnpackVectorFieldEntries(uint2 packed, out VectorFieldEntry vfElement)
+	{
+		vfElement.uHighPriorityFactor = float((packed.x >> PRIORITY_HIGH_OFFSET) & PRIORITY_HIGH_MAX) / PRIORITY_HIGH_MAX;
+		vfElement.uLowPriorityFactor = float((packed.x >> PRIORITY_LOW_OFFSET) & PRIORITY_LOW_MAX) / PRIORITY_LOW_MAX;
 
-	vfElement.bPrimary = PackedVectorFieldEntryIsPrimary(packed.x);
-	vfElement.bValid = (vfElement.uHighPriorityFactor > 0.0f);
-	vfElement.bSecondary = vfElement.bValid && !vfElement.bPrimary;
+		vfElement.bPrimary = PackedVectorFieldEntryIsPrimary(packed.x);
+		vfElement.bValid = (vfElement.uHighPriorityFactor > 0.0f);
+		vfElement.bSecondary = vfElement.bValid && !vfElement.bPrimary;
 
 	// Reverse priority factor for secondary vectors
-	if (vfElement.bSecondary)
-	{
-		vfElement.uHighPriorityFactor = 1.0f - vfElement.uHighPriorityFactor;
-	}
-
-	vfElement.fMotionVector.x = ffxUnpackF32(packed.x).x;
-	vfElement.fMotionVector.y = ffxUnpackF32(packed.y).x;
-	vfElement.bInPainted = false;
-}
-
-void SampleOpticalFlowMotionVectorField(float2 fUv, out VectorFieldEntry vfElement)
-{
-	const float scaleFactor = 1.0f;
-
-	BilinearSamplingData bilinearInfo = GetBilinearSamplingData(fUv, int2(GetOpticalFlowSize2() * scaleFactor));
-
-	vfElement = NewVectorFieldEntry();
-
-	float fWeightSum = 0.0f;
-	for (int iSampleIndex = 0; iSampleIndex < 4; iSampleIndex++)
-	{
-		const int2 iOffset = bilinearInfo.iOffsets[iSampleIndex];
-		const int2 iSamplePos = bilinearInfo.iBasePos + iOffset;
-
-		if (IsOnScreen(iSamplePos, int2(GetOpticalFlowSize2() * scaleFactor)))
+		if (vfElement.bSecondary)
 		{
-			const float fWeight = bilinearInfo.fWeights[iSampleIndex];
-
-			VectorFieldEntry fOfVectorSample = NewVectorFieldEntry();
-			int2 packedOpticalFlowMv = int2(LoadOpticalFlowFieldMv(iSamplePos));
-			UnpackVectorFieldEntries(packedOpticalFlowMv, fOfVectorSample);
-
-			vfElement.fMotionVector += fOfVectorSample.fMotionVector * fWeight;
-			vfElement.uHighPriorityFactor += fOfVectorSample.uHighPriorityFactor * fWeight;
-			vfElement.uLowPriorityFactor += fOfVectorSample.uLowPriorityFactor * fWeight;
-
-			fWeightSum += fWeight;
+			vfElement.uHighPriorityFactor = 1.0f - vfElement.uHighPriorityFactor;
 		}
+
+		vfElement.fMotionVector.x = ffxUnpackF32(packed.x).x;
+		vfElement.fMotionVector.y = ffxUnpackF32(packed.y).x;
+		vfElement.bInPainted = false;
 	}
 
-	if (fWeightSum > 0.0f)
+	void SampleOpticalFlowMotionVectorField(float2 fUv, out VectorFieldEntry vfElement)
 	{
-		vfElement.fMotionVector /= fWeightSum;
-		vfElement.uHighPriorityFactor /= fWeightSum;
-		vfElement.uLowPriorityFactor /= fWeightSum;
-	}
+		const float scaleFactor = 1.0f;
 
-	vfElement.bNegOutside = !IsUvInside(fUv - vfElement.fMotionVector);
-	vfElement.bPosOutside = !IsUvInside(fUv + vfElement.fMotionVector);
-	vfElement.fVelocity = length(vfElement.fMotionVector);
+		BilinearSamplingData bilinearInfo = GetBilinearSamplingData(fUv, int2(GetOpticalFlowSize2() * scaleFactor));
+
+		vfElement = NewVectorFieldEntry();
+
+		float fWeightSum = 0.0f;
+		for (int iSampleIndex = 0; iSampleIndex < 4; iSampleIndex++)
+		{
+			const int2 iOffset = bilinearInfo.iOffsets[iSampleIndex];
+			const int2 iSamplePos = bilinearInfo.iBasePos + iOffset;
+
+			if (IsOnScreen(iSamplePos, int2(GetOpticalFlowSize2() * scaleFactor)))
+			{
+				const float fWeight = bilinearInfo.fWeights[iSampleIndex];
+
+				VectorFieldEntry fOfVectorSample = NewVectorFieldEntry();
+				int2 packedOpticalFlowMv = int2(LoadOpticalFlowFieldMv(iSamplePos));
+				UnpackVectorFieldEntries(packedOpticalFlowMv, fOfVectorSample);
+
+				vfElement.fMotionVector += fOfVectorSample.fMotionVector * fWeight;
+				vfElement.uHighPriorityFactor += fOfVectorSample.uHighPriorityFactor * fWeight;
+				vfElement.uLowPriorityFactor += fOfVectorSample.uLowPriorityFactor * fWeight;
+
+				fWeightSum += fWeight;
+			}
+		}
+
+		if (fWeightSum > 0.0f)
+		{
+			vfElement.fMotionVector /= fWeightSum;
+			vfElement.uHighPriorityFactor /= fWeightSum;
+			vfElement.uLowPriorityFactor /= fWeightSum;
+		}
+
+		vfElement.bNegOutside = !IsUvInside(fUv - vfElement.fMotionVector);
+		vfElement.bPosOutside = !IsUvInside(fUv + vfElement.fMotionVector);
+		vfElement.fVelocity = length(vfElement.fMotionVector);
+	}
 }
 
 // ------------------------------------------------------------------------
@@ -398,10 +395,10 @@ float4 mainPS(Interpolants interpolants) : SV_TARGET
 		color.g = saturate(0.5 + 0.5 * (float(flow.g) / 4.0));
 		color.b = 0;
 #else
-		VectorFieldEntry ofMv;
-		SampleOpticalFlowMotionVectorField(scaledUV, ofMv);
+		opticalFlow::VectorFieldEntry ofMv;
+		opticalFlow::SampleOpticalFlowMotionVectorField(scaledUV, ofMv);
 		
-		color.rgb = getMotionVectorColor(ofMv.fMotionVector);
+		color.rgb = opticalFlow::getMotionVectorColor(ofMv.fMotionVector);
 #endif
 	}
 	else if (modeEnum == MODE_INTERPOLATED_FRAME || modeEnum == MODE_FRAMEGEN_DEBUG_VIEW)

--- a/shaders/buffer_visualization.hlsl
+++ b/shaders/buffer_visualization.hlsl
@@ -33,25 +33,26 @@ struct PushConstants
 };
 
 [[vk::push_constant]]
-ConstantBuffer<PushConstants> pushConstants     : register(b0, space0);
+ConstantBuffer<PushConstants> pushConstants      : register(b0, space0);
 
 ConstantBuffer<SceneUniform>  sceneUniform;
 
-Texture2D<GBUFFER0_DATATYPE>  gbuffer0          : register(t0, space0);
-Texture2D<GBUFFER1_DATATYPE>  gbuffer1          : register(t1, space0);
-Texture2D                     sceneColor        : register(t2, space0);
-Texture2D                     shadowMask        : register(t3, space0);
-Texture2D                     indirectDiffuse   : register(t4, space0);
-Texture2D                     indirectSpecular  : register(t5, space0);
-Texture2D                     velocityMap       : register(t6, space0);
-Texture2D<uint>               visibilityBuffer  : register(t7, space0);
-Texture2D                     barycentricCoord  : register(t8, space0);
-Texture2D<GBUFFER0_DATATYPE>  visGBuffer0       : register(t9, space0);
-Texture2D<GBUFFER1_DATATYPE>  visGBuffer1       : register(t10, space0);
-Texture2D<int2>               opticalFlowVector : register(t11, space0);
-Texture2D                     interpolatedFrame : register(t12, space0);
+Texture2D<GBUFFER0_DATATYPE>  gbuffer0           : register(t0, space0);
+Texture2D<GBUFFER1_DATATYPE>  gbuffer1           : register(t1, space0);
+Texture2D                     sceneColor         : register(t2, space0);
+Texture2D                     shadowMask         : register(t3, space0);
+Texture2D                     indirectDiffuse    : register(t4, space0);
+Texture2D                     indirectSpecular   : register(t5, space0);
+Texture2D                     velocityMap        : register(t6, space0);
+Texture2D<uint>               visibilityBuffer   : register(t7, space0);
+Texture2D                     barycentricCoord   : register(t8, space0);
+Texture2D<GBUFFER0_DATATYPE>  visGBuffer0        : register(t9, space0);
+Texture2D<GBUFFER1_DATATYPE>  visGBuffer1        : register(t10, space0);
+Texture2D<uint>               opticalFlowVectorX : register(t11, space0);
+Texture2D<uint>               opticalFlowVectorY : register(t12, space0);
+Texture2D                     interpolatedFrame  : register(t13, space0);
 
-SamplerState                  textureSampler    : register(s0, space0);
+SamplerState                  textureSampler     : register(s0, space0);
 
 uint2 unpackOpticalFlowVectorTextureSize()
 {
@@ -62,7 +63,7 @@ uint2 unpackOpticalFlowVectorTextureSize()
 // ------------------------------------------------------------------------
 // From ffx_frameinterpolation_common.h
 
-// #todo-fsr3-fg: Keep here until integrating frame interpolation.
+// #wip: Cleanup.
 
 const uint MOTION_VECTOR_FIELD_ENTRY_BIT_COUNT = 32;
 
@@ -176,21 +177,13 @@ bool IsUvInside(float2 fUv)
 
 uint2 LoadOpticalFlowFieldMv(int2 iPxSample)
 {
-	// FidelityFX SDK uses the following macros in the frame interpolation module:
-	// - FFX_FRAMEINTERPOLATION_RESOURCE_IDENTIFIER_OPTICAL_FLOW_MOTION_VECTOR_FIELD_X
-	// - FFX_FRAMEINTERPOLATION_RESOURCE_IDENTIFIER_OPTICAL_FLOW_MOTION_VECTOR_FIELD_Y
-	// But in optical flow doc the output is a single texture of R16G16 format.
-	// Also I can't find how these resources are actually bound. I searched for the macros in the entire SDK folder but nothing pops up?
-	//
-#if 0
-	// #wip: ffx_frameinterpolation generates its own OPTICAL_FLOW_MOTION_VECTOR_FIELD_X/Y.
-	// Then do I not need the optical flow vector texture from the optical flow module???
-	uint packedX = r_optical_flow_motion_vector_field_x[iPxSample];
-	uint packedY = r_optical_flow_motion_vector_field_y[iPxSample];
+	// optical flow pass generates a single int2 texture.
+	// frame gen pass takes it and generates two uint textures, each for x and y.
+#if 1
+	uint packedX = opticalFlowVectorX[iPxSample];
+	uint packedY = opticalFlowVectorY[iPxSample];
 	return uint2(packedX, packedY);
 #else
-	// #todo-fsr3-fg: Correct format of optical flow vector?
-	// Optical flow vector is a single texture of r16g16_int but this visualization logic requires two uint32 textures?
 	uint2 packedXY = opticalFlowVector.Load(int3(iPxSample, 0)).xy;
 	return packedXY;
 #endif
@@ -395,11 +388,10 @@ float4 mainPS(Interpolants interpolants) : SV_TARGET
 	}
 	else if (modeEnum == MODE_OPTICAL_FLOW_VECTOR)
 	{
+#if 0
 		uint2 ofvSize = unpackOpticalFlowVectorTextureSize();
 		int2 coord = int2(scaledUV * float2(ofvSize.x, ofvSize.y));
-		
-		// #todo-fsr3-fg: Use my crude visualization for now. See the comment in LoadOpticalFlowFieldMv().
-#if 1
+
 		int2 flow = opticalFlowVector.Load(int3(coord, 0)).rg;
 		color.r = saturate(0.5 + 0.5 * (float(flow.r) / 4.0));
 		color.g = saturate(0.5 + 0.5 * (float(flow.g) / 4.0));

--- a/shaders/buffer_visualization.hlsl
+++ b/shaders/buffer_visualization.hlsl
@@ -20,6 +20,7 @@
 #define MODE_VIS_METAL_MASK      16
 #define MODE_OPTICAL_FLOW_VECTOR 17
 #define MODE_INTERPOLATED_FRAME  18
+#define MODE_FRAMEGEN_DEBUG_VIEW 19
 
 // ------------------------------------------------------------------------
 // Resource bindings
@@ -403,7 +404,7 @@ float4 mainPS(Interpolants interpolants) : SV_TARGET
 		color.rgb = getMotionVectorColor(ofMv.fMotionVector);
 #endif
 	}
-	else if (modeEnum == MODE_INTERPOLATED_FRAME)
+	else if (modeEnum == MODE_INTERPOLATED_FRAME || modeEnum == MODE_FRAMEGEN_DEBUG_VIEW)
 	{
 		color.rgb = interpolatedFrame.SampleLevel(textureSampler, scaledUV, 0.0).rgb;
 	}

--- a/shaders/buffer_visualization.hlsl
+++ b/shaders/buffer_visualization.hlsl
@@ -29,7 +29,7 @@ struct PushConstants
 	uint modeEnum;
 	uint width;
 	uint height;
-	uint opticalFlowVectorPackedSize; // high 16-bit: width, low 16-bit: height
+	uint opticalFlowVectorPackedSize; // low 16-bit: width, high 16-bit: height
 };
 
 [[vk::push_constant]]

--- a/shaders/util/clear_texture.hlsl
+++ b/shaders/util/clear_texture.hlsl
@@ -28,22 +28,31 @@
 	#error TEXTURE_FORMAT_ENUM is not defined
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_FLOAT4
 	#define TEXTURE_FORMAT float4
+	#define CLEAR_VALUE_TYPE float4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_FLOAT2
 	#define TEXTURE_FORMAT float2
+	#define CLEAR_VALUE_TYPE float4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_FLOAT1
 	#define TEXTURE_FORMAT float1
+	#define CLEAR_VALUE_TYPE float4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_UINT4
 	#define TEXTURE_FORMAT uint4
+	#define CLEAR_VALUE_TYPE uint4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_UINT2
 	#define TEXTURE_FORMAT uint2
+	#define CLEAR_VALUE_TYPE uint4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_UINT1
 	#define TEXTURE_FORMAT uint1
+	#define CLEAR_VALUE_TYPE uint4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_INT4
 	#define TEXTURE_FORMAT int4
+	#define CLEAR_VALUE_TYPE int4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_INT2
 	#define TEXTURE_FORMAT int2
+	#define CLEAR_VALUE_TYPE int4
 #elif TEXTURE_FORMAT_ENUM == TEXTURE_FORMAT_INT1
 	#define TEXTURE_FORMAT int1
+	#define CLEAR_VALUE_TYPE int4
 #else
 	#error TEXTURE_FORMAT_ENUM is defined but the value is invalid
 #endif
@@ -54,6 +63,7 @@ struct PushConstants
 	uint height;
 	uint depth;
 	uint _pad0;
+	CLEAR_VALUE_TYPE clearValue;
 };
 
 [[vk::push_constant]]
@@ -67,7 +77,7 @@ void clear1D(uint3 tid : SV_DispatchThreadID)
 {
 	if (tid.x < pushConstants.width)
 	{
-		rwTexture[tid.x] = 0;
+		rwTexture[tid.x] = pushConstants.clearValue;
 	}
 }
 #endif
@@ -78,7 +88,7 @@ void clear2D(uint3 tid : SV_DispatchThreadID)
 {
 	if (tid.x < pushConstants.width && tid.y < pushConstants.height)
 	{
-		rwTexture[tid.xy] = 0;
+		rwTexture[tid.xy] = pushConstants.clearValue;
 	}
 }
 #endif
@@ -89,7 +99,7 @@ void clear3D(uint3 tid : SV_DispatchThreadID)
 {
 	if (tid.x < pushConstants.width && tid.y < pushConstants.height && tid.z < pushConstants.depth)
 	{
-		rwTexture[tid.xyz] = 0;
+		rwTexture[tid.xyz] = pushConstants.clearValue;
 	}
 }
 #endif


### PR DESCRIPTION
## Overview

Generate interpolated frames using the shaders in FidelityFX frameinterpolation & optical flow modules (optical flow PR: #95).

This PR generates only interpolated frames and does not inject them to the swapchain yet. Swapchain interaction will be worked on the next PR.

## Changes

Frame Generation
- Implement and execute FrameGenPass to generate interpolated frames. No interaction with swapchain yet.
- Add frame generation toggle to GUI.
- Fix debug visualization mode for optical flow vector.
- Add new debug visualization modes for frame generation.
- Extract common logic from optical_flow_pass.h to optical_flow_common.h.

Misc
- Support custom clear value in ClearResourcePass.
- Let VolatileDescriptorHelper::resizeDescriptorHeap() return the heap.
- Change the type of shader defines from std::initializer_list to const std::vector&.
- Support new pixel formats: R8G8_UNORM, R8_UNORM, and R16G16_UINT.
- Add TextureBarrierAuto::toShaderResource() and toUnorderedAccess().

## Sample screenshot

<img width="2373" height="1331" alt="FG_debugview" src="https://github.com/user-attachments/assets/7c79d346-97e2-49e1-9aa1-b4dfd13f95b8" />

Debug view of frame generation passes. Ghosting is due to my faulty RT reflection pass, not due to frame generation.

