### PR TITLE
Feature/108 Fix frame pacing when frame generation is on

### DIFF
--- a/projects/Cyseal/src/core/high_freq_counter.h
+++ b/projects/Cyseal/src/core/high_freq_counter.h
@@ -11,11 +11,11 @@ public:
 		startTime = std::chrono::system_clock::now();
 	}
 
-	uint64 stopWithMilliseconds()
+	float stopWithMilliseconds()
 	{
 		auto endTime = std::chrono::system_clock::now();
-		auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
-		return diff;
+		auto diff = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
+		return (float)diff / 1000.0f;
 	}
 
 private:

--- a/projects/Cyseal/src/render/renderer_options.h
+++ b/projects/Cyseal/src/render/renderer_options.h
@@ -213,7 +213,7 @@ struct RendererOptions
 
 	// Frame generation
 	bool                      bGenerateFrame = true;
-	float                     prevRenderTime = 0.0f; // In milliseconds, used for frame pacing.
+	float                     prevFrameTime = 0.0f; // In milliseconds, used for frame pacing.
 
 	// Debug visualization
 	EBufferVisualizationMode  bufferVisualization = EBufferVisualizationMode::None;

--- a/projects/Cyseal/src/render/renderer_options.h
+++ b/projects/Cyseal/src/render/renderer_options.h
@@ -200,6 +200,9 @@ inline const char** getPathTracingKernelNames()
 
 struct RendererOptions
 {
+	// Presentation
+	bool                      bForceVSync = true;
+
 	// Indirect draw
 	EIndirectDrawMode         indirectDrawMode = EIndirectDrawMode::PopulateOnGPU;
 	bool                      bEnableGPUCulling = true;

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -46,7 +46,7 @@
 #define SCENE_UNIFORM_MEMORY_POOL_SIZE (64 * 1024) // 64 KiB
 #define MAX_CULL_OPERATIONS            (2 * kMaxBasePassPermutation) // depth prepass + base pass
 #define MAX_FINAL_BLIT_OPERATIONS      2 // Actual count: 2 if frame generation is enabled, 1 otherwise.
-#define AVG_RENDER_TIME_WINDOW_SIZE    16
+#define AVG_FRAME_TIME_WINDOW_SIZE     16
 
 static uint32 fullMipCount(uint32 width, uint32 height)
 {
@@ -58,7 +58,7 @@ void SceneRenderer::initialize(RenderDevice* renderDevice)
 	device = renderDevice;
 	frameID = 0;
 
-	avgRenderTime.init(AVG_RENDER_TIME_WINDOW_SIZE);
+	avgFrameTime.init(AVG_FRAME_TIME_WINDOW_SIZE);
 
 	// Scene textures: Don't create yet. You invoke recreateSceneTextures() before using scene renderer.
 	// recreateSceneTextures(width, height);
@@ -1128,18 +1128,14 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 			{
 				interpFrameCounter.start();
 
-				const float frameMS = avgRenderTime.getAverage();
+				const float frameMS = avgFrameTime.getAverage();
 
 				// Accuracy of std::this_thread::sleep_for() is too bad. Do spin wait.
-#if 1
 				HighFrequencyCounter spinWait;
 				spinWait.start();
 				while (spinWait.stopWithMilliseconds() < frameMS);
-#else
-				std::this_thread::sleep_for(std::chrono::milliseconds((uint32)(frameMS)));
-#endif
 
-				interpTimeMS += (float)interpFrameCounter.stopWithMilliseconds();
+				interpTimeMS += interpFrameCounter.stopWithMilliseconds();
 			}
 		}
 
@@ -1160,7 +1156,7 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	}
 
 	frameID += 1;
-	avgRenderTime.push(renderOptions.prevRenderTime - prevInterpTime);
+	avgFrameTime.push(renderOptions.prevFrameTime - prevInterpTime);
 	prevInterpTime = interpTimeMS;
 
 	prevScaledRenderResolutionX = sceneWidth;

--- a/projects/Cyseal/src/render/scene_renderer.cpp
+++ b/projects/Cyseal/src/render/scene_renderer.cpp
@@ -3,6 +3,7 @@
 #include "core/assertion.h"
 #include "core/platform.h"
 #include "core/plane.h"
+#include "core/high_freq_counter.h"
 
 #include "rhi/rhi_policy.h"
 #include "rhi/render_command.h"
@@ -1016,8 +1017,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	{
 		scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
 			.bRealFrame   = false,
-			.colorTexture = RT_finalSceneColor.get(),
-			.colorSRV     = finalSceneColorSRV.get(),
+			.colorTexture = (renderOptions.bufferVisualization != EBufferVisualizationMode::None) ? RT_finalSceneColor.get() : frameGenPassOutput.interpolatedFrameTexture,
+			.colorSRV     = (renderOptions.bufferVisualization != EBufferVisualizationMode::None) ? finalSceneColorSRV.get() : frameGenPassOutput.interpolatedFrameSRV,
 		};
 	}
 	scenePresentInfoArray[scenePresentCount++] = ScenePresentInfo{
@@ -1027,6 +1028,9 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	};
 
 	finalBlitPass->resetBlitResources();
+
+	HighFrequencyCounter interpFrameCounter;
+	float interpTimeMS = 0.0f;
 
 	for (uint32 presentIx = 0; presentIx < scenePresentCount; ++presentIx)
 	{
@@ -1117,15 +1121,25 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 
 		if (bRenderToBackbuffer)
 		{
-			bool bVSync = scenePresentInfoArray[presentIx].bRealFrame;
+			bool bVSync = scenePresentInfoArray[presentIx].bRealFrame && renderOptions.bForceVSync;
 			swapChain->present(bVSync);
 
 			if (scenePresentInfoArray[presentIx].bRealFrame == false)
 			{
-				// #todo-fsr3-present: My measurement includes the time to present interpolated frame so can't use 0.5f * frameMS.
-				// Not intuitive but it kinda works so leave it be?
+				interpFrameCounter.start();
+
 				const float frameMS = avgRenderTime.getAverage();
-				std::this_thread::sleep_for(std::chrono::milliseconds((uint32)(0.25f * frameMS)));
+
+				// Accuracy of std::this_thread::sleep_for() is too bad. Do spin wait.
+#if 1
+				HighFrequencyCounter spinWait;
+				spinWait.start();
+				while (spinWait.stopWithMilliseconds() < frameMS);
+#else
+				std::this_thread::sleep_for(std::chrono::milliseconds((uint32)(frameMS)));
+#endif
+
+				interpTimeMS += (float)interpFrameCounter.stopWithMilliseconds();
 			}
 		}
 
@@ -1146,7 +1160,8 @@ void SceneRenderer::render(const SceneProxy* scene, const Camera* camera, const 
 	}
 
 	frameID += 1;
-	avgRenderTime.push(renderOptions.prevRenderTime);
+	avgRenderTime.push(renderOptions.prevRenderTime - prevInterpTime);
+	prevInterpTime = interpTimeMS;
 
 	prevScaledRenderResolutionX = sceneWidth;
 	prevScaledRenderResolutionY = sceneHeight;

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -103,6 +103,7 @@ private:
 
 	uint32 frameID = 0;
 	SimpleMovingAverage avgRenderTime;
+	float prevInterpTime = 0.0f;
 
 	// ------------------------------------------------------------------------
 	// #todo-renderer: Temporarily manage render targets in the renderer.

--- a/projects/Cyseal/src/render/scene_renderer.h
+++ b/projects/Cyseal/src/render/scene_renderer.h
@@ -77,7 +77,7 @@ public:
 	virtual void recreateSceneTextures(uint32 sceneWidth, uint32 sceneHeight) override;
 
 	virtual void enqueueCustomCommands(std::vector<RenderCommandList::CustomCommandType>&& inCommands) override;
-	
+
 private:
 	void resetCommandList(RenderCommandAllocator* commandAllocator, RenderCommandList* commandList);
 	void immediateFlushCommandQueue(RenderCommandQueue* commandQueue, RenderCommandAllocator* commandAllocator, RenderCommandList* commandList);
@@ -102,7 +102,7 @@ private:
 	SceneUniform prevSceneUniformData;
 
 	uint32 frameID = 0;
-	SimpleMovingAverage avgRenderTime;
+	SimpleMovingAverage avgFrameTime;
 	float prevInterpTime = 0.0f;
 
 	// ------------------------------------------------------------------------

--- a/projects/Cyseal/src/rhi/dx12/d3d_swap_chain.cpp
+++ b/projects/Cyseal/src/rhi/dx12/d3d_swap_chain.cpp
@@ -52,7 +52,7 @@ void D3DSwapChain::initialize(
 		.Scaling     = DXGI_SCALING_STRETCH, // #todo-swapchain: Scaling method
 		.SwapEffect  = DXGI_SWAP_EFFECT_FLIP_DISCARD,
 		.AlphaMode   = DXGI_ALPHA_MODE_UNSPECIFIED,
-		.Flags       = 0,
+		.Flags       = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING,
 	};
 
 	// #todo-swapchain: Support fullscreen
@@ -164,7 +164,7 @@ void D3DSwapChain::createSwapchainImages()
 void D3DSwapChain::present(bool vsync)
 {
 	UINT syncInterval = vsync ? 1 : 0;
-	UINT flags = 0;
+	UINT flags = vsync ? 0 : DXGI_PRESENT_ALLOW_TEARING;
 	HRESULT hResult = rawSwapChain->Present(syncInterval, flags);
 
 	// #todo-dx12: Report DRED log

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -236,8 +236,6 @@ void TestApplication::onTick(float deltaSeconds)
 		world->onTick(deltaSeconds);
 	}
 
-	renderTimeCounter.start();
-
 	// #todo: Move rendering loop to engine
 	{
 		SCOPED_CPU_EVENT(ExecuteRenderer);
@@ -418,13 +416,11 @@ void TestApplication::onTick(float deltaSeconds)
 		}
 		cysealEngine.renderImgui();
 
-		appState.rendererOptions.prevRenderTime = prevRenderTime;
+		appState.rendererOptions.prevFrameTime = 1000.0f * deltaSeconds;
 		cysealEngine.renderScene(sceneProxy, &camera, appState.rendererOptions);
 
 		delete sceneProxy;
 	}
-
-	prevRenderTime = (float)renderTimeCounter.stopWithMilliseconds();
 }
 
 void TestApplication::onTerminate()

--- a/projects/TestApplication/src/app.cpp
+++ b/projects/TestApplication/src/app.cpp
@@ -152,8 +152,10 @@ void TestApplication::onTick(float deltaSeconds)
 		{
 			wchar_t buf[256];
 			float newFPS = 1.0f / deltaSeconds;
-			// #todo-fsr3-present: 1 frame time includes 1 interpolated frame + 1 real frame, so not precise but...
+
+			// 1 frame time includes 1 interpolated frame + 1 real frame, so 2x frame rate.
 			if (appState.rendererOptions.bGenerateFrame) newFPS *= 2.0f;
+
 			framesPerSecond += 0.05f * (newFPS - framesPerSecond);
 			swprintf_s(buf, L"Hello World / FPS: %.2f", framesPerSecond);
 			setWindowTitle(std::wstring(buf));
@@ -307,6 +309,12 @@ void TestApplication::onTick(float deltaSeconds)
 			}
 
 			ImGui::SeparatorText("Frame Generation");
+			const bool bMaxFpsChanged = ImGui::SliderFloat("Max FPS", &appState.maxFrameRate, 30.0f, 480.0f);
+			if (bMaxFpsChanged)
+			{
+				setFPSLimit(appState.maxFrameRate);
+			}
+			ImGui::Checkbox("Force VSync", &appState.rendererOptions.bForceVSync);
 			if (appState.rendererOptions.pathTracing != EPathTracingMode::Disabled)
 			{
 				ImGui::BeginDisabled();

--- a/projects/TestApplication/src/app.h
+++ b/projects/TestApplication/src/app.h
@@ -52,7 +52,4 @@ private:
 	uint32 newViewportHeight = 0;
 
 	float framesPerSecond = 0.0f;
-
-	float prevRenderTime = 0.0f;
-	HighFrequencyCounter renderTimeCounter;
 };

--- a/projects/TestApplication/src/app.h
+++ b/projects/TestApplication/src/app.h
@@ -12,6 +12,7 @@ struct AppState
 	RendererOptions rendererOptions;
 	int32 displayScale                    = 100;
 	int32 renderResolutionScale           = 100;
+	float maxFrameRate                    = 120.0f;
 	int32 selectedIndirectDrawMode        = (int32)EIndirectDrawMode::PopulateOnGPU;
 	int32 selectedBufferVisualizationMode = 0;
 	int32 selectedRayTracedShadowsMode    = 0;


### PR DESCRIPTION
VSync
- Support vsync toggle in dx12 backend.

GUI
- Add options to change max FPS and toggle vsync in GUI.

Frame generation
- Fix a bug that interpolated frame is just not displayed at all if buffer visualization is disabled.
- Fix wait time formula for interpolated frames.
- Do spin wait instead of std::this_thread::sleep_for() due to accuracy problem.

Known issues
- It turned out that the quality of interpolated frame is really really bad. I must have integrated something wrong :(