### PR TITLE
Feature/106 Fix swapchain index when frame generation is on

### DIFF
--- a/projects/Cyseal/src/core/engine.cpp
+++ b/projects/Cyseal/src/core/engine.cpp
@@ -33,6 +33,38 @@
 
 DEFINE_LOG_CATEGORY(LogEngine);
 
+CysealEngine* gEngine = nullptr;
+
+// ---------------------------------------------------------------------
+// EnqueueCustomRenderCommand
+
+EnqueueCustomRenderCommand::EnqueueCustomRenderCommand(RenderCommandList::CustomCommandType inLambda)
+{
+	gEngine->enqueueCustomRenderCommand(inLambda);
+}
+
+#if 0
+FlushRenderCommands::FlushRenderCommands()
+{
+	uint32 swapchainIx = gRenderDevice->getSwapChain()->getCurrentBackbufferIndex();
+
+	RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(swapchainIx);
+	RenderCommandList* commandList = gRenderDevice->getCommandList(swapchainIx);
+	RenderCommandQueue* commandQueue = gRenderDevice->getCommandQueue();
+
+	commandAllocator->reset();
+	commandList->reset(commandAllocator);
+	commandList->executeCustomCommands();
+	commandList->close();
+	commandQueue->executeCommandList(commandList);
+
+	gRenderDevice->flushCommandQueue();
+}
+#endif
+
+// ---------------------------------------------------------------------
+// CysealEngine
+
 CysealEngine::~CysealEngine()
 {
 	CHECK(state == EEngineState::SHUTDOWN);
@@ -55,6 +87,10 @@ void CysealEngine::startup(const CysealEngineCreateParams& inCreateParams)
 
 	// Core
 	createRenderDevice(createParams.renderDevice); // gRenderDevice is now available.
+
+	// #todo: Ideally do this at the end so that subsystems do not access gEngine at their initialization,
+	// but subsystems that use ENQUEUE_RENDER_COMMAND requires gEngine :(
+	gEngine = this;
 
 	// Subsystems
 	{
@@ -157,6 +193,8 @@ void CysealEngine::shutdown()
 	// Shutdown is finished.
 	state = EEngineState::SHUTDOWN;
 
+	gEngine = nullptr;
+
 	CYLOG(LogEngine, Log, TEXT("Engine has been fully terminated."));
 }
 
@@ -190,7 +228,14 @@ void CysealEngine::renderScene(SceneProxy* sceneProxy, Camera* camera, const Ren
 {
 	CHECK(state == EEngineState::RUNNING);
 
+	renderer->enqueueCustomCommands(std::move(customRenderCommands));
+	customRenderCommands.clear();
 	renderer->render(sceneProxy, camera, rendererOptions);
+}
+
+void CysealEngine::enqueueCustomRenderCommand(RenderCommandList::CustomCommandType inLambda)
+{
+	customRenderCommands.push_back(inLambda);
 }
 
 void CysealEngine::setRenderResolution(uint32 newWidth, uint32 newHeight)

--- a/projects/Cyseal/src/core/engine.h
+++ b/projects/Cyseal/src/core/engine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rhi/render_device.h"
+#include "rhi/render_command.h"
 #include "render/renderer.h"
 #include "core/int_types.h"
 #include "util/logging.h"
@@ -22,6 +23,31 @@ struct CysealEngineCreateParams
 	RenderDeviceCreateParams renderDevice;
 	ERendererType rendererType;
 };
+
+// #todo-renderer: Currently every custom commands are executed prior to whole internal rendering pipeline.
+// Needs a lambda wrapper for each internal command for perfect queueing.
+struct EnqueueCustomRenderCommand
+{
+	EnqueueCustomRenderCommand(RenderCommandList::CustomCommandType inLambda);
+};
+
+// Enqueues custom render commands that will be executed at next frame rendering.
+// Search for executeCustomCommands() from SceneRenderer or NullRenderer.
+// Only works if render device is not headless and renderer is running.
+#define ENQUEUE_RENDER_COMMAND(CommandName) EnqueueCustomRenderCommand CommandName
+
+#if 0
+// #todo-rendercommand: Resets the list and only executes custom commands registered so far.
+// Just a hack due to incomplete render command list support.
+struct FlushRenderCommands
+{
+	FlushRenderCommands();
+};
+
+#define FLUSH_RENDER_COMMANDS_INTERNAL(x, y) x ## y
+#define FLUSH_RENDER_COMMANDS_INTERNAL2(x, y) FLUSH_RENDER_COMMANDS_INTERNAL(x, y)
+#define FLUSH_RENDER_COMMANDS() FlushRenderCommands FLUSH_RENDER_COMMANDS_INTERNAL2(flushRenderCommands_, __LINE__)
+#endif
 
 class CysealEngine final
 {
@@ -68,6 +94,9 @@ public:
 
 	void renderScene(SceneProxy* sceneProxy, Camera* camera, const RendererOptions& rendererOptions);
 
+	// Enqueue a command that will be executed in the next execution of the renderer.
+	void enqueueCustomRenderCommand(RenderCommandList::CustomCommandType inLambda);
+
 private:
 	void createRenderDevice(const RenderDeviceCreateParams& createParams);
 	void createRenderer(ERendererType rendererType);
@@ -79,4 +108,8 @@ private:
 
 	RenderDevice* renderDevice = nullptr;
 	Renderer* renderer = nullptr;
+
+	std::vector<RenderCommandList::CustomCommandType> customRenderCommands;
 };
+
+extern CysealEngine* gEngine;

--- a/projects/Cyseal/src/render/null_renderer.cpp
+++ b/projects/Cyseal/src/render/null_renderer.cpp
@@ -8,6 +8,7 @@
 void NullRenderer::initialize(RenderDevice* renderDevice)
 {
 	device = renderDevice;
+	frameID = 0;
 }
 
 void NullRenderer::destroy()
@@ -22,7 +23,7 @@ void NullRenderer::render(const SceneProxy* scene, const Camera* camera, const R
 	SwapChain* swapChain      = device->getSwapChain();
 	swapChain->prepareBackbuffer();
 
-	uint32 swapchainIndex     = swapChain->getCurrentBackbufferIndex();
+	uint32 swapchainIndex     = (frameID % device->maxFramesInFlight());
 	auto swapchainBuffer      = swapChain->getSwapchainBuffer(swapchainIndex);
 	auto swapchainBufferRTV   = swapChain->getSwapchainBufferRTV(swapchainIndex);
 	auto commandAllocator     = device->getCommandAllocator(swapchainIndex);
@@ -32,7 +33,11 @@ void NullRenderer::render(const SceneProxy* scene, const Camera* camera, const R
 	commandAllocator->reset();
 	commandList->reset(commandAllocator);
 
-	commandList->executeCustomCommands();
+	for (RenderCommandList::CustomCommandType lambda : customCommands)
+	{
+		lambda(*commandList);
+	}
+	customCommands.clear();
 
 	TextureBarrierAuto renderToBackbufferBarrier = {
 		EBarrierSync::RENDER_TARGET, EBarrierAccess::RENDER_TARGET, EBarrierLayout::RenderTarget,
@@ -82,4 +87,11 @@ void NullRenderer::render(const SceneProxy* scene, const Camera* camera, const R
 
 	commandList->executeDeferredDealloc();
 #endif
+	
+	frameID += 1;
+}
+
+void NullRenderer::enqueueCustomCommands(std::vector<RenderCommandList::CustomCommandType>&& inCommands)
+{
+	customCommands = inCommands;
 }

--- a/projects/Cyseal/src/render/null_renderer.h
+++ b/projects/Cyseal/src/render/null_renderer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "renderer.h"
+#include "rhi/render_command.h"
 
 // Renders nothing.
 class NullRenderer : public Renderer
@@ -12,6 +13,11 @@ public:
 
 	virtual void recreateSceneTextures(uint32 sceneWidth, uint32 sceneHeight) override {}
 
+	virtual void enqueueCustomCommands(std::vector<RenderCommandList::CustomCommandType>&& inCommands) override;
+
 private:
 	RenderDevice* device = nullptr;
+	uint32 frameID = 0;
+
+	std::vector<RenderCommandList::CustomCommandType> customCommands;
 };

--- a/projects/Cyseal/src/render/renderer.h
+++ b/projects/Cyseal/src/render/renderer.h
@@ -2,8 +2,11 @@
 
 #include "renderer_options.h"
 #include "rhi/render_device.h"
+#include "rhi/render_command.h"
 #include "world/camera.h"
 #include "world/scene_proxy.h"
+
+#include <vector>
 
 class Renderer
 {
@@ -15,4 +18,6 @@ public:
 	virtual void render(const SceneProxy* scene, const Camera* camera, const RendererOptions& renderOptions) = 0;
 
 	virtual void recreateSceneTextures(uint32 sceneWidth, uint32 sceneHeight) = 0;
+
+	virtual void enqueueCustomCommands(std::vector<RenderCommandList::CustomCommandType>&& inCommands) = 0;
 };

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -173,17 +173,15 @@ void SceneRenderer::destroy()
 
 void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const RendererOptions& renderOptions)
 {
-	bool bRenderToBackbuffer = renderOptions.renderToBackbuffer();
+	const bool bRenderToBackbuffer = renderOptions.renderToBackbuffer();
 
-	// #todo-renderer: Refactor swapchainIndex.
-	// - I'm using swapchainIndex for buffered resources in various render passes,
-	//   but they are not really related to specific swapchain index anymore.
-	// - By introduction of frame generation, they became even more irrelevant because 'current backbuffer index'
-	//   now changes twice per render().
-	uint32            swapchainIndex     = 0;
+	// #wip: Rename realSwapchainIndex and swapchainIndex...
+	uint32            realSwapchainIndex     = 0;
 	SwapChain*        swapChain          = nullptr;
 	SwapChainImage*   swapchainBuffer    = nullptr;
 	RenderTargetView* swapchainBufferRTV = nullptr;
+
+	uint32            swapchainIndex = (frameID % device->maxFramesInFlight());
 
 	if (bRenderToBackbuffer)
 	{
@@ -192,9 +190,9 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		swapChain->prepareBackbuffer();
 
-		swapchainIndex     = swapChain->getCurrentBackbufferIndex();
-		swapchainBuffer    = swapChain->getSwapchainBuffer(swapchainIndex);
-		swapchainBufferRTV = swapChain->getSwapchainBufferRTV(swapchainIndex);
+		realSwapchainIndex = swapChain->getCurrentBackbufferIndex();
+		swapchainBuffer    = swapChain->getSwapchainBuffer(realSwapchainIndex);
+		swapchainBufferRTV = swapChain->getSwapchainBufferRTV(realSwapchainIndex);
 	}
 
 	auto commandAllocator  = device->getCommandAllocator(swapchainIndex);
@@ -261,7 +259,11 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	// Just execute prior to any standard renderer works.
 	// If some custom commands should execute in midst of frame rendering,
 	// I need to insert delegates here and there of this SceneRenderer::render() function.
-	commandList->executeCustomCommands();
+	for (RenderCommandList::CustomCommandType lambda : customCommands)
+	{
+		lambda(*commandList);
+	}
+	customCommands.clear();
 
 	// #todo-renderer: In future each render pass might write to RTs of different dimensions.
 	// Currently all passes work at full resolution.
@@ -1130,9 +1132,9 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			{
 				swapChain->prepareBackbuffer();
 
-				swapchainIndex     = swapChain->getCurrentBackbufferIndex();
-				swapchainBuffer    = swapChain->getSwapchainBuffer(swapchainIndex);
-				swapchainBufferRTV = swapChain->getSwapchainBufferRTV(swapchainIndex);
+				realSwapchainIndex = swapChain->getCurrentBackbufferIndex();
+				swapchainBuffer    = swapChain->getSwapchainBuffer(realSwapchainIndex);
+				swapchainBufferRTV = swapChain->getSwapchainBufferRTV(realSwapchainIndex);
 
 				finalBlitTarget    = swapchainBuffer;
 				finalBlitRTV       = swapchainBufferRTV;
@@ -1666,6 +1668,11 @@ void SceneRenderer::recreateSceneTextures(uint32 sceneWidth, uint32 sceneHeight)
 			},
 		}
 	));
+}
+
+void SceneRenderer::enqueueCustomCommands(std::vector<RenderCommandList::CustomCommandType>&& inCommands)
+{
+	customCommands = inCommands;
 }
 
 void SceneRenderer::resetCommandList(RenderCommandAllocator* commandAllocator, RenderCommandList* commandList)

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -195,13 +195,12 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 		acquireSwapchainResources(swapchainBuffer, swapchainBufferRTV);
 	}
 
-	// #todo-renderer: The length of all buffered resources in each render pass is 2 for now, so I can just modulo 2 here.
-	// Ideally, I just pass frameID to render passes and they do modulo themselves, if I ever have a buffered resource of length >= 3.
-	const uint32 frameIndex = (frameID % 2);
+	// #todo-renderer: Ideally, I just pass frameID to render passes and they do modulo themselves.
+	const uint32 frameIndex = (frameID % device->maxFramesInFlight());
 
-	auto commandAllocator   = device->getCommandAllocator(frameIndex);
-	auto commandList        = device->getCommandList(frameIndex);
-	auto commandQueue       = device->getCommandQueue();
+	auto commandAllocator     = device->getCommandAllocator(frameIndex);
+	auto commandList          = device->getCommandList(frameIndex);
+	auto commandQueue         = device->getCommandQueue();
 
 	createFinalBlitRTV(commandList, renderOptions);
 

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -175,13 +175,15 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 {
 	const bool bRenderToBackbuffer = renderOptions.renderToBackbuffer();
 
-	// #wip: Rename realSwapchainIndex and swapchainIndex...
-	uint32            realSwapchainIndex     = 0;
 	SwapChain*        swapChain          = nullptr;
 	SwapChainImage*   swapchainBuffer    = nullptr;
 	RenderTargetView* swapchainBufferRTV = nullptr;
 
-	uint32            swapchainIndex = (frameID % device->maxFramesInFlight());
+	auto acquireSwapchainResources = [&](SwapChainImage*& outBuffer, RenderTargetView*& outRTV) {
+		uint32 swapchainIndex = swapChain->getCurrentBackbufferIndex();
+		outBuffer = swapChain->getSwapchainBuffer(swapchainIndex);
+		outRTV = swapChain->getSwapchainBufferRTV(swapchainIndex);
+	};
 
 	if (bRenderToBackbuffer)
 	{
@@ -190,14 +192,16 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		swapChain->prepareBackbuffer();
 
-		realSwapchainIndex = swapChain->getCurrentBackbufferIndex();
-		swapchainBuffer    = swapChain->getSwapchainBuffer(realSwapchainIndex);
-		swapchainBufferRTV = swapChain->getSwapchainBufferRTV(realSwapchainIndex);
+		acquireSwapchainResources(swapchainBuffer, swapchainBufferRTV);
 	}
 
-	auto commandAllocator  = device->getCommandAllocator(swapchainIndex);
-	auto commandList       = device->getCommandList(swapchainIndex);
-	auto commandQueue      = device->getCommandQueue();
+	// #todo-renderer: The length of all buffered resources in each render pass is 2 for now, so I can just modulo 2 here.
+	// Ideally, I just pass frameID to render passes and they do modulo themselves, if I ever have a buffered resource of length >= 3.
+	const uint32 frameIndex = (frameID % 2);
+
+	auto commandAllocator   = device->getCommandAllocator(frameIndex);
+	auto commandList        = device->getCommandList(frameIndex);
+	auto commandQueue       = device->getCommandQueue();
 
 	createFinalBlitRTV(commandList, renderOptions);
 
@@ -250,7 +254,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 	const bool bRenderFrameGeneration = renderOptions.bGenerateFrame && !bRenderPathTracing && bRenderToBackbuffer;
 
-	clearResourcePass->prepareForFrame(swapchainIndex);
+	clearResourcePass->prepareForFrame(frameIndex);
 
 	rebuildFrameResources(commandList, scene);
 
@@ -284,8 +288,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	commandList->rsSetViewport(fullscreenViewport);
 	commandList->rsSetScissorRect(fullscreenScissorRect);
 
-	updateSceneUniform(commandList, swapchainIndex, scene, camera, sceneWidth, sceneHeight);
-	auto sceneUniformCBV = sceneUniformCBVs.at(swapchainIndex);
+	updateSceneUniform(commandList, frameIndex, scene, camera, sceneWidth, sceneHeight);
+	auto sceneUniformCBV = sceneUniformCBVs.at(frameIndex);
 
 	{
 		SCOPED_DRAW_EVENT(commandList, GPUScene);
@@ -294,8 +298,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.scene  = scene,
 			.camera = camera,
 		};
-		gpuScene->renderGPUScene(commandList, swapchainIndex, passInput);
-		gpuScene->generateDrawcalls(commandList, swapchainIndex, passInput);
+		gpuScene->renderGPUScene(commandList, frameIndex, passInput);
+		gpuScene->generateDrawcalls(commandList, frameIndex, passInput);
 	}
 
 	if (renderOptions.bEnableGPUCulling)
@@ -395,7 +399,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.gpuScene           = gpuScene,
 			.gpuCulling         = gpuCulling,
 		};
-		depthPrepass->renderDepthPrepass(commandList, swapchainIndex, passInput);
+		depthPrepass->renderDepthPrepass(commandList, frameIndex, passInput);
 	}
 
 	if (bRenderVisibilityBuffer)
@@ -419,7 +423,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.visGBuffer1UAV     = visGbufferUAVs[1].get(),
 		};
 
-		decodeVisBufferPass->decodeVisBuffer(commandList, swapchainIndex, passInput);
+		decodeVisBufferPass->decodeVisBuffer(commandList, frameIndex, passInput);
 	}
 
 	// Ray Traced Shadows
@@ -462,7 +466,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.raytracingScene    = accelStructure.get(),
 			.shadowMaskUAV      = shadowMaskUAV.get(),
 		};
-		rayTracedShadowsPass->renderRayTracedShadows(commandList, swapchainIndex, passInput);
+		rayTracedShadowsPass->renderRayTracedShadows(commandList, frameIndex, passInput);
 	}
 
 	// Base pass
@@ -519,7 +523,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.gpuCulling         = gpuCulling,
 			.shadowMaskSRV      = shadowMaskSRV.get(),
 		};
-		basePass->renderBasePass(commandList, swapchainIndex, passInput);
+		basePass->renderBasePass(commandList, frameIndex, passInput);
 	}
 
 	Texture* currentGBufferTexture0 = nullptr;
@@ -553,7 +557,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.gbuffer0SRV          = currentGBufferSRV0,
 			.gbuffer1SRV          = currentGBufferSRV1,
 		};
-		storeHistoryPass->extractCurrent(commandList, swapchainIndex, passInput);
+		storeHistoryPass->extractCurrent(commandList, frameIndex, passInput);
 	}
 
 	// HiZ pass
@@ -569,7 +573,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.hizSRV            = hizSRV.get(),
 			.hizUAVs           = hizUAVs,
 		};
-		hizPass->renderHiZ(commandList, swapchainIndex, passInput);
+		hizPass->renderHiZ(commandList, frameIndex, passInput);
 	}
 
 	// Sky pass
@@ -583,7 +587,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.sceneUniformBuffer = sceneUniformCBV,
 			.skyboxSRV          = skyboxSRV.get(),
 		};
-		skyPass->renderSky(commandList, swapchainIndex, passInput);
+		skyPass->renderSky(commandList, frameIndex, passInput);
 	}
 
 	// Path Tracing
@@ -624,7 +628,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.gbuffer1SRV           = currentGBufferSRV1,
 				.skyboxSRV             = skyboxSRV.get(),
 			};
-			pathTracingPass->renderPathTracing(commandList, swapchainIndex, passInput);
+			pathTracingPass->renderPathTracing(commandList, frameIndex, passInput);
 		}
 	}
 	// Path Tracing Denoising
@@ -651,7 +655,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 					.gbuffer0SRV   = currentGBufferSRV0,
 					.gbuffer1SRV   = currentGBufferSRV1,
 				};
-				denoiserPluginPass->blitTextures(commandList, swapchainIndex, passInput);
+				denoiserPluginPass->blitTextures(commandList, frameIndex, passInput);
 			}
 			{
 				SCOPED_DRAW_EVENT(commandList, FlushCommandQueue);
@@ -718,7 +722,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.indirectDiffuseTexture = RT_indirectDiffuse.get(),
 			.indirectDiffuseUAV     = indirectDiffuseUAV.get(),
 		};
-		indirectDiffusePass->renderIndirectDiffuse(commandList, swapchainIndex, passInput);
+		indirectDiffusePass->renderIndirectDiffuse(commandList, frameIndex, passInput);
 	}
 
 	// Indirect Specular Reflection
@@ -742,7 +746,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		SCOPED_DRAW_EVENT(commandList, IndirectSpecular);
 
-		StoreHistoryPassResources historyResources = storeHistoryPass->getResources(swapchainIndex);
+		StoreHistoryPassResources historyResources = storeHistoryPass->getResources(frameIndex);
 		
 		IndirectSpecularInput passInput{
 			.scene                   = scene,
@@ -785,7 +789,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.tileCounterBufferUAV    = indirectSpecularTileCounterBufferUAV.get(),
 			.indirectSpecularTexture = RT_indirectSpecular.get(),
 		};
-		indirectSpecularPass->renderIndirectSpecular(commandList, swapchainIndex, passInput);
+		indirectSpecularPass->renderIndirectSpecular(commandList, frameIndex, passInput);
 	}
 
 	if (!bRenderPathTracing)
@@ -807,7 +811,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.indirectSpecularTexture = RT_indirectSpecular.get(),
 			.indirectSpecularSRV     = indirectSpecularSRV.get(),
 		};
-		combineLightingPass->combineLighting(commandList, swapchainIndex, passInput);
+		combineLightingPass->combineLighting(commandList, frameIndex, passInput);
 	}
 
 	// Store history pass (step 2)
@@ -828,7 +832,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		commandList->copyTexture2D(RT_sceneDepth.get(), RT_prevSceneDepth.get());
 
-		storeHistoryPass->copyCurrentToPrev(commandList, swapchainIndex);
+		storeHistoryPass->copyCurrentToPrev(commandList, frameIndex);
 	}
 
 	// Set final color as render target.
@@ -869,7 +873,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.sceneUniformCBV     = sceneUniformCBV,
 			.sceneColorSRV       = alternateSceneColorSRV,
 		};
-		toneMapping->renderToneMapping(commandList, swapchainIndex, passInput);
+		toneMapping->renderToneMapping(commandList, frameIndex, passInput);
 	}
 
 	OpticalFlowPassOutput opticalFlowPassOutput{};
@@ -903,7 +907,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.sceneColorTexture  = frameGenInputColorTexture,
 				.sceneColorSRV      = frameGenInputColorSRV,
 			};
-			opticalFlowPassOutput = opticalFlowPass->runOpticalFlow(commandList, swapchainIndex, passInput);
+			opticalFlowPassOutput = opticalFlowPass->runOpticalFlow(commandList, frameIndex, passInput);
 		}
 		{
 			SCOPED_DRAW_EVENT(commandList, FrameGeneration);
@@ -935,7 +939,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.motionVectorTexture        = RT_velocityMap.get(),
 				.motionVectorSRV            = velocityMapSRV.get(),
 			};
-			frameGenPassOutput = frameGenPass->runFrameGeneration(commandList, swapchainIndex, passInput);
+			frameGenPassOutput = frameGenPass->runFrameGeneration(commandList, frameIndex, passInput);
 		}
 	}
 
@@ -989,7 +993,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			.interpolatedFrameSRV   = bRenderFrameGeneration ? frameGenPassOutput.interpolatedFrameSRV : grey2DSRV.get(),
 		};
 
-		bufferVisualization->renderVisualization(commandList, swapchainIndex, sources);
+		bufferVisualization->renderVisualization(commandList, frameIndex, sources);
 	}
 
 	// Flush GPU before present work.
@@ -1077,7 +1081,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 				.renderTarget       = renderOptions.finalRenderTarget,
 				.finalSceneColorSRV = presentInfo.colorSRV,
 			};
-			finalBlitPass->renderFinalBlit(commandList, swapchainIndex, passInput);
+			finalBlitPass->renderFinalBlit(commandList, frameIndex, passInput);
 		}
 
 		// Dear Imgui: Record commands
@@ -1132,9 +1136,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			{
 				swapChain->prepareBackbuffer();
 
-				realSwapchainIndex = swapChain->getCurrentBackbufferIndex();
-				swapchainBuffer    = swapChain->getSwapchainBuffer(realSwapchainIndex);
-				swapchainBufferRTV = swapChain->getSwapchainBufferRTV(realSwapchainIndex);
+				acquireSwapchainResources(swapchainBuffer, swapchainBufferRTV);
 
 				finalBlitTarget    = swapchainBuffer;
 				finalBlitRTV       = swapchainBufferRTV;
@@ -1695,7 +1697,7 @@ void SceneRenderer::immediateFlushCommandQueue(RenderCommandQueue* commandQueue,
 
 void SceneRenderer::updateSceneUniform(
 	RenderCommandList* commandList,
-	uint32 swapchainIndex,
+	uint32 frameIndex,
 	const SceneProxy* scene,
 	const Camera* camera,
 	uint32 sceneWidth,
@@ -1729,7 +1731,7 @@ void SceneRenderer::updateSceneUniform(
 	sceneUniformData.sunDirection                  = scene->sun.direction;
 	sceneUniformData.sunIlluminance                = scene->sun.illuminance;
 	
-	sceneUniformCBVs[swapchainIndex]->writeToGPU(commandList, &sceneUniformData, sizeof(sceneUniformData));
+	sceneUniformCBVs[frameIndex]->writeToGPU(commandList, &sceneUniformData, sizeof(sceneUniformData));
 
 	memcpy_s(&prevSceneUniformData, sizeof(SceneUniform), &sceneUniformData, sizeof(SceneUniform));
 

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -82,7 +82,7 @@ private:
 	void resetCommandList(RenderCommandAllocator* commandAllocator, RenderCommandList* commandList);
 	void immediateFlushCommandQueue(RenderCommandQueue* commandQueue, RenderCommandAllocator* commandAllocator, RenderCommandList* commandList);
 
-	void updateSceneUniform(RenderCommandList* commandList, uint32 swapchainIndex, const SceneProxy* scene, const Camera* camera, uint32 sceneWidth, uint32 sceneHeight);
+	void updateSceneUniform(RenderCommandList* commandList, uint32 frameIndex, const SceneProxy* scene, const Camera* camera, uint32 sceneWidth, uint32 sceneHeight);
 
 	void rebuildFrameResources(RenderCommandList* commandList, const SceneProxy* scene);
 

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -75,6 +75,8 @@ public:
 	/// <param name="sceneWidth">Width of new render resolution.</param>
 	/// <param name="sceneHeight">Height of new render resolution.</param>
 	virtual void recreateSceneTextures(uint32 sceneWidth, uint32 sceneHeight) override;
+
+	virtual void enqueueCustomCommands(std::vector<RenderCommandList::CustomCommandType>&& inCommands) override;
 	
 private:
 	void resetCommandList(RenderCommandAllocator* commandAllocator, RenderCommandList* commandList);
@@ -90,6 +92,8 @@ private:
 
 private:
 	RenderDevice* device = nullptr;
+
+	std::vector<RenderCommandList::CustomCommandType> customCommands;
 
 	struct DeferredCleanup { GPUResource* resource; /*uint32 count;*/ }; // Don't remember why I put 'count' there...?
 	std::vector<DeferredCleanup> deferredCleanupList;

--- a/projects/Cyseal/src/rhi/dx12/d3d_device.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_device.cpp
@@ -830,13 +830,3 @@ void D3DDevice::copyDescriptors(
 
 	device->CopyDescriptorsSimple(numDescriptors, destHandle, srcHandle, into_d3d::descriptorHeapType(dstType));
 }
-
-RenderCommandList* D3DDevice::getCommandListForCustomCommand() const
-{
-	uint32 swapchainIx = getCreateParams().swapChainParams.bHeadless
-		? 0
-		: getSwapChain()->getCurrentBackbufferIndex();
-
-	RenderCommandList* commandList = getCommandList(swapchainIx);
-	return commandList;
-}

--- a/projects/Cyseal/src/rhi/dx12/d3d_device.h
+++ b/projects/Cyseal/src/rhi/dx12/d3d_device.h
@@ -102,8 +102,6 @@ public:
 	// ------------------------------------------------------------------------
 	// Getters
 
-	virtual RenderCommandList* getCommandListForCustomCommand() const override;
-
 	virtual uint32 getMultiSampleQuality(EMultiSampleLevel level) const override { return msaaQualityLevels[(uint32)level]; }
 	virtual bool supportsMultiSampleLevel(EMultiSampleLevel level) const override { return msaaQualityLevels[(uint32)level] > 0; }
 	

--- a/projects/Cyseal/src/rhi/render_command.cpp
+++ b/projects/Cyseal/src/rhi/render_command.cpp
@@ -2,23 +2,6 @@
 #include "render_device.h"
 #include "swap_chain.h"
 
-// ---------------------------------------------------------------------
-// RenderCommandList
-
-void RenderCommandList::enqueueCustomCommand(CustomCommandType lambda)
-{
-	customCommands.push_back(lambda);
-}
-
-void RenderCommandList::executeCustomCommands()
-{
-	for (CustomCommandType lambda : customCommands)
-	{
-		lambda(*this);
-	}
-	customCommands.clear();
-}
-
 void RenderCommandList::executeDeferredDealloc()
 {
 	for (auto deallocFn : deferredDeallocs)
@@ -27,31 +10,3 @@ void RenderCommandList::executeDeferredDealloc()
 	}
 	deferredDeallocs.clear();
 }
-
-// ---------------------------------------------------------------------
-// EnqueueCustomRenderCommand
-
-EnqueueCustomRenderCommand::EnqueueCustomRenderCommand(RenderCommandList::CustomCommandType inLambda)
-{
-	RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
-	commandList->enqueueCustomCommand(inLambda);
-}
-
-#if 0
-FlushRenderCommands::FlushRenderCommands()
-{
-	uint32 swapchainIx = gRenderDevice->getSwapChain()->getCurrentBackbufferIndex();
-
-	RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(swapchainIx);
-	RenderCommandList* commandList = gRenderDevice->getCommandList(swapchainIx);
-	RenderCommandQueue* commandQueue = gRenderDevice->getCommandQueue();
-
-	commandAllocator->reset();
-	commandList->reset(commandAllocator);
-	commandList->executeCustomCommands();
-	commandList->close();
-	commandQueue->executeCommandList(commandList);
-
-	gRenderDevice->flushCommandQueue();
-}
-#endif

--- a/projects/Cyseal/src/rhi/render_command.h
+++ b/projects/Cyseal/src/rhi/render_command.h
@@ -186,11 +186,6 @@ public:
 	virtual void beginEventMarker(const char* eventName) = 0; // For GPU debuggers
 	virtual void endEventMarker() = 0;
 
-	void enqueueCustomCommand(CustomCommandType lambda);
-	void executeCustomCommands();
-
-	inline bool hasCustomCommands() const { return customCommands.size() > 0; }
-
 	template<typename T>
 	void enqueueDeferredDealloc(T* addrToDelete, bool ignoreNullPtr = false)
 	{
@@ -211,31 +206,6 @@ private:
 	std::vector<CustomCommandType> customCommands;
 	std::vector<std::function<void()>> deferredDeallocs; // Free'd after all GPU works for this command list is done.
 };
-
-// #todo-rendercommand: Currently every custom commands are executed prior to whole internal rendering pipeline.
-// Needs a lambda wrapper for each internal command for perfect queueing.
-struct EnqueueCustomRenderCommand
-{
-	EnqueueCustomRenderCommand(RenderCommandList::CustomCommandType inLambda);
-};
-
-// Enqueues custom render commands that will be executed at next frame rendering.
-// Search for executeCustomCommands() from SceneRenderer or NullRenderer.
-// Only works if render device is not headless and renderer is running.
-#define ENQUEUE_RENDER_COMMAND(CommandName) EnqueueCustomRenderCommand CommandName
-
-#if 0
-// #todo-rendercommand: Resets the list and only executes custom commands registered so far.
-// Just a hack due to incomplete render command list support.
-struct FlushRenderCommands
-{
-	FlushRenderCommands();
-};
-
-#define FLUSH_RENDER_COMMANDS_INTERNAL(x, y) x ## y
-#define FLUSH_RENDER_COMMANDS_INTERNAL2(x, y) FLUSH_RENDER_COMMANDS_INTERNAL(x, y)
-#define FLUSH_RENDER_COMMANDS() FlushRenderCommands FLUSH_RENDER_COMMANDS_INTERNAL2(flushRenderCommands_, __LINE__)
-#endif
 
 struct ScopedDrawEvent
 {

--- a/projects/Cyseal/src/rhi/render_device.h
+++ b/projects/Cyseal/src/rhi/render_device.h
@@ -202,8 +202,6 @@ public:
 	inline RenderCommandList* getCommandList(uint32 swapchainIndex) const { return commandLists[swapchainIndex]; }
 	inline RenderCommandQueue* getCommandQueue() const { return commandQueue; }
 
-	virtual RenderCommandList* getCommandListForCustomCommand() const = 0;
-
 	virtual uint32 getMultiSampleQuality(EMultiSampleLevel level) const = 0;
 	virtual bool supportsMultiSampleLevel(EMultiSampleLevel level) const = 0;
 

--- a/projects/Cyseal/src/rhi/texture_manager.cpp
+++ b/projects/Cyseal/src/rhi/texture_manager.cpp
@@ -2,6 +2,7 @@
 #include "render_device.h"
 #include "render_command.h"
 #include "gpu_resource.h"
+#include "core/engine.h"
 #include "core/assertion.h"
 #include "util/resource_finder.h"
 #include "loader/image_loader.h"

--- a/projects/Cyseal/src/rhi/vulkan/vk_device.cpp
+++ b/projects/Cyseal/src/rhi/vulkan/vk_device.cpp
@@ -1496,23 +1496,6 @@ void VulkanDevice::copyDescriptors(
 	CHECK_NO_ENTRY();
 }
 
-RenderCommandList* VulkanDevice::getCommandListForCustomCommand() const
-{
-	const bool bHeadless = getCreateParams().swapChainParams.bHeadless;
-
-	uint32 swapchainIx = bHeadless
-		? 0
-		: getSwapChain()->getCurrentBackbufferIndex();
-
-	if (!bHeadless && getSwapChain()->getCurrentBackbufferIndex() == 0xffffffff)
-	{
-		swapchainIx = 0;
-	}
-
-	RenderCommandList* commandList = getCommandList(swapchainIx);
-	return commandList;
-}
-
 void VulkanDevice::beginVkDebugMarker(
 	VkCommandBuffer& cmdBuffer,
 	const char* debugName,

--- a/projects/Cyseal/src/rhi/vulkan/vk_device.h
+++ b/projects/Cyseal/src/rhi/vulkan/vk_device.h
@@ -105,8 +105,6 @@ public:
 	// ------------------------------------------------------------------------
 	// Getters
 
-	virtual RenderCommandList* getCommandListForCustomCommand() const override;
-
 	virtual uint32 getMultiSampleQuality(EMultiSampleLevel level) const override { return msaaQualityLevels[(uint32)level]; }
 	virtual bool supportsMultiSampleLevel(EMultiSampleLevel level) const override { return msaaQualityLevels[(uint32)level] > 0; }
 

--- a/projects/UnitTest/src/render/TestGpuDriven.cpp
+++ b/projects/UnitTest/src/render/TestGpuDriven.cpp
@@ -258,7 +258,7 @@ private:
 
 	RenderCommandList* beginRendering()
 	{
-		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandList* commandList = gRenderDevice->getCommandList(0);
 		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
 
 		commandList->reset(commandAllocator);

--- a/projects/UnitTest/src/render/TestImageComparison.cpp
+++ b/projects/UnitTest/src/render/TestImageComparison.cpp
@@ -131,7 +131,7 @@ namespace UnitTest
 	private:
 		RenderCommandList* getCommandList()
 		{
-			return renderDevice->getCommandListForCustomCommand();
+			return renderDevice->getCommandList(0);
 		}
 		void beginRendering()
 		{

--- a/projects/UnitTest/src/render/TestIndirectDiffuse.cpp
+++ b/projects/UnitTest/src/render/TestIndirectDiffuse.cpp
@@ -280,7 +280,7 @@ private:
 
 	RenderCommandList* beginRendering()
 	{
-		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandList* commandList = gRenderDevice->getCommandList(0);
 		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
 
 		commandList->reset(commandAllocator);

--- a/projects/UnitTest/src/render/TestIndirectSpecular.cpp
+++ b/projects/UnitTest/src/render/TestIndirectSpecular.cpp
@@ -340,7 +340,7 @@ private:
 
 	RenderCommandList* beginRendering()
 	{
-		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandList* commandList = gRenderDevice->getCommandList(0);
 		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
 
 		commandList->reset(commandAllocator);

--- a/projects/UnitTest/src/render/TestPathTracing.cpp
+++ b/projects/UnitTest/src/render/TestPathTracing.cpp
@@ -344,7 +344,7 @@ private:
 
 	RenderCommandList* beginRendering()
 	{
-		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandList* commandList = gRenderDevice->getCommandList(0);
 		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
 
 		commandList->reset(commandAllocator);

--- a/projects/UnitTest/src/render/TestRayTracedShadows.cpp
+++ b/projects/UnitTest/src/render/TestRayTracedShadows.cpp
@@ -267,7 +267,7 @@ private:
 
 	RenderCommandList* beginRendering()
 	{
-		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandList* commandList = gRenderDevice->getCommandList(0);
 		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
 
 		commandList->reset(commandAllocator);

--- a/projects/UnitTest/src/render/TestSkybox.cpp
+++ b/projects/UnitTest/src/render/TestSkybox.cpp
@@ -190,7 +190,7 @@ private:
 
 	RenderCommandList* beginRendering()
 	{
-		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandList* commandList = gRenderDevice->getCommandList(0);
 		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
 
 		commandList->reset(commandAllocator);

--- a/projects/UnitTest/src/render/TestVisibilityBuffer.cpp
+++ b/projects/UnitTest/src/render/TestVisibilityBuffer.cpp
@@ -277,7 +277,7 @@ private:
 
 	RenderCommandList* beginRendering()
 	{
-		RenderCommandList* commandList = gRenderDevice->getCommandListForCustomCommand();
+		RenderCommandList* commandList = gRenderDevice->getCommandList(0);
 		RenderCommandAllocator* commandAllocator = gRenderDevice->getCommandAllocator(0);
 
 		commandList->reset(commandAllocator);

--- a/projects/UnitTest/src/rhi/TestBufferUpload.cpp
+++ b/projects/UnitTest/src/rhi/TestBufferUpload.cpp
@@ -18,7 +18,7 @@ namespace UnitTest
 		{
 			RenderDevice* renderDevice = rhi_test::createHeadlessDevice(graphicsAPI);
 
-			auto commandList = renderDevice->getCommandListForCustomCommand();
+			auto commandList = renderDevice->getCommandList(0);
 			auto commandAllocator = renderDevice->getCommandAllocator(0);
 			auto commandQueue = renderDevice->getCommandQueue();
 			SwapChain* nullSwapChain = nullptr;

--- a/projects/UnitTest/src/rhi/TestTextureUpload.cpp
+++ b/projects/UnitTest/src/rhi/TestTextureUpload.cpp
@@ -370,7 +370,7 @@ namespace UnitTest
 	private:
 		RenderCommandList* getCommandList()
 		{
-			return renderDevice->getCommandListForCustomCommand();
+			return renderDevice->getCommandList(0);
 		}
 		void beginRendering()
 		{


### PR DESCRIPTION
Refactor swapchainIndex
- Separate `swapchainIndex` and `frameIndex` to fix temporal accumulation in render passes when frame generation is on.
- Refactor custom render command API due to change of semantic of `swapchainIndex`. Also move its ownership from render device to engine.

Known issues
- Graphics tests that involve temporal accumulation are broken because the tests use a headless device, so the frameIndex (previously swapchainIndex) was always zero. It was already broken but found out while working on this PR.