### PR TITLE
Feature/101 [FSR3] Present interpolated frames

### DIFF
--- a/projects/Cyseal/Cyseal.vcxproj
+++ b/projects/Cyseal/Cyseal.vcxproj
@@ -94,6 +94,7 @@
     <ClInclude Include="src\core\critical_section.h" />
     <ClInclude Include="src\core\cymath.h" />
     <ClInclude Include="src\core\engine.h" />
+    <ClInclude Include="src\core\high_freq_counter.h" />
     <ClInclude Include="src\core\int_types.h" />
     <ClInclude Include="src\core\matrix.h" />
     <ClInclude Include="src\geometry\meso_geometry.h" />

--- a/projects/Cyseal/Cyseal.vcxproj.filters
+++ b/projects/Cyseal/Cyseal.vcxproj.filters
@@ -411,6 +411,9 @@
     <ClInclude Include="src\render\optical_flow_common.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\core\high_freq_counter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\memory\mem_alloc.cpp">

--- a/projects/Cyseal/src/core/high_freq_counter.h
+++ b/projects/Cyseal/src/core/high_freq_counter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "int_types.h"
+#include <chrono>
+
+class HighFrequencyCounter
+{
+public:
+	void start()
+	{
+		startTime = std::chrono::system_clock::now();
+	}
+
+	uint64 stopWithMilliseconds()
+	{
+		auto endTime = std::chrono::system_clock::now();
+		auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+		return diff;
+	}
+
+private:
+	std::chrono::time_point<std::chrono::system_clock> startTime;
+};

--- a/projects/Cyseal/src/render/buffer_visualization.cpp
+++ b/projects/Cyseal/src/render/buffer_visualization.cpp
@@ -86,7 +86,7 @@ void BufferVisualization::renderVisualization(RenderCommandList* commandList, ui
 	SPT.constantBuffer("sceneUniform", passInput.sceneUniformCBV);
 	SPT.texture("gbuffer0", passInput.gbuffer0SRV);
 	SPT.texture("gbuffer1", passInput.gbuffer1SRV);
-	SPT.texture("sceneColor", passInput.sceneColorSRV);
+	SPT.texture("sceneColor", passInput.sceneColorSRV); // #todo-renderer: This is not direct lighting anymore ever since CombineLightingPass was introduced.
 	SPT.texture("shadowMask", passInput.shadowMaskSRV);
 	SPT.texture("indirectDiffuse", passInput.indirectDiffuseSRV);
 	SPT.texture("indirectSpecular", passInput.indirectSpecularSRV);

--- a/projects/Cyseal/src/render/final_blit_pass.cpp
+++ b/projects/Cyseal/src/render/final_blit_pass.cpp
@@ -99,7 +99,7 @@ void FinalBlitPass::renderFinalBlit(RenderCommandList* commandList, uint32 swapc
 	SPT.constantBuffer("sceneUniform", passInput.sceneUniformCBV);
 	SPT.texture("sourceTexture", passInput.finalSceneColorSRV);
 
-	uint32 requiredVolatiles = SPT.totalDescriptors();
+	uint32 requiredVolatiles = SPT.totalDescriptors() * maxBlitOperationsPerFrame;
 	passDescriptor.resizeDescriptorHeap(swapchainIndex, requiredVolatiles);
 	DescriptorHeap* volatileHeap = passDescriptor.getDescriptorHeap(swapchainIndex);
 

--- a/projects/Cyseal/src/render/final_blit_pass.cpp
+++ b/projects/Cyseal/src/render/final_blit_pass.cpp
@@ -6,9 +6,10 @@
 #include "rhi/render_command.h"
 #include "rhi/texture_manager.h"
 
-void FinalBlitPass::initialize(RenderDevice* inDevice)
+void FinalBlitPass::initialize(RenderDevice* inDevice, uint32 inMaxBlitOperationsPerFrame)
 {
 	device = inDevice;
+	maxBlitOperationsPerFrame = inMaxBlitOperationsPerFrame;
 
 	const uint32 swapchainCount = device->maxFramesInFlight();
 	if (device->getCreateParams().swapChainParams.bHeadless == false)
@@ -81,8 +82,17 @@ void FinalBlitPass::initialize(RenderDevice* inDevice)
 	}
 }
 
+void FinalBlitPass::resetBlitResources()
+{
+	descriptorIndexTracker.lastIndex = 0;
+	currentBlitOperations = 0;
+}
+
 void FinalBlitPass::renderFinalBlit(RenderCommandList* commandList, uint32 swapchainIndex, const FinalBlitPassInput& passInput)
 {
+	CHECK(currentBlitOperations < maxBlitOperationsPerFrame);
+	currentBlitOperations += 1;
+
 	GraphicsPipelineState* pipelineState = getPipelineState(passInput.renderTarget);
 
 	ShaderParameterTable SPT{};
@@ -98,7 +108,7 @@ void FinalBlitPass::renderFinalBlit(RenderCommandList* commandList, uint32 swapc
 	//commandList->rsSetScissorRect(passInput.scissorRect);
 
 	commandList->setGraphicsPipelineState(pipelineState);
-	commandList->bindGraphicsShaderParameters(pipelineState, &SPT, volatileHeap);
+	commandList->bindGraphicsShaderParameters(pipelineState, &SPT, volatileHeap, &descriptorIndexTracker);
 	commandList->iaSetPrimitiveTopology(EPrimitiveTopology::TRIANGLELIST);
 
 	commandList->beginRenderPass();

--- a/projects/Cyseal/src/render/final_blit_pass.h
+++ b/projects/Cyseal/src/render/final_blit_pass.h
@@ -20,7 +20,10 @@ struct FinalBlitPassInput
 class FinalBlitPass final : public SceneRenderPass
 {
 public:
-	void initialize(RenderDevice* inRenderDevice);
+	void initialize(RenderDevice* inRenderDevice, uint32 inMaxBlitOperationsPerFrame);
+
+	// Invoke every frame before calling renderFinalBlit().
+	void resetBlitResources();
 
 	void renderFinalBlit(RenderCommandList* commandList, uint32 swapchainIndex, const FinalBlitPassInput& passInput);
 
@@ -36,4 +39,7 @@ private:
 
 	VertexInputLayout                        inputLayout;
 	VolatileDescriptorHelper                 passDescriptor;
+	DescriptorIndexTracker                   descriptorIndexTracker;
+	uint32                                   maxBlitOperationsPerFrame = 1;
+	uint32                                   currentBlitOperations = 0xffffffff;
 };

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -116,9 +116,11 @@ static void setupDeviceDepthToViewSpaceDepthParams(const Camera* camera, float v
 	outDeviceToViewDepth[3] = (1.0f / b);
 }
 
-void FrameGenPass::initialize(RenderDevice* inRenderDevice)
+void FrameGenPass::initialize(RenderDevice* inRenderDevice, EPixelFormat inSourceColorFormat)
 {
 	device = inRenderDevice;
+	sourceColorFormat = inSourceColorFormat;
+
 	cpuFrameIndex = 0;
 
 	initializePipelines();
@@ -415,7 +417,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		commandList->enqueueDeferredDealloc(prevInterpolationSourceUAV.release(), true);
 
 		TextureCreateParams texDesc = TextureCreateParams::texture2D(
-			PF_sceneColor,
+			sourceColorFormat,
 			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 			passInput.displaySizeX, passInput.displaySizeY);
 		prevInterpolationSourceTexture = UniquePtr<Texture>(device->createTexture(texDesc));
@@ -480,7 +482,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		commandList->enqueueDeferredDealloc(interpolationOutputUAV.release(), true);
 
 		TextureCreateParams texDesc = TextureCreateParams::texture2D(
-			PF_sceneColor,
+			sourceColorFormat,
 			ETextureAccessFlags::SRV | ETextureAccessFlags::UAV,
 			passInput.displaySizeX, passInput.displaySizeY);
 		interpolationOutputTexture = UniquePtr<Texture>(device->createTexture(texDesc));

--- a/projects/Cyseal/src/render/frame_gen_pass.cpp
+++ b/projects/Cyseal/src/render/frame_gen_pass.cpp
@@ -453,7 +453,7 @@ void FrameGenPass::recreateResources(RenderCommandList* commandList, const Frame
 		}
 	}
 
-	// #todo-fsr3: Included in FidelityFX but not used. Probably dead code but create and bind it anyway.
+	// #todo-fsr3-unused: Included in FidelityFX but not used. Probably dead code but create and bind it anyway.
 	// See r_optical_flow_confidence and FFX_FRAMEINTERPOLATION_RESOURCE_IDENTIFIER_OPTICAL_FLOW_CONFIDENCE.
 	// It's declared as uint2, but LoadOpticalFlowConfidence() reads its y channel and returns it as float.
 	// Then fConfidenceFactor = ffxMax(FFX_FRAMEINTERPOLATION_EPSILON, LoadOpticalFlowConfidence(samplePos)).
@@ -513,18 +513,18 @@ void FrameGenPass::updateUniforms(RenderCommandList* commandList, const FrameGen
 		.cameraNear                 = passInput.camera->getZNear(),
 		.cameraFar                  = passInput.camera->getZFar(),
 		.upscalerTargetSize         = { passInput.renderSizeX, passInput.renderSizeY },
-		.Mode                       = 0, // #todo-fsr3: FidelityFX defines but does not use it.
+		.Mode                       = 0, // #todo-fsr3-unused: FidelityFX defines but does not use it.
 		.reset                      = bResetCurrentFrame || bDisjointFrameID,
 		.fDeviceToViewDepth         = { 0, 0, 0, 0 }, // Set below
-		.deltaTime                  = 0, // #todo-fsr3: FidelityFX defines but does not use it.
+		.deltaTime                  = 0, // #todo-fsr3-unused: FidelityFX defines but does not use it.
 		.HUDLessAttachedFactor      = 0, // #todo-fsr3: HUDLessAttachedFactor
 		.distortionFieldSize        = { 1, 1 },
 		.opticalFlowScale           = { 1.0f / (float)(passInput.displaySizeX), 1.0f / (float)(passInput.displaySizeY) },
 		.opticalFlowBlockSize       = kOpticalFlowBlockSize,
 		.dispatchFlags              = (uint32)passInput.dispatchFlags,
 		.maxRenderSize              = { passInput.displaySizeX, passInput.displaySizeY },
-		.opticalFlowHalfResMode     = 0, // #todo-fsr3: FidelityFX defines but does not use it.
-		.NumInstances               = 0, // #todo-fsr3: FidelityFX defines but does not use it.
+		.opticalFlowHalfResMode     = 0, // #todo-fsr3-unused: FidelityFX defines but does not use it.
+		.NumInstances               = 0, // #todo-fsr3-unused: FidelityFX defines but does not use it.
 		.interpolationRectBase      = { 0, 0 },
 		.interpolationRectSize      = { passInput.renderSizeX, passInput.renderSizeY },
 		.debugBarColor              = { 1.0f, 0.0f, 0.0f },
@@ -728,7 +728,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			SPT.constantBuffer("cbFI", frameInterpUniformCBV); // FFX_FRAMEINTERPOLATION_BIND_CB_FRAMEINTERPOLATION
 			SPT.texture("r_dilated_motion_vectors", dilatedMotionVectorSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_MOTION_VECTORS
 			SPT.texture("r_dilated_depth", dilatedDepthSRV.get()); // FFX_FRAMEINTERPOLATION_BIND_SRV_DILATED_DEPTH
-			// #todo-fsr3: declared but not used in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
+			// #todo-fsr3-unused: declared but not used in ffx_frameinterpolation_reconstruct_previous_depth_pass.hlsl
 			SPT.texture("r_current_interpolation_source", currInterpolationSourceSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_CURRENT_INTERPOLATION_SOURCE
 			SPT.texture("r_input_distortion_field", distortionFieldSRV); // FFX_FRAMEINTERPOLATION_BIND_SRV_DISTORTION_FIELD
 			SPT.rwTexture("rw_reconstructed_depth_interpolated_frame", reconstructedDepthInterpolatedFrameUAV.get()); // FFX_FRAMEINTERPOLATION_BIND_UAV_RECONSTRUCTED_DEPTH_INTERPOLATED_FRAME
@@ -937,7 +937,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		commandList->dispatchCompute(dispatchThreadGroupCountXY[0], dispatchThreadGroupCountXY[1], 1);
 	}
 
-	// #todo-fsr3-presentbackbuffer: Revisit when dealing with swapchain interaction.
+	// #todo-fsr3-present: Revisit when dealing with swapchain interaction.
 	// Currently just assume that PRESENT_BACKBUFFER == currInterpolationSourceTexture.
 	auto presentBackbufferSRV = currInterpolationSourceSRV;
 
@@ -950,7 +950,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 		TextureBarrierAuto textureBarriers[] = {
 			TextureBarrierAuto::toShaderResource(passInput.opticalFlowPassOutput->sceneChangeDetectionTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
-			// #todo-fsr3-presentbackbuffer
+			// #todo-fsr3-present
 			//TextureBarrierAuto::toShaderResource(presentBackbufferTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toUnorderedAccess(interpolationOutputTexture.get(), EBarrierSync::COMPUTE_SHADING),
@@ -986,7 +986,7 @@ void FrameGenPass::dispatchPhase(RenderCommandList* commandList, uint32 swapchai
 			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[0].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(opticalFlowMotionVectorFieldTextures[1].get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(disocclusionMaskTexture.get(), EBarrierSync::COMPUTE_SHADING),
-			// #todo-fsr3-presentbackbuffer
+			// #todo-fsr3-present
 			//TextureBarrierAuto::toShaderResource(presentBackbufferTexture, EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(inpaintingPyramidTexture.get(), EBarrierSync::COMPUTE_SHADING),
 			TextureBarrierAuto::toShaderResource(currInterpolationSourceTexture, EBarrierSync::COMPUTE_SHADING),

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -52,7 +52,7 @@ struct FrameGenPassOutput
 class FrameGenPass final : public SceneRenderPass
 {
 public:
-	void initialize(RenderDevice* inRenderDevice);
+	void initialize(RenderDevice* inRenderDevice, EPixelFormat inSourceColorFormat);
 
 	FrameGenPassOutput runFrameGeneration(RenderCommandList* commandList, uint32 swapchainIndex, const FrameGenPassInput& passInput);
 
@@ -70,6 +70,8 @@ private:
 
 private:
 	RenderDevice* device = nullptr;
+	EPixelFormat sourceColorFormat;
+
 	uint32 cpuFrameIndex = 0;
 	uint32 prevFrameID = 0; // from FrameGenPassInput
 	uint32 interpolationDispatchCount = 0;

--- a/projects/Cyseal/src/render/frame_gen_pass.h
+++ b/projects/Cyseal/src/render/frame_gen_pass.h
@@ -135,7 +135,7 @@ private:
 	UniquePtr<Texture>                     inpaintingPyramidTexture;
 	UniquePtr<ShaderResourceView>          inpaintingPyramidSRV;
 	UniquePtr<UnorderedAccessView>         inpaintingPyramidUAVs[13];
-	UniquePtr<Texture>                     opticalFlowConfidenceTexture; // #todo-fsr3: Probably dead code.
+	UniquePtr<Texture>                     opticalFlowConfidenceTexture;
 	UniquePtr<ShaderResourceView>          opticalFlowConfidenceSRV;
 	UniquePtr<Texture>                     interpolationOutputTexture;
 	UniquePtr<ShaderResourceView>          interpolationOutputSRV;

--- a/projects/Cyseal/src/render/null_renderer.cpp
+++ b/projects/Cyseal/src/render/null_renderer.cpp
@@ -76,7 +76,7 @@ void NullRenderer::render(const SceneProxy* scene, const Camera* camera, const R
 
 	commandQueue->executeCommandList(commandList, swapChain);
 
-	swapChain->present();
+	swapChain->present(true);
 
 	device->flushCommandQueue();
 

--- a/projects/Cyseal/src/render/optical_flow_pass.cpp
+++ b/projects/Cyseal/src/render/optical_flow_pass.cpp
@@ -118,7 +118,7 @@ OpticalFlowPassOutput OpticalFlowPass::runOpticalFlow(RenderCommandList* command
 	uint32 workGroupOffset[2];
 	uint32 numWorkGroupsAndMips[2];
 	const uint32 rectInfo[4] = { 0u, 0u, (uint32)passInput.lumaResolutionX, (uint32)passInput.lumaResolutionY };
-	// #todo-fsr3-fg: Why mips = 4, not 7? (result is correct based on PIX)
+	// #todo-fsr3: Why mips = 4, not 7? (result is correct based on PIX)
 	ffxSpdSetup(threadGroupSizeOpticalFlowInputPyramid, workGroupOffset, numWorkGroupsAndMips, rectInfo, 4);
 
 	SpdUniform spdUniformData{
@@ -442,7 +442,7 @@ OpticalFlowPassOutput OpticalFlowPass::runOpticalFlow(RenderCommandList* command
 			};
 		}
 
-		// #todo-fsr3-fg: What is this?
+		// #todo-fsr3-unused: What is this?
 #if 0
 		if (level > 0)
 		{
@@ -614,7 +614,7 @@ void OpticalFlowPass::recreateResources(RenderCommandList* commandList, uint32 s
 		));
 	};
 
-	// #todo-fsr3-fg: Use bContainerResolutionChanged?
+	// #todo-fsr3: Use bContainerResolutionChanged?
 	if (bLumaResolutionChanged)
 	{
 		for (uint32 frameIx = 0; frameIx < 2; ++frameIx)

--- a/projects/Cyseal/src/render/renderer_options.h
+++ b/projects/Cyseal/src/render/renderer_options.h
@@ -210,6 +210,7 @@ struct RendererOptions
 
 	// Frame generation
 	bool                      bGenerateFrame = true;
+	float                     prevRenderTime = 0.0f; // In milliseconds, used for frame pacing.
 
 	// Debug visualization
 	EBufferVisualizationMode  bufferVisualization = EBufferVisualizationMode::None;

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -40,6 +40,8 @@
 
 #include "util/profiling.h"
 
+#include <thread>
+
 #define SCENE_UNIFORM_MEMORY_POOL_SIZE (64 * 1024) // 64 KiB
 #define MAX_CULL_OPERATIONS            (2 * kMaxBasePassPermutation) // depth prepass + base pass
 #define MAX_FINAL_BLIT_OPERATIONS      2 // Actual count: 2 if frame generation is enabled, 1 otherwise.
@@ -170,6 +172,11 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 {
 	bool bRenderToBackbuffer = renderOptions.renderToBackbuffer();
 
+	// #todo-renderer: Refactor swapchainIndex.
+	// - I'm using swapchainIndex for buffered resources in various render passes,
+	//   but they are not really related to specific swapchain index anymore.
+	// - By introduction of frame generation, they became even more irrelevant because 'current backbuffer index'
+	//   now changes twice per render().
 	uint32            swapchainIndex     = 0;
 	SwapChain*        swapChain          = nullptr;
 	SwapChainImage*   swapchainBuffer    = nullptr;
@@ -1015,8 +1022,9 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		const ScenePresentInfo& presentInfo = scenePresentInfoArray[presentIx];
 
-		// #wip: Crashes for interp frame; maybe need to renew swapchainBuffer?
-		if (presentInfo.bRealFrame == false) continue;
+		// Debugging: Show only interpolated frame or real frame.
+		//if (presentInfo.bRealFrame == true) continue;
+		//if (presentInfo.bRealFrame == false) continue;
 
 		// Set final render target.
 		{
@@ -1101,12 +1109,31 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		{
 			bool bVSync = scenePresentInfoArray[presentIx].bRealFrame;
 			swapChain->present(bVSync);
-			// #wip: Force wait if about to present an interpolated frame. Calculate the wait time with moving-average-thing.
+
+			if (scenePresentInfoArray[presentIx].bRealFrame == false)
+			{
+				// #wip: Force wait if about to present an interpolated frame. Calculate the wait time with moving-average-thing.
+				const float targetFPS = 120.0f;
+				const float frameMS = 1000.0f / targetFPS;
+				std::this_thread::sleep_for(std::chrono::milliseconds((uint32)(0.5f * frameMS)));
+			}
 		}
 
 		if (presentIx != scenePresentCount - 1)
 		{
 			resetCommandList(commandAllocator, commandList);
+
+			if (bRenderToBackbuffer)
+			{
+				swapChain->prepareBackbuffer();
+
+				swapchainIndex     = swapChain->getCurrentBackbufferIndex();
+				swapchainBuffer    = swapChain->getSwapchainBuffer(swapchainIndex);
+				swapchainBufferRTV = swapChain->getSwapchainBufferRTV(swapchainIndex);
+
+				finalBlitTarget    = swapchainBuffer;
+				finalBlitRTV       = swapchainBufferRTV;
+			}
 		}
 	}
 

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -1115,7 +1115,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 			if (scenePresentInfoArray[presentIx].bRealFrame == false)
 			{
-				// #wip: My measurement includes the time to present interpolated frame so can't use 0.5f * frameMS.
+				// #todo-fsr3-present: My measurement includes the time to present interpolated frame so can't use 0.5f * frameMS.
 				// Not intuitive but it kinda works so leave it be?
 				const float frameMS = avgRenderTime.getAverage();
 				std::this_thread::sleep_for(std::chrono::milliseconds((uint32)(0.25f * frameMS)));

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -239,7 +239,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 	const bool bRenderAnyRaytracingPass = renderOptions.anyRayTracingEnabled();
 
-	const bool bRenderFrameGeneration = renderOptions.bGenerateFrame && !bRenderPathTracing;
+	const bool bRenderFrameGeneration = renderOptions.bGenerateFrame && !bRenderPathTracing && bRenderToBackbuffer;
 
 	clearResourcePass->prepareForFrame(swapchainIndex);
 
@@ -860,7 +860,57 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			};
 			frameGenPassOutput = frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
 		}
+		{
+			// #wip: Hmm framegen output is not tone mapped just because how my renderer is configured :(
+			// Then just run tone mapping one more here?
+		}
 	}
+
+	// Store history pass (step 2)
+	{
+		SCOPED_DRAW_EVENT(commandList, StoreHistoryPass_Prev);
+
+		TextureBarrierAuto textureBarriers[] = {
+			{
+				EBarrierSync::COPY, EBarrierAccess::COPY_SOURCE, EBarrierLayout::CopySource,
+				RT_sceneDepth.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
+			},
+			{
+				EBarrierSync::COPY, EBarrierAccess::COPY_DEST, EBarrierLayout::CopyDest,
+				RT_prevSceneDepth.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
+			},
+		};
+		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+		commandList->copyTexture2D(RT_sceneDepth.get(), RT_prevSceneDepth.get());
+
+		storeHistoryPass->copyCurrentToPrev(commandList, swapchainIndex);
+	}
+
+	// #wip: Run the below passes and present at most twice using this struct.
+#if 0
+	struct ScenePresentInfo
+	{
+		bool                bRealFrame;
+		Texture*            colorTexture;
+		ShaderResourceView* colorSRV;
+	} scenePresentInfoArray[2];
+
+	uint32 scenePresentCount = 0;
+	if (bRenderFrameGeneration)
+	{
+		scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
+			.bRealFrame   = false,
+			.colorTexture = frameGenPassOutput.interpolatedFrameTexture,
+			.colorSRV     = frameGenPassOutput.interpolatedFrameSRV,
+		};
+	}
+	scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
+		.bRealFrame   = true,
+		.colorTexture = bRenderPathTracing ? RT_pathTracing.get() : RT_sceneColor.get(),
+		.colorSRV     = bRenderPathTracing ? pathTracingSRV.get() : sceneColorSRV.get(),
+	};
+#endif
 
 	// Set final color as render target.
 	{
@@ -956,29 +1006,10 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		bufferVisualization->renderVisualization(commandList, swapchainIndex, sources);
 	}
 
-	// Store history pass (step 2)
-	{
-		SCOPED_DRAW_EVENT(commandList, StoreHistoryPass_Prev);
-
-		TextureBarrierAuto textureBarriers[] = {
-			{
-				EBarrierSync::COPY, EBarrierAccess::COPY_SOURCE, EBarrierLayout::CopySource,
-				RT_sceneDepth.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
-			},
-			{
-				EBarrierSync::COPY, EBarrierAccess::COPY_DEST, EBarrierLayout::CopyDest,
-				RT_prevSceneDepth.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
-			},
-		};
-		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
-
-		commandList->copyTexture2D(RT_sceneDepth.get(), RT_prevSceneDepth.get());
-
-		storeHistoryPass->copyCurrentToPrev(commandList, swapchainIndex);
-	}
-
 	// -----------------------------------------------------------------------
 	// Internal rendering is done. Prepare to blit to the final render target.
+
+	// #wip: flush the commands here and start new command list for each present.
 
 	// Set final render target.
 	{
@@ -1029,9 +1060,6 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		finalBlitPass->renderFinalBlit(commandList, swapchainIndex, passInput);
 	}
 
-	prevScaledRenderResolutionX = sceneWidth;
-	prevScaledRenderResolutionY = sceneHeight;
-
 	// Dear Imgui: Record commands
 	if (device->isHeadless() == false)
 	{
@@ -1059,18 +1087,22 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 	commandQueue->executeCommandList(commandList, swapChain);
 
-	if (bRenderToBackbuffer)
-	{
-		swapChain->present();
-	}
-
 	{
 		SCOPED_CPU_EVENT(WaitForGPU);
-
 		device->flushCommandQueue();
 	}
 
+	if (bRenderToBackbuffer)
+	{
+		// #wip: Present without vsync and force wait if about to present an interpolated frame.
+
+		swapChain->present();
+	}
+
 	frameID += 1;
+
+	prevScaledRenderResolutionX = sceneWidth;
+	prevScaledRenderResolutionY = sceneHeight;
 
 	// Deallocate memory, a bit messy
 	commandList->executeDeferredDealloc();

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -926,31 +926,6 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		}
 	}
 
-	// #wip: Run the below passes and present at most twice using this struct.
-#if 0
-	struct ScenePresentInfo
-	{
-		bool                bRealFrame;
-		Texture*            colorTexture;
-		ShaderResourceView* colorSRV;
-	} scenePresentInfoArray[2];
-
-	uint32 scenePresentCount = 0;
-	if (bRenderFrameGeneration)
-	{
-		scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
-			.bRealFrame   = false,
-			.colorTexture = frameGenPassOutput.interpolatedFrameTexture,
-			.colorSRV     = frameGenPassOutput.interpolatedFrameSRV,
-		};
-	}
-	scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
-		.bRealFrame   = true,
-		.colorTexture = bRenderPathTracing ? RT_pathTracing.get() : RT_sceneColor.get(),
-		.colorSRV     = bRenderPathTracing ? pathTracingSRV.get() : sceneColorSRV.get(),
-	};
-#endif
-
 	// Buffer visualization
 	if (renderOptions.bufferVisualization != EBufferVisualizationMode::None)
 	{
@@ -1004,10 +979,39 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		bufferVisualization->renderVisualization(commandList, swapchainIndex, sources);
 	}
 
+	// Flush GPU before present work.
+	immediateFlushCommandQueue(commandQueue, commandAllocator, commandList);
+	resetCommandList(commandAllocator, commandList);
+
 	// -----------------------------------------------------------------------
 	// Internal rendering is done. Prepare to blit to the final render target.
 
-	// #wip: flush the commands here and start new command list for each present.
+	// #wip: Run the below passes and present at most twice using this struct.
+#if 0
+	struct ScenePresentInfo
+	{
+		bool                bRealFrame;
+		Texture*            colorTexture;
+		ShaderResourceView* colorSRV;
+	} scenePresentInfoArray[2];
+
+	uint32 scenePresentCount = 0;
+	if (bRenderFrameGeneration)
+	{
+		scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
+			.bRealFrame   = false,
+			.colorTexture = frameGenPassOutput.interpolatedFrameTexture,
+			.colorSRV     = frameGenPassOutput.interpolatedFrameSRV,
+		};
+	}
+	scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
+		.bRealFrame   = true,
+		.colorTexture = bRenderPathTracing ? RT_pathTracing.get() : RT_sceneColor.get(),
+		.colorSRV     = bRenderPathTracing ? pathTracingSRV.get() : sceneColorSRV.get(),
+	};
+#endif
+
+	// #wip: start new command list for each present.
 
 	// Set final render target.
 	{
@@ -1082,9 +1086,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 	commandList->close();
 	commandAllocator->markValid();
-
 	commandQueue->executeCommandList(commandList, swapChain);
-
 	{
 		SCOPED_CPU_EVENT(WaitForGPU);
 		device->flushCommandQueue();

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -138,7 +138,7 @@ void SceneRenderer::initialize(RenderDevice* renderDevice)
 		denoiserPluginPass->initialize(renderDevice);
 		storeHistoryPass->initialize(renderDevice);
 		opticalFlowPass->initialize(renderDevice);
-		frameGenPass->initialize(renderDevice);
+		frameGenPass->initialize(renderDevice, PF_finalSceneColor);
 		finalBlitPass->initialize(renderDevice);
 	}
 }
@@ -797,75 +797,6 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		combineLightingPass->combineLighting(commandList, swapchainIndex, passInput);
 	}
 
-	OpticalFlowPassOutput opticalFlowPassOutput{};
-	FrameGenPassOutput frameGenPassOutput{};
-	if (bRenderFrameGeneration)
-	{
-		const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::PQCorrectedHdrToPerceivedLuminance;
-		const bool bResetOpticalFlowAccumulation = false;
-
-		// #todo-fsr3: How to calculate min/max luminance? Just downsample the sceneColor to 1x1?
-		// But how to read it? GPU stall and readback is def not an option :(
-		// If these are not scene luminance min/max but the range in HDR calibration then I should pass them from application logic side.
-		const float fMinLuminance = 0.0f;
-		const float fMaxLuminance = 3000.0f;
-
-		{
-			SCOPED_DRAW_EVENT(commandList, OpticalFlow);
-
-			OpticalFlowPassInput passInput{
-				.clearResourcePass  = clearResourcePass,
-				.transferFunction   = backbufferTransferFunction,
-				.bResetAccumulation = bResetOpticalFlowAccumulation,
-				.containerSizeX     = unscaledRenderWidth,
-				.containerSizeY     = unscaledRenderHeight,
-				.lumaResolutionX    = (int32)sceneWidth,
-				.lumaResolutionY    = (int32)sceneHeight,
-				.minLuminance       = fMinLuminance,
-				.maxLuminance       = fMaxLuminance,
-				.sceneColorTexture  = RT_sceneColor.get(),
-				.sceneColorSRV      = sceneColorSRV.get(),
-			};
-			opticalFlowPassOutput = opticalFlowPass->runOpticalFlow(commandList, swapchainIndex, passInput);
-		}
-		{
-			SCOPED_DRAW_EVENT(commandList, FrameGeneration);
-
-			EFrameGenDispatchFlags dispatchFlags = EFrameGenDispatchFlags::NONE;
-			if (renderOptions.bufferVisualization == EBufferVisualizationMode::FrameGenerationDebugView)
-			{
-				dispatchFlags |= EFrameGenDispatchFlags::DRAW_DEBUG_VIEW;
-			}
-
-			FrameGenPassInput passInput{
-				.clearResourcePass          = clearResourcePass,
-				.opticalFlowPassOutput      = &opticalFlowPassOutput,
-				.camera                     = camera,
-				.renderSizeX                = (int32)sceneWidth,
-				.renderSizeY                = (int32)sceneHeight,
-				.displaySizeX               = (int32)unscaledRenderWidth,
-				.displaySizeY               = (int32)unscaledRenderHeight,
-				.frameID                    = frameID,
-				.dispatchFlags              = dispatchFlags,
-				.backBufferTransferFunction = backbufferTransferFunction,
-				.bReset                     = bResetOpticalFlowAccumulation,
-				.minLuminance               = fMinLuminance,
-				.maxLuminance               = fMaxLuminance,
-				.sceneColorTexture          = RT_sceneColor.get(),
-				.sceneColorSRV              = sceneColorSRV.get(),
-				.sceneDepthTexture          = RT_sceneDepth.get(),
-				.sceneDepthSRV              = sceneDepthSRV.get(),
-				.motionVectorTexture        = RT_velocityMap.get(),
-				.motionVectorSRV            = velocityMapSRV.get(),
-			};
-			frameGenPassOutput = frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
-		}
-		{
-			// #wip: Hmm framegen output is not tone mapped just because how my renderer is configured :(
-			// Then just run tone mapping one more here?
-		}
-	}
-
 	// Store history pass (step 2)
 	{
 		SCOPED_DRAW_EVENT(commandList, StoreHistoryPass_Prev);
@@ -886,31 +817,6 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		storeHistoryPass->copyCurrentToPrev(commandList, swapchainIndex);
 	}
-
-	// #wip: Run the below passes and present at most twice using this struct.
-#if 0
-	struct ScenePresentInfo
-	{
-		bool                bRealFrame;
-		Texture*            colorTexture;
-		ShaderResourceView* colorSRV;
-	} scenePresentInfoArray[2];
-
-	uint32 scenePresentCount = 0;
-	if (bRenderFrameGeneration)
-	{
-		scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
-			.bRealFrame   = false,
-			.colorTexture = frameGenPassOutput.interpolatedFrameTexture,
-			.colorSRV     = frameGenPassOutput.interpolatedFrameSRV,
-		};
-	}
-	scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
-		.bRealFrame   = true,
-		.colorTexture = bRenderPathTracing ? RT_pathTracing.get() : RT_sceneColor.get(),
-		.colorSRV     = bRenderPathTracing ? pathTracingSRV.get() : sceneColorSRV.get(),
-	};
-#endif
 
 	// Set final color as render target.
 	{
@@ -952,6 +858,98 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		};
 		toneMapping->renderToneMapping(commandList, swapchainIndex, passInput);
 	}
+
+	OpticalFlowPassOutput opticalFlowPassOutput{};
+	FrameGenPassOutput frameGenPassOutput{};
+	if (bRenderFrameGeneration)
+	{
+		const bool bResetOpticalFlowAccumulation = false;
+
+		// #todo-fsr3: Change transfer func and min/max luminance when HDR display support is implemented.
+		// Currently backbuffer is always in LDR so just hard-code them.
+		const auto backbufferTransferFunction = OpticalFlowBackbufferTransferFunction::LinearLdrToLuminance;
+		const float fMinLuminance = 0.0f;
+		const float fMaxLuminance = 1.0f;
+
+		auto frameGenInputColorTexture = RT_finalSceneColor.get();
+		auto frameGenInputColorSRV = finalSceneColorSRV.get();
+
+		{
+			SCOPED_DRAW_EVENT(commandList, OpticalFlow);
+
+			OpticalFlowPassInput passInput{
+				.clearResourcePass  = clearResourcePass,
+				.transferFunction   = backbufferTransferFunction,
+				.bResetAccumulation = bResetOpticalFlowAccumulation,
+				.containerSizeX     = unscaledRenderWidth,
+				.containerSizeY     = unscaledRenderHeight,
+				.lumaResolutionX    = (int32)sceneWidth,
+				.lumaResolutionY    = (int32)sceneHeight,
+				.minLuminance       = fMinLuminance,
+				.maxLuminance       = fMaxLuminance,
+				.sceneColorTexture  = frameGenInputColorTexture,
+				.sceneColorSRV      = frameGenInputColorSRV,
+			};
+			opticalFlowPassOutput = opticalFlowPass->runOpticalFlow(commandList, swapchainIndex, passInput);
+		}
+		{
+			SCOPED_DRAW_EVENT(commandList, FrameGeneration);
+
+			EFrameGenDispatchFlags dispatchFlags = EFrameGenDispatchFlags::NONE;
+			if (renderOptions.bufferVisualization == EBufferVisualizationMode::FrameGenerationDebugView)
+			{
+				dispatchFlags |= EFrameGenDispatchFlags::DRAW_DEBUG_VIEW;
+			}
+
+			FrameGenPassInput passInput{
+				.clearResourcePass          = clearResourcePass,
+				.opticalFlowPassOutput      = &opticalFlowPassOutput,
+				.camera                     = camera,
+				.renderSizeX                = (int32)sceneWidth,
+				.renderSizeY                = (int32)sceneHeight,
+				.displaySizeX               = (int32)unscaledRenderWidth,
+				.displaySizeY               = (int32)unscaledRenderHeight,
+				.frameID                    = frameID,
+				.dispatchFlags              = dispatchFlags,
+				.backBufferTransferFunction = backbufferTransferFunction,
+				.bReset                     = bResetOpticalFlowAccumulation,
+				.minLuminance               = fMinLuminance,
+				.maxLuminance               = fMaxLuminance,
+				.sceneColorTexture          = frameGenInputColorTexture,
+				.sceneColorSRV              = frameGenInputColorSRV,
+				.sceneDepthTexture          = RT_sceneDepth.get(),
+				.sceneDepthSRV              = sceneDepthSRV.get(),
+				.motionVectorTexture        = RT_velocityMap.get(),
+				.motionVectorSRV            = velocityMapSRV.get(),
+			};
+			frameGenPassOutput = frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
+		}
+	}
+
+	// #wip: Run the below passes and present at most twice using this struct.
+#if 0
+	struct ScenePresentInfo
+	{
+		bool                bRealFrame;
+		Texture*            colorTexture;
+		ShaderResourceView* colorSRV;
+	} scenePresentInfoArray[2];
+
+	uint32 scenePresentCount = 0;
+	if (bRenderFrameGeneration)
+	{
+		scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
+			.bRealFrame   = false,
+			.colorTexture = frameGenPassOutput.interpolatedFrameTexture,
+			.colorSRV     = frameGenPassOutput.interpolatedFrameSRV,
+		};
+	}
+	scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
+		.bRealFrame   = true,
+		.colorTexture = bRenderPathTracing ? RT_pathTracing.get() : RT_sceneColor.get(),
+		.colorSRV     = bRenderPathTracing ? pathTracingSRV.get() : sceneColorSRV.get(),
+	};
+#endif
 
 	// Buffer visualization
 	if (renderOptions.bufferVisualization != EBufferVisualizationMode::None)

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -45,6 +45,7 @@
 #define SCENE_UNIFORM_MEMORY_POOL_SIZE (64 * 1024) // 64 KiB
 #define MAX_CULL_OPERATIONS            (2 * kMaxBasePassPermutation) // depth prepass + base pass
 #define MAX_FINAL_BLIT_OPERATIONS      2 // Actual count: 2 if frame generation is enabled, 1 otherwise.
+#define AVG_RENDER_TIME_WINDOW_SIZE    16
 
 static uint32 fullMipCount(uint32 width, uint32 height)
 {
@@ -55,6 +56,8 @@ void SceneRenderer::initialize(RenderDevice* renderDevice)
 {
 	device = renderDevice;
 	frameID = 0;
+
+	avgRenderTime.init(AVG_RENDER_TIME_WINDOW_SIZE);
 
 	// Scene textures: Don't create yet. You invoke recreateSceneTextures() before using scene renderer.
 	// recreateSceneTextures(width, height);
@@ -1112,10 +1115,10 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 			if (scenePresentInfoArray[presentIx].bRealFrame == false)
 			{
-				// #wip: Force wait if about to present an interpolated frame. Calculate the wait time with moving-average-thing.
-				const float targetFPS = 120.0f;
-				const float frameMS = 1000.0f / targetFPS;
-				std::this_thread::sleep_for(std::chrono::milliseconds((uint32)(0.5f * frameMS)));
+				// #wip: My measurement includes the time to present interpolated frame so can't use 0.5f * frameMS.
+				// Not intuitive but it kinda works so leave it be?
+				const float frameMS = avgRenderTime.getAverage();
+				std::this_thread::sleep_for(std::chrono::milliseconds((uint32)(0.25f * frameMS)));
 			}
 		}
 
@@ -1138,6 +1141,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	}
 
 	frameID += 1;
+	avgRenderTime.push(renderOptions.prevRenderTime);
 
 	prevScaledRenderResolutionX = sceneWidth;
 	prevScaledRenderResolutionY = sceneHeight;

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -42,6 +42,7 @@
 
 #define SCENE_UNIFORM_MEMORY_POOL_SIZE (64 * 1024) // 64 KiB
 #define MAX_CULL_OPERATIONS            (2 * kMaxBasePassPermutation) // depth prepass + base pass
+#define MAX_FINAL_BLIT_OPERATIONS      2 // Actual count: 2 if frame generation is enabled, 1 otherwise.
 
 static uint32 fullMipCount(uint32 width, uint32 height)
 {
@@ -139,7 +140,7 @@ void SceneRenderer::initialize(RenderDevice* renderDevice)
 		storeHistoryPass->initialize(renderDevice);
 		opticalFlowPass->initialize(renderDevice);
 		frameGenPass->initialize(renderDevice, PF_finalSceneColor);
-		finalBlitPass->initialize(renderDevice);
+		finalBlitPass->initialize(renderDevice, MAX_FINAL_BLIT_OPERATIONS);
 	}
 }
 
@@ -986,8 +987,6 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	// -----------------------------------------------------------------------
 	// Internal rendering is done. Prepare to blit to the final render target.
 
-	// #wip: Run the below passes and present at most twice using this struct.
-#if 0
 	struct ScenePresentInfo
 	{
 		bool                bRealFrame;
@@ -1000,103 +999,115 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
 			.bRealFrame   = false,
-			.colorTexture = frameGenPassOutput.interpolatedFrameTexture,
-			.colorSRV     = frameGenPassOutput.interpolatedFrameSRV,
+			.colorTexture = RT_finalSceneColor.get(),
+			.colorSRV     = finalSceneColorSRV.get(),
 		};
 	}
 	scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
 		.bRealFrame   = true,
-		.colorTexture = bRenderPathTracing ? RT_pathTracing.get() : RT_sceneColor.get(),
-		.colorSRV     = bRenderPathTracing ? pathTracingSRV.get() : sceneColorSRV.get(),
+		.colorTexture = RT_finalSceneColor.get(),
+		.colorSRV     = finalSceneColorSRV.get(),
 	};
-#endif
 
-	// #wip: start new command list for each present.
+	finalBlitPass->resetBlitResources();
 
-	// Set final render target.
+	for (uint32 presentIx = 0; presentIx < scenePresentCount; ++presentIx)
 	{
-		SCOPED_DRAW_EVENT(commandList, SetFinalRenderTarget);
+		const ScenePresentInfo& presentInfo = scenePresentInfoArray[presentIx];
 
-		const Viewport finalBlitViewport{
-			.topLeftX = 0,
-			.topLeftY = 0,
-			.width    = static_cast<float>(finalBlitWidth),
-			.height   = static_cast<float>(finalBlitHeight),
-			.minDepth = 0.0f,
-			.maxDepth = 1.0f,
-		};
-		const ScissorRect finalBlitScissorRect{
-			.left   = 0,
-			.top    = 0,
-			.right  = finalBlitWidth,
-			.bottom = finalBlitHeight,
-		};
-		commandList->rsSetViewport(finalBlitViewport);
-		commandList->rsSetScissorRect(finalBlitScissorRect);
+		// #wip: Crashes for interp frame; maybe need to renew swapchainBuffer?
+		if (presentInfo.bRealFrame == false) continue;
 
-		TextureBarrierAuto barrier{
-			EBarrierSync::RENDER_TARGET, EBarrierAccess::RENDER_TARGET, EBarrierLayout::RenderTarget,
-			finalBlitTarget, BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
-		};
-		commandList->barrierAuto(0, nullptr, 1, &barrier, 0, nullptr);
+		// Set final render target.
+		{
+			SCOPED_DRAW_EVENT(commandList, SetFinalRenderTarget);
 
-		commandList->omSetRenderTarget(finalBlitRTV, nullptr);
-	}
+			const Viewport finalBlitViewport{
+				.topLeftX = 0,
+				.topLeftY = 0,
+				.width    = static_cast<float>(finalBlitWidth),
+				.height   = static_cast<float>(finalBlitHeight),
+				.minDepth = 0.0f,
+				.maxDepth = 1.0f,
+			};
+			const ScissorRect finalBlitScissorRect{
+				.left   = 0,
+				.top    = 0,
+				.right  = finalBlitWidth,
+				.bottom = finalBlitHeight,
+			};
+			commandList->rsSetViewport(finalBlitViewport);
+			commandList->rsSetScissorRect(finalBlitScissorRect);
 
-	{
-		SCOPED_DRAW_EVENT(commandList, FinalBlit);
+			TextureBarrierAuto barrier{
+				EBarrierSync::RENDER_TARGET, EBarrierAccess::RENDER_TARGET, EBarrierLayout::RenderTarget,
+				finalBlitTarget, BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
+			};
+			commandList->barrierAuto(0, nullptr, 1, &barrier, 0, nullptr);
 
-		TextureBarrierAuto textureBarriers[] = {
-			{
-				EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
-				RT_finalSceneColor.get(), BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
-			},
-		};
-		commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+			commandList->omSetRenderTarget(finalBlitRTV, nullptr);
+		}
 
-		FinalBlitPassInput passInput{
-			.sceneUniformCBV    = sceneUniformCBV,
-			.renderTarget       = renderOptions.finalRenderTarget,
-			.finalSceneColorSRV = finalSceneColorSRV.get(),
-		};
-		finalBlitPass->renderFinalBlit(commandList, swapchainIndex, passInput);
-	}
+		{
+			SCOPED_DRAW_EVENT(commandList, FinalBlit);
 
-	// Dear Imgui: Record commands
-	if (device->isHeadless() == false)
-	{
-		SCOPED_DRAW_EVENT(commandList, DearImgui);
+			TextureBarrierAuto textureBarriers[] = {
+				{
+					EBarrierSync::PIXEL_SHADING, EBarrierAccess::SHADER_RESOURCE, EBarrierLayout::ShaderResource,
+					presentInfo.colorTexture, BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None
+				},
+			};
+			commandList->barrierAuto(0, nullptr, _countof(textureBarriers), textureBarriers, 0, nullptr);
+
+			FinalBlitPassInput passInput{
+				.sceneUniformCBV    = sceneUniformCBV,
+				.renderTarget       = renderOptions.finalRenderTarget,
+				.finalSceneColorSRV = presentInfo.colorSRV,
+			};
+			finalBlitPass->renderFinalBlit(commandList, swapchainIndex, passInput);
+		}
+
+		// Dear Imgui: Record commands
+		if (device->isHeadless() == false)
+		{
+			SCOPED_DRAW_EVENT(commandList, DearImgui);
 		
-		DescriptorHeap* imguiHeaps[] = { device->getDearImguiSRVHeap() };
-		commandList->setDescriptorHeaps(1, imguiHeaps);
-		device->renderDearImgui(commandList, swapchainBuffer);
-	}
+			DescriptorHeap* imguiHeaps[] = { device->getDearImguiSRVHeap() };
+			commandList->setDescriptorHeaps(1, imguiHeaps);
+			device->renderDearImgui(commandList, swapchainBuffer);
+		}
 
-	//////////////////////////////////////////////////////////////////////////
-	// Finalize
+		//////////////////////////////////////////////////////////////////////////
+		// Finalize
 
-	if (bRenderToBackbuffer)
-	{
-		TextureBarrierAuto presentBarrier = {
-			EBarrierSync::DRAW, EBarrierAccess::COMMON, EBarrierLayout::Present,
-			swapchainBuffer, BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
-		};
-		commandList->barrierAuto(0, nullptr, 1, &presentBarrier, 0, nullptr);
-	}
+		if (bRenderToBackbuffer)
+		{
+			TextureBarrierAuto presentBarrier = {
+				EBarrierSync::DRAW, EBarrierAccess::COMMON, EBarrierLayout::Present,
+				swapchainBuffer, BarrierSubresourceRange::allMips(), ETextureBarrierFlags::None,
+			};
+			commandList->barrierAuto(0, nullptr, 1, &presentBarrier, 0, nullptr);
+		}
 
-	commandList->close();
-	commandAllocator->markValid();
-	commandQueue->executeCommandList(commandList, swapChain);
-	{
-		SCOPED_CPU_EVENT(WaitForGPU);
-		device->flushCommandQueue();
-	}
+		commandList->close();
+		commandAllocator->markValid();
+		commandQueue->executeCommandList(commandList, swapChain);
+		{
+			SCOPED_CPU_EVENT(WaitForGPU);
+			device->flushCommandQueue();
+		}
 
-	if (bRenderToBackbuffer)
-	{
-		// #wip: Present without vsync and force wait if about to present an interpolated frame.
+		if (bRenderToBackbuffer)
+		{
+			bool bVSync = scenePresentInfoArray[presentIx].bRealFrame;
+			swapChain->present(bVSync);
+			// #wip: Force wait if about to present an interpolated frame. Calculate the wait time with moving-average-thing.
+		}
 
-		swapChain->present();
+		if (presentIx != scenePresentCount - 1)
+		{
+			resetCommandList(commandAllocator, commandList);
+		}
 	}
 
 	frameID += 1;

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -28,6 +28,33 @@ struct SceneUniform
 	vec3          sunIlluminance; float _pad2;
 };
 
+class SimpleMovingAverage
+{
+public:
+	void init(uint32 windowSize)
+	{
+		values.resize(windowSize);
+	}
+	void push(float x)
+	{
+		values[currIx] = x;
+		currIx = (currIx + 1) % values.size();
+		itemCount = itemCount + 1;
+		if (itemCount > (uint32)values.size()) itemCount = (uint32)values.size();
+	}
+	float getAverage() const
+	{
+		float avg = 0.0f;
+		for (uint32 i = 0; i < itemCount; ++i) avg += values[i];
+		avg /= (float)itemCount;
+		return avg;
+	}
+private:
+	uint32 itemCount = 0;
+	uint32 currIx = 0;
+	std::vector<float> values;
+};
+
 // Render a 3D scene with hybrid rendering. (rasterization + raytracing)
 class SceneRenderer final : public Renderer
 {
@@ -71,6 +98,7 @@ private:
 	SceneUniform prevSceneUniformData;
 
 	uint32 frameID = 0;
+	SimpleMovingAverage avgRenderTime;
 
 	// ------------------------------------------------------------------------
 	// #todo-renderer: Temporarily manage render targets in the renderer.

--- a/projects/Cyseal/src/rhi/dx12/d3d_render_command.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_render_command.cpp
@@ -400,7 +400,7 @@ void D3DRenderCommandList::setDescriptorHeaps(uint32 count, DescriptorHeap* cons
 }
 
 // #todo-dx12: bindGraphicsShaderParameters(), bindComputeShaderParameters(), and bindRaytracingShaderParameters() are almost same, but a little hard to extract common part.
-void D3DRenderCommandList::bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* inParameters, DescriptorHeap* descriptorHeap)
+void D3DRenderCommandList::bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* inParameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker)
 {
 	D3DGraphicsPipelineState* d3dPipelineState = static_cast<D3DGraphicsPipelineState*>(pipelineState);
 	ID3D12RootSignature* d3dRootSig = d3dPipelineState->getRootSignature();
@@ -438,7 +438,7 @@ void D3DRenderCommandList::bindGraphicsShaderParameters(PipelineState* pipelineS
 
 	// #todo-dx12: Root Descriptor vs Descriptor Table
 	// For now, always use descriptor table.
-	uint32 descriptorIx = 0;
+	uint32 descriptorIx = (tracker == nullptr) ? 0 : tracker->lastIndex;
 
 	for (const auto& inParam : inParameters->_pushConstants)
 	{
@@ -465,6 +465,8 @@ void D3DRenderCommandList::bindGraphicsShaderParameters(PipelineState* pipelineS
 	setRootDescriptorTables(commandList.Get(), inParameters->textures, &descriptorIx);
 	setRootDescriptorTables(commandList.Get(), inParameters->rwTextures, &descriptorIx);
 	CHECK(inParameters->accelerationStructures.size() == 0); // Not allowed in graphics pipeline.
+
+	if (tracker != nullptr) tracker->lastIndex = descriptorIx;
 }
 
 void D3DRenderCommandList::updateGraphicsRootConstants(PipelineState* pipelineState, const ShaderParameterTable* inParameters)

--- a/projects/Cyseal/src/rhi/dx12/d3d_render_command.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_render_command.h
@@ -100,7 +100,7 @@ public:
 	virtual void beginRenderPass() override;
 	virtual void endRenderPass() override;
 
-	virtual void bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap) override;
+	virtual void bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker) override;
 
 	virtual void updateGraphicsRootConstants(PipelineState* pipelineState, const ShaderParameterTable* parameters) override;
 

--- a/projects/Cyseal/src/rhi/dx12/d3d_swap_chain.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_swap_chain.cpp
@@ -161,9 +161,9 @@ void D3DSwapChain::createSwapchainImages()
 	}
 }
 
-void D3DSwapChain::present()
+void D3DSwapChain::present(bool vsync)
 {
-	UINT syncInterval = 1;
+	UINT syncInterval = vsync ? 1 : 0;
 	UINT flags = 0;
 	HRESULT hResult = rawSwapChain->Present(syncInterval, flags);
 

--- a/projects/Cyseal/src/rhi/dx12/d3d_swap_chain.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_swap_chain.h
@@ -41,7 +41,7 @@ public:
 
 	virtual void resize(uint32 newWidth, uint32 newHeight) override;
 
-	virtual void present() override;
+	virtual void present(bool vsync) override;
 	virtual void prepareBackbuffer() override;
 	virtual uint32 getBufferCount() const override { return SWAP_CHAIN_BUFFER_COUNT; }
 

--- a/projects/Cyseal/src/rhi/render_command.h
+++ b/projects/Cyseal/src/rhi/render_command.h
@@ -122,7 +122,7 @@ public:
 	virtual void omSetRenderTarget(RenderTargetView* RTV, DepthStencilView* DSV) = 0;
 	virtual void omSetRenderTargets(uint32 numRTVs, RenderTargetView* const* RTVs, DepthStencilView* DSV) = 0;
 
-	virtual void bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap) = 0;
+	virtual void bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker = nullptr) = 0;
 
 	// When a graphics PSO is already bound, only update root constants for fast path.
 	// - pipelineState must have been bound with bindGraphicsShaderParameters().

--- a/projects/Cyseal/src/rhi/swap_chain.h
+++ b/projects/Cyseal/src/rhi/swap_chain.h
@@ -48,7 +48,7 @@ public:
 
 	virtual void resize(uint32 newWidth, uint32 newHeight) = 0;
 
-	virtual void present() = 0;
+	virtual void present(bool vsync) = 0;
 	virtual void prepareBackbuffer() = 0;
 	virtual uint32 getBufferCount() const = 0;
 

--- a/projects/Cyseal/src/rhi/vulkan/vk_render_command.cpp
+++ b/projects/Cyseal/src/rhi/vulkan/vk_render_command.cpp
@@ -379,7 +379,7 @@ void VulkanRenderCommandList::omSetRenderTargets(uint32 numRTVs, RenderTargetVie
 	currentDSV = DSV;
 }
 
-void VulkanRenderCommandList::bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap)
+void VulkanRenderCommandList::bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker)
 {
 	// #todo-vulkan
 	CHECK_NO_ENTRY();

--- a/projects/Cyseal/src/rhi/vulkan/vk_render_command.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_render_command.h
@@ -97,7 +97,7 @@ public:
 	virtual void omSetRenderTarget(RenderTargetView* RTV, DepthStencilView* DSV) override;
 	virtual void omSetRenderTargets(uint32 numRTVs, RenderTargetView* const* RTVs, DepthStencilView* DSV) override;
 
-	virtual void bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap) override;
+	virtual void bindGraphicsShaderParameters(PipelineState* pipelineState, const ShaderParameterTable* parameters, DescriptorHeap* descriptorHeap, DescriptorIndexTracker* tracker) override;
 
 	virtual void updateGraphicsRootConstants(PipelineState* pipelineState, const ShaderParameterTable* parameters) override;
 

--- a/projects/Cyseal/src/rhi/vulkan/vk_swapchain.cpp
+++ b/projects/Cyseal/src/rhi/vulkan/vk_swapchain.cpp
@@ -299,8 +299,10 @@ void VulkanSwapchain::resize(uint32 newWidth, uint32 newHeight)
 	CHECK_NO_ENTRY();
 }
 
-void VulkanSwapchain::present()
+void VulkanSwapchain::present(bool vsync)
 {
+	// #todo-vulkan: Handle vsync parameter
+
 	VkSemaphore waitSemaphores[] = { deviceWrapper->getVkRenderFinishedSemaphore() };
 	VkSwapchainKHR swapchains[] = { swapchainKHR };
 	uint32 swapchainIndices[] = { backbufferInFlight };

--- a/projects/Cyseal/src/rhi/vulkan/vk_swapchain.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_swapchain.h
@@ -73,7 +73,7 @@ public:
 
 	virtual void resize(uint32 newWidth, uint32 newHeight) override;
 
-	virtual void present() override;
+	virtual void present(bool vsync) override;
 	virtual void prepareBackbuffer() override;
 	virtual uint32 getBufferCount() const override { return swapchainImageCount; }
 

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -152,7 +152,7 @@ void TestApplication::onTick(float deltaSeconds)
 		{
 			wchar_t buf[256];
 			float newFPS = 1.0f / deltaSeconds;
-			// 1 frame time includes 1 interpolated frame + 1 real frame, so not precise but...
+			// #todo-fsr3-present: 1 frame time includes 1 interpolated frame + 1 real frame, so not precise but...
 			if (appState.rendererOptions.bGenerateFrame) newFPS *= 2.0f;
 			framesPerSecond += 0.05f * (newFPS - framesPerSecond);
 			swprintf_s(buf, L"Hello World / FPS: %.2f", framesPerSecond);

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -230,6 +230,8 @@ void TestApplication::onTick(float deltaSeconds)
 		world->onTick(deltaSeconds);
 	}
 
+	renderTimeCounter.start();
+
 	// #todo: Move rendering loop to engine
 	{
 		SCOPED_CPU_EVENT(ExecuteRenderer);
@@ -404,10 +406,13 @@ void TestApplication::onTick(float deltaSeconds)
 		}
 		cysealEngine.renderImgui();
 
+		appState.rendererOptions.prevRenderTime = prevRenderTime;
 		cysealEngine.renderScene(sceneProxy, &camera, appState.rendererOptions);
 
 		delete sceneProxy;
 	}
+
+	prevRenderTime = (float)renderTimeCounter.stopWithMilliseconds();
 }
 
 void TestApplication::onTerminate()

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -149,11 +149,15 @@ void TestApplication::onTick(float deltaSeconds)
 	{
 		SCOPED_CPU_EVENT(WorldLogic);
 
-		wchar_t buf[256];
-		float newFPS = 1.0f / deltaSeconds;
-		framesPerSecond += 0.05f * (newFPS - framesPerSecond);
-		swprintf_s(buf, L"Hello World / FPS: %.2f", framesPerSecond);
-		setWindowTitle(std::wstring(buf));
+		{
+			wchar_t buf[256];
+			float newFPS = 1.0f / deltaSeconds;
+			// 1 frame time includes 1 interpolated frame + 1 real frame, so not precise but...
+			if (appState.rendererOptions.bGenerateFrame) newFPS *= 2.0f;
+			framesPerSecond += 0.05f * (newFPS - framesPerSecond);
+			swprintf_s(buf, L"Hello World / FPS: %.2f", framesPerSecond);
+			setWindowTitle(std::wstring(buf));
+		}
 
 		// Control camera by user input.
 		bool bCameraHasMoved = false;

--- a/projects/TestApplication/src/app.h
+++ b/projects/TestApplication/src/app.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/win/windows_application.h"
+#include "core/high_freq_counter.h"
 #include "render/renderer_options.h"
 #include "world/scene.h"
 #include "world/camera.h"
@@ -50,4 +51,7 @@ private:
 	uint32 newViewportHeight = 0;
 
 	float framesPerSecond = 0.0f;
+
+	float prevRenderTime = 0.0f;
+	HighFrequencyCounter renderTimeCounter;
 };


### PR DESCRIPTION
Frame Generation
- Use tone mapped color in frame generation.
- Present interpolated frames. Since I don't use FidelityFX's FG swapchain logic, simply render real frame and interpolated frame at once in a single render() call, present the interpolated frame without vsync, sleep for a certain amount of time, present the real frame with vsync on. The sleep time is calculated using Simple Moving Average for smooth frame pacing.

Misc
- Add HighFrequencyCounter class.
- Allow running FinalBlitPass multiple times per frame.
- Add DescriptorIndexTracker* parameter to RenderCommand::bindGraphicsShaderParameters().
- Add vsync parameter to SwapChain::present().
